### PR TITLE
Fix update_interval being ignored when changed via Configure dialog

### DIFF
--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -189,9 +189,16 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Initialize the coordinator."""
-        # Always convert to integer in case it comes as string from config
+        # Always convert to integer in case it comes as string from config.
+        # Options (set via the Configure dialog after initial setup) take
+        # precedence over data (set on the original setup form) - this
+        # mirrors async_update_options()'s lookup below, which is what
+        # actually detects changes and triggers a reload.
         update_interval_minutes = int(
-            entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
+            entry.options.get(
+                CONF_UPDATE_INTERVAL,
+                entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL),
+            )
         )
 
         _LOGGER.warning(


### PR DESCRIPTION
## Summary

Changing the update interval via the integration's Configure (gear icon) dialog after initial setup silently has no effect.

`LKSystemCoordinator.__init__` reads `CONF_UPDATE_INTERVAL` only from `entry.data`:

```python
update_interval_minutes = int(
    entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL)
)
```

`entry.data` is set once, on the original setup form. But the options flow (`OptionsFlowHandler.async_step_init` in `config_flow.py`) writes interval changes to `entry.options` instead — that's standard Home Assistant behavior for anything created via `async_create_entry` inside an `OptionsFlow`.

The interesting part: `async_update_options()` a bit further down in the same file *already* does the correct lookup:

```python
new_update_interval = entry.options.get(
    CONF_UPDATE_INTERVAL,
    entry.data.get(CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL),
)
```

It correctly detects the change and triggers `hass.config_entries.async_reload(entry.entry_id)` — but that reload just re-runs `__init__`, which never looked at `entry.options` at all, so the freshly recreated coordinator silently reverts to the old value.

## Fix

`__init__` now uses the same `entry.options`-first, `entry.data`-fallback lookup that `async_update_options()` already relies on, so a changed interval actually sticks after the reload it triggers.

## Testing

Not covered by an automated test — this file imports `homeassistant` directly, which isn't installed in this project's current lightweight test setup (only the HA-independent `pylksystems` client is unit tested today, see `tests/conftest.py`'s comment). Verified by:
- Static reasoning against `async_update_options()`'s already-correct, already-relied-upon lookup a few dozen lines below.
- A syntax/import (`py_compile`) check.
- Full existing suite still green (15/15) — unaffected, as expected, since this change is isolated to the coordinator's `__init__`.

Real regression coverage for this is tracked separately (adding `pytest-homeassistant-custom-component`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)