### PR TITLE
Fix missing device_class and unit_of_measurement for Arc sensors

### DIFF
--- a/custom_components/lksystems/sensor.py
+++ b/custom_components/lksystems/sensor.py
@@ -506,6 +506,11 @@ class LKArcSensorEntity(CoordinatorEntity, SensorEntity):
         return self._device_class
 
     @property
+    def native_unit_of_measurement(self) -> Optional[str]:
+        """Return the unit of measurement."""
+        return self._attr_unit_of_measurement
+
+    @property
     def native_value(self) -> Any:
         """Return the value of the sensor."""
         # First check device_details for the most up-to-date information

--- a/custom_components/lksystems/sensor.py
+++ b/custom_components/lksystems/sensor.py
@@ -501,6 +501,11 @@ class LKArcSensorEntity(CoordinatorEntity, SensorEntity):
         return False
 
     @property
+    def device_class(self) -> Optional[str]:
+        """Return the device class."""
+        return self._device_class
+
+    @property
     def native_value(self) -> Any:
         """Return the value of the sensor."""
         # First check device_details for the most up-to-date information


### PR DESCRIPTION
## Summary
Fixes missing `device_class` and `native_unit_of_measurement` properties for Arc sensor entities, ensuring proper display and categorization in Home Assistant.

## Changes
1. Added `device_class` property to `LKArcSensorEntity` class
2. Added `native_unit_of_measurement` property to `LKArcSensorEntity` class

## Issue
Arc-Sense temperature, humidity, battery, and RSSI sensors were storing device class and unit of measurement internally but not exposing them via properties. This caused:
- Temperature sensors not showing units (°C) in the UI
- Sensors not being properly grouped with other sensors of the same type in graphs
- Missing proper device class categorization

## Solution
Added the missing properties to expose `device_class` and `native_unit_of_measurement` to Home Assistant, following the same pattern already used in `LKArcHubEntity`.

## Testing
- Verified temperature sensors now display °C units
- Confirmed sensors can be grouped with other temperature sensors in graphs
- Checked that device_class appears correctly in developer tools