### PR TITLE
Add deploy script and document dev/MCP workflow for contributors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 __pycache__
 .venv-test/
 .pytest_cache/
+.vscode/
+.claude/
+.mcp.json

--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ If your test instance has the built-in [**Model Context Protocol Server**](https
 To set it up:
 
 1. In HA, add the **Model Context Protocol Server** integration and create a long-lived access token for it (**Settings → People → your profile → Security → Long-lived access tokens**).
-2. Install [`mcp-proxy`](https://github.com/sparfenyuk/mcp-proxy) locally, which bridges your editor/tool's MCP client to HA's HTTP-based MCP endpoint (`https://<host>:8123/api/mcp`).
-3. Point your tool's MCP config at it, e.g. for Claude Code, a project-local `.mcp.json`:
+2. Install [`mcp-proxy`](https://github.com/sparfenyuk/mcp-proxy) locally (e.g. `pip install --user mcp-proxy`), which bridges your editor/tool's MCP client to HA's HTTP-based MCP endpoint (`https://<host>:8123/api/mcp`). At time of writing, `mcp-proxy` needs `mcp<2` (`pip install --user "mcp==1.29.0"`) — the just-released `mcp` 2.0.0 changed internals in a way `mcp-proxy` 0.12.0 doesn't support yet.
+3. Point your tool's MCP config at it, e.g. for Claude Code, a project-local `.mcp.json`. The token goes in as an `Authorization: Bearer` header via `-H`, not an environment variable:
 
    ```json
    {
@@ -94,15 +94,17 @@ To set it up:
          "args": [
            "--transport=streamablehttp",
            "--stateless",
+           "-H",
+           "Authorization",
+           "Bearer <your-long-lived-token>",
            "https://<your-host>:8123/api/mcp"
-         ],
-         "env": { "API_ACCESS_TOKEN": "<your-long-lived-token>" }
+         ]
        }
      }
    }
    ```
 
-Keep this file out of version control (it's gitignored here) since it points at your personal instance and, depending on setup, may carry a token.
+Keep this file out of version control (it's gitignored here) since it points at your personal instance and carries a live token.
 
 ### Submitting a change
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,47 @@ The test suite covers `custom_components/lksystems/pylksystems` (the LK Systems 
 
 Note: `sensor.py`, `climate.py`, and `config_flow.py` aren't covered yet — testing those needs Home Assistant's own test harness (`pytest-homeassistant-custom-component`), which hasn't been wired up. Contributions adding that setup are very welcome.
 
+### Deploying to a test Home Assistant instance
+
+`deploy.sh` syncs your local `custom_components/lksystems/` straight into a running Home Assistant instance over SSH, for testing changes against a real account before opening a PR.
+
+```bash
+./deploy.sh <user> <host>
+# e.g. ./deploy.sh homeassistant homeassistant.local
+```
+
+Requirements on the target instance: SSH access (e.g. the [Terminal & SSH add-on](https://github.com/home-assistant/addons/tree/master/ssh) on HAOS) reachable with `ssh <user>@<host>`, and a `/config` directory. The script creates `/config/custom_components/lksystems/` if needed and `rsync`s the integration's files there.
+
+After syncing, reload the integration (**Settings → Devices & Services → LK Systems → ⋮ → Reload**), or restart HA on a first install.
+
+### Using the Home Assistant MCP server for live testing
+
+If your test instance has the built-in [**Model Context Protocol Server**](https://www.home-assistant.io/integrations/mcp_server/) integration enabled, an AI coding assistant (like Claude Code) can query live entity states and call services directly against it — useful for verifying a change actually behaves correctly in HA, not just that the unit tests pass.
+
+To set it up:
+
+1. In HA, add the **Model Context Protocol Server** integration and create a long-lived access token for it (**Settings → People → your profile → Security → Long-lived access tokens**).
+2. Install [`mcp-proxy`](https://github.com/sparfenyuk/mcp-proxy) locally, which bridges your editor/tool's MCP client to HA's HTTP-based MCP endpoint (`https://<host>:8123/api/mcp`).
+3. Point your tool's MCP config at it, e.g. for Claude Code, a project-local `.mcp.json`:
+
+   ```json
+   {
+     "mcpServers": {
+       "Home Assistant": {
+         "command": "mcp-proxy",
+         "args": [
+           "--transport=streamablehttp",
+           "--stateless",
+           "https://<your-host>:8123/api/mcp"
+         ],
+         "env": { "API_ACCESS_TOKEN": "<your-long-lived-token>" }
+       }
+     }
+   }
+   ```
+
+Keep this file out of version control (it's gitignored here) since it points at your personal instance and, depending on setup, may carry a token.
+
 ### Submitting a change
 
 1. Create a branch off `main` in your fork.

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# Usage: ./deploy.sh <user> <host>
+# Example: ./deploy.sh homeassistant homeassistant.local
+if [ -z "$1" ] || [ -z "$2" ]; then
+  echo "Usage: $0 <user> <host>"
+  exit 1
+fi
+
+USER="$1"
+HOST_ARG="$2"
+HOST="$USER@$HOST_ARG"
+REMOTE_DIR="/config/custom_components/lksystems"
+
+echo "==> Creating remote directory..."
+ssh "$HOST" "sudo mkdir -p $REMOTE_DIR && sudo chmod 777 $REMOTE_DIR"
+
+echo "==> Syncing files..."
+rsync -avO --exclude='__pycache__' --exclude='.DS_Store' \
+  custom_components/lksystems/ \
+  "$HOST:$REMOTE_DIR/"
+
+echo "==> Done! Reload the integration in HA: Settings → Devices & Services → LK Systems → (3 dots) → Reload."
+echo "    Or restart HA if this is a first install."


### PR DESCRIPTION
## Summary

Adds a way to test changes against a real, running Home Assistant instance before opening a PR, and documents it for contributors.

- **`deploy.sh`** — rsyncs `custom_components/lksystems/` to a running HA instance over SSH (`./deploy.sh <user> <host>`). Same pattern I use in another integration of mine ([sram-axs-for-ha](https://github.com/karl-petter/sram-axs-for-ha)), adapted for this repo's path/domain.
- **README** — new Contributing subsections:
  - How to use `deploy.sh` and reload the integration afterward.
  - How to optionally wire up HA's built-in [Model Context Protocol Server](https://www.home-assistant.io/integrations/mcp_server/) integration via `mcp-proxy`, so an AI coding assistant can query live entity states / call services against a real instance while developing — handy for verifying a fix actually behaves correctly in HA, not just that unit tests pass.
- **`.gitignore`** — added `.vscode/`, `.claude/`, `.mcp.json`, since a contributor's MCP config points at their own personal instance (host + possibly a token) and should never be committed.

No functional code changes; docs + tooling only. Full test suite still green (15/15).

🤖 Generated with [Claude Code](https://claude.com/claude-code)