### PR TITLE
Fix IndexError when account has no devices

### DIFF
--- a/custom_components/lksystems/pylksystems/__init__.py
+++ b/custom_components/lksystems/pylksystems/__init__.py
@@ -240,6 +240,16 @@ class LKSystemsManager:
         endpoint = f"service/users/user/{self.userid}/structure/1"
         success, res = await self._get(endpoint)
         if success:
+            if not res:
+                # Accounts with no devices/realestates registered get back
+                # an empty list rather than a missing structure. Treat that
+                # as "no structure available" instead of crashing on res[0].
+                _LOGGER.warning(
+                    "User structure response was empty - account has no "
+                    "devices or realestates registered"
+                )
+                self._user_structure = None
+                return False
             self._user_structure = res[0]
             return True
         return False

--- a/tests/test_pylksystems.py
+++ b/tests/test_pylksystems.py
@@ -68,6 +68,58 @@ class TestLogin:
         assert result is False
 
 
+class TestGetUserStructure:
+    async def test_success_uses_first_element_of_list(self, manager):
+        manager.userid = "user-123"
+        api_response = [{"realestateId": "re-1", "cacheUpdated": 111}]
+
+        with aioresponses() as m:
+            m.get(
+                BASE_URL + "service/users/user/user-123/structure/1",
+                payload=api_response,
+                status=200,
+            )
+            async with manager:
+                result = await manager.get_user_structure()
+
+        assert result is True
+        assert manager.user_structure == {"realestateId": "re-1", "cacheUpdated": 111}
+
+    async def test_empty_list_response_does_not_raise(self, manager):
+        """Account with no devices/realestates: API returns `[]`.
+
+        Regression test for issue #30 - this used to raise
+        `IndexError: list index out of range`.
+        """
+        manager.userid = "user-123"
+
+        with aioresponses() as m:
+            m.get(
+                BASE_URL + "service/users/user/user-123/structure/1",
+                payload=[],
+                status=200,
+            )
+            async with manager:
+                result = await manager.get_user_structure()
+
+        assert result is False
+        assert manager.user_structure is None
+
+    async def test_request_failure_returns_false(self, manager):
+        manager.userid = "user-123"
+
+        with aioresponses() as m:
+            m.get(
+                BASE_URL + "service/users/user/user-123/structure/1",
+                status=500,
+            )
+            async with manager:
+                result = await manager.get_user_structure()
+
+        assert result is False
+        assert manager.user_structure is None
+
+
 class TestGetDevices:
     async def test_list_response_skips_cubic_and_extracts_arc_fields(self, manager):
         manager.userid = "user-123"


### PR DESCRIPTION
## Summary

Fixes a crash reported in #30: accounts with no devices/realestates registered got an `IndexError: list index out of range` instead of failing gracefully.

`get_user_structure()` in the `pylksystems` client indexed into the API response with `res[0]` unconditionally. For accounts with no devices, the API returns an empty list rather than a one-element list, which blew up the index access.

## Fix

- Treat an empty response as "no structure available": log a warning, clear `_user_structure`, and return `False`.
- The coordinator (`custom_components/lksystems/__init__.py`) already handles a `False` return from `get_user_structure()` cleanly via `UpdateFailed`, so no downstream changes were needed there.

## Testing

Added regression tests to `tests/test_pylksystems.py` (`TestGetUserStructure`) covering:
- the normal case (list with one structure),
- the empty-list case that used to crash (issue #30),
- a request failure.

Full suite: 18/18 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)