### PR TITLE
Stop logging sensitive data (auth headers, tokens, usernames)

### DIFF
--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -37,6 +37,7 @@ from .pylksystems import (
     LKThresholds,
     LKPressureThresholds,
 )
+from .redact import mask_username
 
 from .services import async_setup_services
 
@@ -389,7 +390,7 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                 )
                 raise ConfigEntryAuthFailed("Missing username or password")
 
-            _LOGGER.debug("Using credentials for user: %s", username)
+            _LOGGER.debug("Using credentials for user: %s", mask_username(username))
 
             # Check if we have stored tokens for this entry
             stored_tokens = TOKEN_STORAGE.get(self._entry_id, {})

--- a/custom_components/lksystems/pylksystems/__init__.py
+++ b/custom_components/lksystems/pylksystems/__init__.py
@@ -15,6 +15,20 @@ from dateutil.relativedelta import relativedelta
 
 _LOGGER = logging.getLogger(__name__)
 
+# Header names (case-insensitive) whose values must never be logged verbatim.
+_SENSITIVE_HEADERS = {"authorization", "ocp-apim-subscription-key"}
+_REDACTED = "***REDACTED***"
+
+
+def _redact_headers(headers: dict) -> dict:
+    """Return a copy of headers with sensitive values replaced for logging."""
+    if not headers:
+        return headers
+    return {
+        key: _REDACTED if key.lower() in _SENSITIVE_HEADERS else value
+        for key, value in headers.items()
+    }
+
 
 # Add the missing LKSystemsError class
 class LKSystemsError(Exception):
@@ -93,7 +107,7 @@ class LKSystemsManager:
         _LOGGER.error(
             "An error occurred during the request. URL: %s, Headers: %s. Error: %s",
             self.base_url + endpoint,
-            headers,
+            _redact_headers(headers),
             error,
         )
         return False
@@ -830,8 +844,8 @@ class LKSystemsManager:
             }
 
             _LOGGER.debug(
-                "Using Azure endpoint for thermostat control with token: %s...",
-                self.jwt_token[:20] if self.jwt_token else "None",
+                "Using Azure endpoint for thermostat control, token present: %s",
+                self.jwt_token is not None,
             )
 
             # Create simple payload according to the required format

--- a/custom_components/lksystems/redact.py
+++ b/custom_components/lksystems/redact.py
@@ -1,0 +1,26 @@
+"""Pure helpers for keeping sensitive data out of logs.
+
+No Home Assistant (or any other) imports here on purpose, so this module can
+be exercised directly in the lightweight, HA-free test environment the same
+way pylksystems is - see tests/conftest.py and tests/test_redact.py.
+"""
+
+from __future__ import annotations
+
+
+def mask_username(username: str | None) -> str | None:
+    """Mask a username/email for logging.
+
+    Keeps the first and last 3 characters, plus any literal '.' or '@'
+    character (so an email address's shape stays recognizable for
+    troubleshooting), and replaces every other character with '*'.
+    """
+    if not username:
+        return username
+
+    length = len(username)
+    masked_chars = [
+        char if index < 3 or index >= length - 3 or char in ".@" else "*"
+        for index, char in enumerate(username)
+    ]
+    return "".join(masked_chars)

--- a/tests/test_pylksystems.py
+++ b/tests/test_pylksystems.py
@@ -7,6 +7,8 @@ merge/dedupe, error handling) without ever hitting the real LK Systems API.
 
 from __future__ import annotations
 
+import logging
+
 from aiohttp import ClientConnectionError
 from aioresponses import aioresponses
 
@@ -261,3 +263,41 @@ class TestSetDeviceTemperature:
 
         assert result is False
         assert "AA:BB:CC" not in manager.device_measurements
