### PR TITLE
Add pytest test suite and CI for the pylksystems client

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install test dependencies
+        run: pip install -r requirements_test.txt
+
+      - name: Run tests
+        run: pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 
 .DS_Store
 __pycache__
+.venv-test/
+.pytest_cache/

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+testpaths = tests

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,9 @@
+pytest==8.3.3
+pytest-asyncio==0.24.0
+# aiohttp is pinned (rather than following manifest.json's >=3.9.1) because
+# aioresponses mocks aiohttp's internals and breaks on newer aiohttp releases
+# that changed ClientResponse's constructor (e.g. the added `stream_writer`
+# kwarg). Bump together with aioresponses once upstream compatibility lands.
+aiohttp==3.9.1
+aioresponses==0.7.9
+python-dateutil>=2.8.2

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the LK Systems integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+"""Shared fixtures for the LK Systems test suite."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# The pylksystems client is a plain aiohttp-based module with no Home
+# Assistant dependency, but it lives inside the `custom_components.lksystems`
+# package. Importing that package the normal way (``import
+# custom_components.lksystems.pylksystems``) runs the parent package's
+# __init__.py first, which imports `homeassistant` — not installed in this
+# lightweight test environment. Loading the module directly from its file
+# path sidesteps that and keeps these tests fast and dependency-free.
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "lksystems"
+    / "pylksystems"
+    / "__init__.py"
+)
+
+
+def _load_pylksystems():
+    spec = importlib.util.spec_from_file_location("pylksystems", _MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+pylksystems = _load_pylksystems()
+
+
+@pytest.fixture
+def manager():
+    """A fresh, unauthenticated LKSystemsManager instance."""
+    return pylksystems.LKSystemsManager("user@example.com", "hunter2")

--- a/tests/test_pylksystems.py
+++ b/tests/test_pylksystems.py
@@ -1,0 +1,263 @@
+"""Unit tests for the pylksystems API client.
+
+These tests mock the HTTP layer with aioresponses so they exercise the
+client's parsing/branching logic (auth flow, device-list normalization,
+merge/dedupe, error handling) without ever hitting the real LK Systems API.
+"""
+
+from __future__ import annotations
+
+from aiohttp import ClientConnectionError
+from aioresponses import aioresponses
+
+BASE_URL = "https://link2.lk.nu/"
+
+
+class TestLogin:
+    async def test_success_sets_tokens_and_userid(self, manager):
+        with aioresponses() as m:
+            m.post(
+                BASE_URL + "auth/auth/login",
+                payload={"accessToken": "tok-123", "refreshToken": "refresh-123"},
+                status=200,
+            )
+            m.get(
+                BASE_URL + "auth/auth/user",
+                payload={"userId": "user-123"},
+                status=200,
+            )
+            async with manager:
+                result = await manager.login()
+
+        assert result is True
+        assert manager.jwt_token == "tok-123"
+        assert manager.refresh_token == "refresh-123"
+        assert manager.userid == "user-123"
+
+    async def test_unauthorized_returns_false(self, manager):
+        with aioresponses() as m:
+            m.post(BASE_URL + "auth/auth/login", payload={}, status=401)
+            async with manager:
+                result = await manager.login()
+
+        assert result is False
+        assert manager.jwt_token is None
+
+    async def test_userid_lookup_failure_returns_false(self, manager):
+        with aioresponses() as m:
+            m.post(
+                BASE_URL + "auth/auth/login",
+                payload={"accessToken": "tok-123", "refreshToken": "refresh-123"},
+                status=200,
+            )
+            m.get(BASE_URL + "auth/auth/user", payload={}, status=500)
+            async with manager:
+                result = await manager.login()
+
+        # Tokens are already set from the first call, only userid lookup failed.
+        assert result is False
+        assert manager.jwt_token == "tok-123"
+        assert manager.userid is None
+
+    async def test_connection_error_is_handled(self, manager):
+        with aioresponses() as m:
+            m.post(BASE_URL + "auth/auth/login", exception=ClientConnectionError())
+            async with manager:
+                result = await manager.login()
+
+        assert result is False
+
+
+class TestGetDevices:
+    async def test_list_response_skips_cubic_and_extracts_arc_fields(self, manager):
+        manager.userid = "user-123"
+        api_response = [
+            {
+                "cacheUpdated": 111,
+                "realestateMachines": [
+                    {
+                        "deviceType": "cubicsecure",
+                        "deviceRole": "cubicsecure",
+                        "identity": "cubic-1",
+                    },
+                    {
+                        "deviceGroup": "arc",
+                        "deviceType": "arc-sense",
+                        "deviceRole": "sense",
+                        "identity": "AA:BB:CC",
+                        "zone": "Living Room",
+                    },
+                ],
+            }
+        ]
+
+        with aioresponses() as m:
+            m.get(
+                BASE_URL + "service/users/user/user-123/structure/false",
+                payload=api_response,
+                status=200,
+            )
+            async with manager:
+                result = await manager.get_devices()
+
+        assert result is True
+        devices = manager.devices["devices"]
+        assert len(devices) == 1
+        assert devices[0]["mac"] == "AA:BB:CC"
+        assert devices[0]["deviceGroup"] == "arc"
+        assert devices[0]["zone"] == "Living Room"
+        assert devices[0]["cacheUpdated"] == 111
+
+    async def test_dict_response_used_as_is(self, manager):
+        manager.userid = "user-123"
+        api_response = {
+            "devices": [{"mac": "DD:EE:FF", "deviceGroup": "arc"}],
+            "cacheUpdated": 222,
+        }
+
+        with aioresponses() as m:
+            m.get(
+                BASE_URL + "service/users/user/user-123/structure/false",
+                payload=api_response,
+                status=200,
+            )
+            async with manager:
+                result = await manager.get_devices()
+
+        assert result is True
+        assert manager.devices == api_response
+
+    async def test_merges_and_dedupes_against_existing_devices(self, manager):
+        manager.userid = "user-123"
+        manager._devices = {
+            "devices": [{"mac": "AA", "existing": True}],
+            "cacheUpdated": 1,
+        }
+        api_response = [
+            {
+                "cacheUpdated": 999,
+                "realestateMachines": [
+                    # Duplicate mac - must not be added a second time, and the
+                    # existing entry must be preserved rather than overwritten.
+                    {"deviceGroup": "arc", "deviceType": "x", "identity": "AA"},
+                    {"deviceGroup": "arc", "deviceType": "x", "identity": "BB"},
+                ],
+            }
+        ]
+
+        with aioresponses() as m:
+            m.get(
+                BASE_URL + "service/users/user/user-123/structure/false",
+                payload=api_response,
+                status=200,
+            )
+            async with manager:
+                result = await manager.get_devices()
+
+        assert result is True
+        macs = [d["mac"] for d in manager.devices["devices"]]
+        assert macs.count("AA") == 1
+        assert "BB" in macs
+        assert manager.devices["devices"][0] == {"mac": "AA", "existing": True}
+
+    async def test_request_failure_falls_back_to_existing_devices(self, manager):
+        manager.userid = "user-123"
+        manager._devices = {"devices": [{"mac": "AA"}], "cacheUpdated": 1}
+
+        with aioresponses() as m:
+            m.get(
+                BASE_URL + "service/users/user/user-123/structure/false",
+                status=500,
+            )
+            async with manager:
+                result = await manager.get_devices()
+
+        # Falls back to True because devices already exist locally.
+        assert result is True
+        assert manager.devices["devices"] == [{"mac": "AA"}]
+
+
+class TestCubicSecureMeasurement:
+    async def test_force_update_selects_endpoint(self, manager):
+        with aioresponses() as m:
+            m.get(
+                BASE_URL + "service/cubic/secure/cubic-1/measurement/1",
+                payload={"flow": 1.5},
+                status=200,
+            )
+            async with manager:
+                result = await manager.get_cubic_secure_measurement(
+                    "cubic-1", force_update=True
+                )
+
+        assert result is True
+        assert manager.cubic_secure_messurement == {"flow": 1.5}
+
+    async def test_without_force_update_selects_endpoint(self, manager):
+        with aioresponses() as m:
+            m.get(
+                BASE_URL + "service/cubic/secure/cubic-1/measurement/0",
+                payload={"flow": 0.0},
+                status=200,
+            )
+            async with manager:
+                result = await manager.get_cubic_secure_measurement("cubic-1")
+
+        assert result is True
+        assert manager.cubic_secure_messurement == {"flow": 0.0}
+
+    async def test_error_status_returns_false_and_keeps_state(self, manager):
+        with aioresponses() as m:
+            m.get(
+                BASE_URL + "service/cubic/secure/cubic-1/measurement/0",
+                status=404,
+            )
+            async with manager:
+                result = await manager.get_cubic_secure_measurement("cubic-1")
+
+        assert result is False
+        assert manager.cubic_secure_messurement is None
+
+
+class TestSetDeviceTemperature:
+    async def test_success_converts_and_sends_tenths_of_degree(self, manager):
+        with aioresponses() as m:
+            m.get(
+                BASE_URL + "service/arc/sense/AA:BB:CC/measurement/true",
+                payload={"currentTemperature": 210, "desiredTemperature": 200},
+                status=200,
+            )
+            m.post(
+                BASE_URL + "service/arc/sense/AA:BB:CC/measurement/true",
+                payload={"currentTemperature": 210, "desiredTemperature": 215},
+                status=200,
+            )
+            async with manager:
+                result = await manager.set_device_temperature("AA:BB:CC", 21.5)
+
+        assert result is True
+        assert manager.device_measurements["AA:BB:CC"]["desiredTemperature"] == 215
+
+    async def test_non_arc_device_identity_is_rejected(self, manager):
+        async with manager:
+            result = await manager.set_device_temperature("not-a-mac", 21.5)
+
+        assert result is False
+
+    async def test_empty_device_identity_is_rejected(self, manager):
+        async with manager:
+            result = await manager.set_device_temperature("", 21.5)
+
+        assert result is False
+
+    async def test_measurement_fetch_failure_aborts_before_posting(self, manager):
+        with aioresponses() as m:
+            m.get(
+                BASE_URL + "service/arc/sense/AA:BB:CC/measurement/true",
+                status=500,
+            )
+            async with manager:
+                result = await manager.set_device_temperature("AA:BB:CC", 21.5)
+
+        assert result is False
+        assert "AA:BB:CC" not in manager.device_measurements


### PR DESCRIPTION
## Why

This repo currently has no tests and no CI, despite a fair amount of non-trivial logic (auth flow, device-list parsing across different API response shapes, merging/deduping cached devices, temperature conversion, error handling). This PR adds a starting point.

## What's included

- `requirements_test.txt` — pytest, pytest-asyncio, aioresponses, python-dateutil
- `pytest.ini` — asyncio auto mode
- `.github/workflows/test.yml` — runs the suite on push/PR against Python 3.11 and 3.12
- `tests/` — unit tests for `custom_components/lksystems/pylksystems` (the API client), covering:
  - `login()` success, 401, userId-lookup failure, connection error
  - `get_devices()` — list vs dict API response shapes, cubic-device filtering, merge/dedupe against already-cached devices, fallback to cached devices on request failure
  - `get_cubic_secure_measurement()` — force-update endpoint selection, error status handling
  - `set_device_temperature()` — temperature→tenths-of-degree conversion, non-Arc device rejection, aborting before POST when the measurement fetch fails

All 15 tests pass locally (`pytest -v`) against Python 3.11.

## Notes / follow-ups

- `tests/conftest.py` loads `pylksystems/__init__.py` directly from its file path instead of via `custom_components.lksystems.pylksystems`, because importing the parent `custom_components.lksystems` package pulls in `homeassistant` (via its own `__init__.py`), which isn't installed for this lightweight suite.
- `aiohttp` is pinned to `3.9.1` in `requirements_test.txt` (rather than the manifest's `>=3.9.1`) because `aioresponses` mocks aiohttp internals and currently breaks against newer aiohttp releases (`ClientResponse.__init__()` gained a required `stream_writer` kwarg). Worth revisiting once aioresponses catches up.
- Not covered here: entity-level tests for `sensor.py`, `climate.py`, and `config_flow.py` — those depend on Home Assistant's own test harness (`pytest-homeassistant-custom-component`), which is a heavier addition I left out of this first PR so it could be reviewed on its own.