### PR TITLE
Add Contributing section to README and PR checklist

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+## What does this change do, and why?
+
+<!-- Describe the change and the motivation behind it. -->
+
+## Checklist
+
+- [ ] I added or updated tests for any behavior change in `pylksystems` (see `tests/test_pylksystems.py` for the pattern), or explained below why that isn't applicable.
+- [ ] `pytest` passes locally.
+
+## Notes for reviewers
+
+<!-- Anything a reviewer should know: known limitations, follow-ups, things you're unsure about. -->

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install test dependencies
+        run: pip install -r requirements_test.txt
+
+      - name: Run tests
+        run: pytest -v

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 
 .DS_Store
 __pycache__
+.venv-test/
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -37,3 +37,27 @@ The integration supports:
 ## Enable the integration
 Go to Settings / Devices & Services / Integrations. Click **+ ADD INTEGRATION**
 Follow the instructions
+
+# Contributing
+Contributions are welcome, whether that's a bug fix, a new sensor/entity, or tests for existing code.
+
+### Setting up a dev environment
+1. Fork the repo and clone your fork.
+2. Install the test dependencies: `pip install -r requirements_test.txt`
+
+### Running the tests
+
+```bash
+pytest
+```
+
+The test suite covers `custom_components/lksystems/pylksystems` (the LK Systems API client) and mocks all HTTP calls with [aioresponses](https://github.com/pnuckowski/aioresponses), so it runs without a real LK Systems account and without Home Assistant installed.
+
+Note: `sensor.py`, `climate.py`, and `config_flow.py` aren't covered yet — testing those needs Home Assistant's own test harness (`pytest-homeassistant-custom-component`), which hasn't been wired up. Contributions adding that setup are very welcome.
+
+### Submitting a change
+1. Create a branch off `main` in your fork.
+2. If you're changing behavior in `pylksystems`, please add or update a test alongside the change — see `tests/test_pylksystems.py` for the existing pattern.
+3. Open a pull request against `main` describing what changed and why.
+
+CI runs the test suite automatically on every pull request.

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+testpaths = tests

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,9 @@
+pytest==8.3.3
+pytest-asyncio==0.24.0
+# aiohttp is pinned (rather than following manifest.json's >=3.9.1) because
+# aioresponses mocks aiohttp's internals and breaks on newer aiohttp releases
+# that changed ClientResponse's constructor (e.g. the added `stream_writer`
+# kwarg). Bump together with aioresponses once upstream compatibility lands.
+aiohttp==3.9.1
+aioresponses==0.7.9
+python-dateutil>=2.8.2

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for the LK Systems integration."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,41 @@
+"""Shared fixtures for the LK Systems test suite."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+# The pylksystems client is a plain aiohttp-based module with no Home
+# Assistant dependency, but it lives inside the `custom_components.lksystems`
+# package. Importing that package the normal way (``import
+# custom_components.lksystems.pylksystems``) runs the parent package's
+# __init__.py first, which imports `homeassistant` — not installed in this
+# lightweight test environment. Loading the module directly from its file
+# path sidesteps that and keeps these tests fast and dependency-free.
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "lksystems"
+    / "pylksystems"
+    / "__init__.py"
+)
+
+
+def _load_pylksystems():
+    spec = importlib.util.spec_from_file_location("pylksystems", _MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+pylksystems = _load_pylksystems()
+
+
+@pytest.fixture
+def manager():
+    """A fresh, unauthenticated LKSystemsManager instance."""
+    return pylksystems.LKSystemsManager("user@example.com", "hunter2")

--- a/tests/test_pylksystems.py
+++ b/tests/test_pylksystems.py
@@ -1,0 +1,263 @@
+"""Unit tests for the pylksystems API client.
+
+These tests mock the HTTP layer with aioresponses so they exercise the
+client's parsing/branching logic (auth flow, device-list normalization,
+merge/dedupe, error handling) without ever hitting the real LK Systems API.
+"""
+
+from __future__ import annotations
+
+from aiohttp import ClientConnectionError
+from aioresponses import aioresponses
+
+BASE_URL = "https://link2.lk.nu/"
+
+
+class TestLogin:
+    async def test_success_sets_tokens_and_userid(self, manager):
+        with aioresponses() as m:
+            m.post(
+                BASE_URL + "auth/auth/login",
+                payload={"accessToken": "tok-123", "refreshToken": "refresh-123"},
+                status=200,
+            )
+            m.get(
+                BASE_URL + "auth/auth/user",
+                payload={"userId": "user-123"},
+                status=200,
+            )
+            async with manager:
+                result = await manager.login()
+
+        assert result is True
+        assert manager.jwt_token == "tok-123"
+        assert manager.refresh_token == "refresh-123"
+        assert manager.userid == "user-123"
+
+    async def test_unauthorized_returns_false(self, manager):
+        with aioresponses() as m:
+            m.post(BASE_URL + "auth/auth/login", payload={}, status=401)
+            async with manager:
+                result = await manager.login()
+
+        assert result is False
+        assert manager.jwt_token is None
+
+    async def test_userid_lookup_failure_returns_false(self, manager):
+        with aioresponses() as m:
+            m.post(
+                BASE_URL + "auth/auth/login",
+                payload={"accessToken": "tok-123", "refreshToken": "refresh-123"},
+                status=200,
+            )
+            m.get(BASE_URL + "auth/auth/user", payload={}, status=500)
+            async with manager:
+                result = await manager.login()
+
+        # Tokens are already set from the first call, only userid lookup failed.
+        assert result is False
+        assert manager.jwt_token == "tok-123"
+        assert manager.userid is None
+
+    async def test_connection_error_is_handled(self, manager):
+        with aioresponses() as m:
+            m.post(BASE_URL + "auth/auth/login", exception=ClientConnectionError())
+            async with manager:
+                result = await manager.login()
+
+        assert result is False
+
+
+class TestGetDevices:
+    async def test_list_response_skips_cubic_and_extracts_arc_fields(self, manager):
+        manager.userid = "user-123"
+        api_response = [
+            {
+                "cacheUpdated": 111,
+                "realestateMachines": [
+                    {
+                        "deviceType": "cubicsecure",
+                        "deviceRole": "cubicsecure",
+                        "identity": "cubic-1",
+                    },
+                    {
+                        "deviceGroup": "arc",
+                        "deviceType": "arc-sense",
+                        "deviceRole": "sense",
+                        "identity": "AA:BB:CC",
+                        "zone": "Living Room",
+                    },
+                ],
+            }
+        ]
+
+        with aioresponses() as m:
+            m.get(
+                BASE_URL + "service/users/user/user-123/structure/false",
+                payload=api_response,
+                status=200,
+            )
+            async with manager:
+                result = await manager.get_devices()
+
+        assert result is True
+        devices = manager.devices["devices"]
+        assert len(devices) == 1
+        assert devices[0]["mac"] == "AA:BB:CC"
+        assert devices[0]["deviceGroup"] == "arc"
+        assert devices[0]["zone"] == "Living Room"
+        assert devices[0]["cacheUpdated"] == 111
+
+    async def test_dict_response_used_as_is(self, manager):
+        manager.userid = "user-123"
+        api_response = {
+            "devices": [{"mac": "DD:EE:FF", "deviceGroup": "arc"}],
+            "cacheUpdated": 222,
+        }
+
+        with aioresponses() as m:
+            m.get(
+                BASE_URL + "service/users/user/user-123/structure/false",
+                payload=api_response,
+                status=200,
+            )
+            async with manager:
+                result = await manager.get_devices()
+
+        assert result is True
+        assert manager.devices == api_response
+
+    async def test_merges_and_dedupes_against_existing_devices(self, manager):
+        manager.userid = "user-123"
+        manager._devices = {
+            "devices": [{"mac": "AA", "existing": True}],
+            "cacheUpdated": 1,
+        }
+        api_response = [
+            {
+                "cacheUpdated": 999,
+                "realestateMachines": [
+                    # Duplicate mac - must not be added a second time, and the
+                    # existing entry must be preserved rather than overwritten.
+                    {"deviceGroup": "arc", "deviceType": "x", "identity": "AA"},
+                    {"deviceGroup": "arc", "deviceType": "x", "identity": "BB"},
+                ],
+            }
+        ]
+
+        with aioresponses() as m:
+            m.get(
+                BASE_URL + "service/users/user/user-123/structure/false",
+                payload=api_response,
+                status=200,
+            )
+            async with manager:
+                result = await manager.get_devices()
+
+        assert result is True
+        macs = [d["mac"] for d in manager.devices["devices"]]
+        assert macs.count("AA") == 1
+        assert "BB" in macs
+        assert manager.devices["devices"][0] == {"mac": "AA", "existing": True}
+
+    async def test_request_failure_falls_back_to_existing_devices(self, manager):
+        manager.userid = "user-123"
+        manager._devices = {"devices": [{"mac": "AA"}], "cacheUpdated": 1}
+
+        with aioresponses() as m:
+            m.get(
+                BASE_URL + "service/users/user/user-123/structure/false",
+                status=500,
+            )
+            async with manager:
+                result = await manager.get_devices()
+
+        # Falls back to True because devices already exist locally.
+        assert result is True
+        assert manager.devices["devices"] == [{"mac": "AA"}]
+
+
+class TestCubicSecureMeasurement:
+    async def test_force_update_selects_endpoint(self, manager):
+        with aioresponses() as m:
+            m.get(
+                BASE_URL + "service/cubic/secure/cubic-1/measurement/1",
+                payload={"flow": 1.5},
+                status=200,
+            )
+            async with manager:
+                result = await manager.get_cubic_secure_measurement(
+                    "cubic-1", force_update=True
+                )
+
+        assert result is True
+        assert manager.cubic_secure_messurement == {"flow": 1.5}
+
+    async def test_without_force_update_selects_endpoint(self, manager):
+        with aioresponses() as m:
+            m.get(
+                BASE_URL + "service/cubic/secure/cubic-1/measurement/0",
+                payload={"flow": 0.0},
+                status=200,
+            )
+            async with manager:
+                result = await manager.get_cubic_secure_measurement("cubic-1")
+
+        assert result is True
+        assert manager.cubic_secure_messurement == {"flow": 0.0}
+
+    async def test_error_status_returns_false_and_keeps_state(self, manager):
+        with aioresponses() as m:
+            m.get(
+                BASE_URL + "service/cubic/secure/cubic-1/measurement/0",
+                status=404,
+            )
+            async with manager:
+                result = await manager.get_cubic_secure_measurement("cubic-1")
+
+        assert result is False
+        assert manager.cubic_secure_messurement is None
+
+
+class TestSetDeviceTemperature:
+    async def test_success_converts_and_sends_tenths_of_degree(self, manager):
+        with aioresponses() as m:
+            m.get(
+                BASE_URL + "service/arc/sense/AA:BB:CC/measurement/true",
+                payload={"currentTemperature": 210, "desiredTemperature": 200},
+                status=200,
+            )
+            m.post(
+                BASE_URL + "service/arc/sense/AA:BB:CC/measurement/true",
+                payload={"currentTemperature": 210, "desiredTemperature": 215},
+                status=200,
+            )
+            async with manager:
+                result = await manager.set_device_temperature("AA:BB:CC", 21.5)
+
+        assert result is True
+        assert manager.device_measurements["AA:BB:CC"]["desiredTemperature"] == 215
+
+    async def test_non_arc_device_identity_is_rejected(self, manager):
+        async with manager:
+            result = await manager.set_device_temperature("not-a-mac", 21.5)
+
+        assert result is False
+
+    async def test_empty_device_identity_is_rejected(self, manager):
+        async with manager:
+            result = await manager.set_device_temperature("", 21.5)
+
+        assert result is False
+
+    async def test_measurement_fetch_failure_aborts_before_posting(self, manager):
+        with aioresponses() as m:
+            m.get(
+                BASE_URL + "service/arc/sense/AA:BB:CC/measurement/true",
+                status=500,
+            )
+            async with manager:
+                result = await manager.set_device_temperature("AA:BB:CC", 21.5)
+
+        assert result is False
+        assert "AA:BB:CC" not in manager.device_measurements


### PR DESCRIPTION
## Why

Stacked on #34 (test suite + CI) — this PR is based on that branch, so its diff includes those commits until #34 merges. Once #34 is merged this will show cleanly.

Follow-up to the discussion on #34: the README had no guidance for contributors, and there was no lightweight way to nudge new PRs toward including tests.

## What's included

- **README**: a `Contributing` section covering dev environment setup, running the test suite (`pytest`), and what to include when submitting a change. Also notes the current gap — `sensor.py`/`climate.py`/`config_flow.py` aren't covered because they'd need `pytest-homeassistant-custom-component`, not wired up yet.
- **`.github/pull_request_template.md`**: a short checklist asking contributors to add/update tests for `pylksystems` changes.

## Why not a hard coverage-threshold gate?

Discussed and deliberately left out: a numeric coverage % (via `pytest-cov`/`diff-cover`) is easy to satisfy with a test that executes a line but asserts nothing, and doesn't reflect whether the new code is *meaningfully* tested. A human-reviewed checklist is cheaper and gives a better signal for a repo this size. Happy to revisit CI-enforced coverage later if that changes.

We also discussed GitHub Copilot as a PR reviewer for this — leaving that out of scope here since enabling it is a repo-level setting only available to the repo owner.