### PR TITLE
Ignore TODO.local.md for personal backlog notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__
 .venv-test/
 .pytest_cache/
+TODO.local.md


### PR DESCRIPTION
Small housekeeping change: adds \`TODO.local.md\` to \`.gitignore\`.

The \`.local.\` naming (matching conventions like \`docker-compose.override.yml\`) signals it's a personal scratch file for tracking backlog/notes locally - never meant to be part of the tracked project, so it's excluded up front rather than relying on developers to remember not to \`git add\` it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)