### PR TITLE
Add explicit request timeout to pylksystems ClientSession

### DIFF
--- a/custom_components/lksystems/pylksystems/__init__.py
+++ b/custom_components/lksystems/pylksystems/__init__.py
@@ -10,10 +10,15 @@ import re
 from typing import TypedDict
 
 
-from aiohttp import ClientError, ClientResponseError, ClientSession
+from aiohttp import ClientError, ClientResponseError, ClientSession, ClientTimeout
 from dateutil.relativedelta import relativedelta
 
 _LOGGER = logging.getLogger(__name__)
+
+# aiohttp defaults to a 300s total timeout when none is set. That lets one
+# slow/unresponsive LK API call stall an entire coordinator update for up to
+# 5 minutes before it even fails - fail fast instead.
+REQUEST_TIMEOUT = ClientTimeout(total=20)
 
 
 # Add the missing LKSystemsError class
@@ -81,7 +86,7 @@ class LKSystemsManager:
 
     async def __aenter__(self):
         """Asynchronous enter."""
-        self.session = ClientSession()
+        self.session = ClientSession(timeout=REQUEST_TIMEOUT)
         return self
 
     async def __aexit__(self, exc_type, exc_value, traceback):

--- a/tests/test_pylksystems.py
+++ b/tests/test_pylksystems.py
@@ -261,3 +261,18 @@ class TestSetDeviceTemperature:
 
         assert result is False
         assert "AA:BB:CC" not in manager.device_measurements
+
+
+class TestClientSessionTimeout:
+    async def test_session_has_a_bounded_timeout(self, manager):
+        """Regression test: aiohttp defaults to a 300s total timeout when
+        none is configured on the ClientSession. That lets one slow or
+        unresponsive LK API call stall an entire coordinator update cycle
+        for up to 5 minutes before it even fails. The session must set an
+        explicit, short timeout instead of relying on that default.
+        """
+        async with manager:
+            timeout = manager.session.timeout
+
+        assert timeout.total is not None
+        assert timeout.total <= 30


### PR DESCRIPTION
## Summary

`ClientSession()` in the pylksystems client is created with no timeout, so aiohttp falls back to its default: a 300s (5 minute) total timeout per request.

Since `get_user_structure()` is the first call in the coordinator's update cycle and its failure aborts the entire cycle, a single slow or unresponsive LK API call could stall the whole update for up to 5 minutes before even failing. In practice this showed up as:

- A `Connection timeout` error in the logs (aiohttp's default timeout firing).
- Irregular update cadence — a 5-minute configured interval producing real-world gaps of 15-20 minutes, since one hung request can eat most of an interval before the coordinator even gets to retry.

## Fix

Set an explicit 20s total timeout on the `ClientSession`, so a slow/dead request fails fast instead of blocking most of an update cycle.

## Testing

Added a regression test (`TestClientSessionTimeout`) asserting the session's configured timeout is bounded, rather than aiohttp's 300s default. Full suite: 16/16 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)