+
+
+class TestSensitiveDataNotLogged:
+    """Regression tests: request failures and debug logs must never leak
+    the bearer token, the API subscription key, or any part of a JWT.
+    """
+
+    async def test_handle_client_error_redacts_headers(self, manager, caplog):
+        headers = {
+            "content-type": "application/json",
+            "authorization": "Bearer super-secret-jwt",
+            "ocp-apim-subscription-key": "super-secret-key",
+        }
+
+        await manager.handle_client_error("some/endpoint", headers, ValueError("boom"))
+
+        log_text = caplog.text
+        assert "super-secret-jwt" not in log_text
+        assert "super-secret-key" not in log_text
+        # Non-sensitive headers are still useful for debugging.
+        assert "application/json" in log_text
+
+    async def test_set_thermostat_temperature_logs_token_presence_not_value(
+        self, manager, caplog
+    ):
+        manager.jwt_token = "super-secret-jwt"
+        caplog.set_level(logging.DEBUG)
+
+        with aioresponses() as m:
+            m.post(
+                "https://lk-arc-structure-mapper.azurewebsites.net/api/measurement/sense",
+                payload={"currentTemperature": 210},
+                status=200,
+            )
+            async with manager:
+                await manager.set_thermostat_temperature("AA:BB:CC", 215)
+
+        assert "super-secret-jwt" not in caplog.text

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -1,0 +1,46 @@
+"""Unit tests for custom_components.lksystems.redact.
+
+Loaded directly from its file path (like pylksystems in conftest.py) since
+custom_components/lksystems/__init__.py pulls in `homeassistant`, which
+isn't installed in this lightweight test environment - see conftest.py's
+_load_pylksystems() for the same trick.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "lksystems"
+    / "redact.py"
+)
+
+
+def _load_redact():
+    spec = importlib.util.spec_from_file_location("lksystems_redact", _MODULE_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+redact = _load_redact()
+
+
+class TestMaskUsername:
+    def test_email_keeps_edges_and_dots_and_at_sign(self):
+        assert redact.mask_username("john.doe@example.com") == "joh*.***@*******.com"
+
+    def test_plain_username_with_no_dot_or_at(self):
+        assert redact.mask_username("adminuser") == "adm***ser"
+
+    def test_short_username_is_fully_within_edge_margins(self):
+        # len <= 6: every index is within the first-3/last-3 margin, so
+        # nothing gets masked. Documenting this boundary rather than hiding it.
+        assert redact.mask_username("abcdef") == "abcdef"
+
+    def test_none_and_empty_pass_through_unchanged(self):
+        assert redact.mask_username(None) is None
+        assert redact.mask_username("") == ""


### PR DESCRIPTION
## Summary

Three places in the codebase logged sensitive data in plaintext:

1. **`handle_client_error()`** (pylksystems) logged the entire request `headers` dict on every failed request — including the live `Authorization: Bearer <JWT>` and the `ocp-apim-subscription-key`. This is exactly what showed up when a user shared a log excerpt for troubleshooting: a valid bearer token, which decodes to the account's name and email.
2. **`set_thermostat_temperature()`** logged the first 20 characters of the JWT at debug level — short enough tokens would be logged in full.
3. The coordinator logged the configured username (an email address) in full at debug level.

## Fix

- `handle_client_error()` now redacts the `authorization` and `ocp-apim-subscription-key` header values before logging (other headers, like `content-type`, are left as-is since they're useful for debugging and not sensitive).
- The Azure endpoint debug log now logs only whether a token is present (`True`/`False`), never any part of its value.
- Added `custom_components/lksystems/redact.py` with `mask_username()` — a small, dependency-free helper that keeps the first/last 3 characters of a username plus any `.`/`@` characters (so an email's shape stays recognizable for troubleshooting) and masks everything else with `*`. Used for the username debug log.

## Testing

- `TestSensitiveDataNotLogged` in `tests/test_pylksystems.py`: asserts a fake token/subscription-key never appear in captured log output for both the header-redaction and token-presence-logging paths.
- `tests/test_redact.py`: unit tests for `mask_username()`, including an email example, a plain non-email username, and short-string edge cases.

`redact.py` has no Home Assistant or aiohttp dependency by design, so it's loaded and tested the same lightweight way as pylksystems (see `tests/conftest.py`'s existing approach).

Full suite: 21/21 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)