### PR TITLE
Fix KeyError crashing cubic sensors on a transient fetch failure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        # pytest-homeassistant-custom-component / homeassistant require >=3.12
+        python-version: ["3.12", "3.13"]
     steps:
       - uses: actions/checkout@v4
 
@@ -23,4 +24,10 @@ jobs:
         run: pip install -r requirements_test.txt
 
       - name: Run tests
-        run: pytest -v
+        # pytest-homeassistant-custom-component registers a global autouse
+        # cleanup fixture the moment it's installed, which collides with
+        # this suite (see requirements_test.txt) - explicitly disabled here.
+        run: pytest tests/ -p no:homeassistant -v
+
+      - name: Run Home Assistant integration tests
+        run: pytest tests_ha/ -v

--- a/README.md
+++ b/README.md
@@ -55,13 +55,18 @@ Contributions are welcome, whether that's a bug fix, a new sensor/entity, or tes
 
 ### Running the tests
 
+There are two suites, run as separate `pytest` invocations (see below for why):
+
 ```bash
-pytest
+pytest tests/ -p no:homeassistant
+pytest tests_ha/
 ```
 
-The test suite covers `custom_components/lksystems/pylksystems` (the LK Systems API client) and mocks all HTTP calls with [aioresponses](https://github.com/pnuckowski/aioresponses), so it runs without a real LK Systems account and without Home Assistant installed.
+`tests/` covers `custom_components/lksystems/pylksystems` (the LK Systems API client) and mocks all HTTP calls with [aioresponses](https://github.com/pnuckowski/aioresponses) — no real LK Systems account needed.
 
-Note: `sensor.py`, `climate.py`, and `config_flow.py` aren't covered yet — testing those needs Home Assistant's own test harness (`pytest-homeassistant-custom-component`), which hasn't been wired up. Contributions adding that setup are very welcome.
+`tests_ha/` covers the pieces that import `homeassistant` directly (`__init__.py`, `climate.py`, `sensor.py`, `config_flow.py`, `services.py`) using Home Assistant's own test harness, [`pytest-homeassistant-custom-component`](https://github.com/MatthewFlamm/pytest-homeassistant-custom-component). Requires Python 3.12+.
+
+The `-p no:homeassistant` flag on the first command matters: once `pytest-homeassistant-custom-component` is installed, it registers a global autouse cleanup fixture that checks every test in the session for lingering threads/timers — including ones in `tests/` that never touch Home Assistant at all — and it trips on a background thread aiohttp itself leaves behind. Disabling the plugin for that invocation avoids the false positive; it's picked back up for `tests_ha/`.
 
 ### Deploying to a test Home Assistant instance
 
@@ -117,4 +122,3 @@ CI runs the test suite automatically on every pull request.
 ### API documentation
 
 The integration uses the API exposed by LK System. [API documentation](https://lk-home-assistant-prod.developer.azure-api.net/)
-

--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -650,6 +650,18 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                                     lk_inst.cubic_secure_configuration
                                 )
                             except Exception as err:
+                                # Sensors index these keys directly, so they
+                                # must exist even on failure; reuse the last
+                                # known values if we have them.
+                                previous_data = self.data or {}
+                                resp.setdefault(
+                                    "cubic_last_measurement",
+                                    previous_data.get("cubic_last_measurement"),
+                                )
+                                resp.setdefault(
+                                    "cubic_configuration",
+                                    previous_data.get("cubic_configuration"),
+                                )
                                 _LOGGER.warning(
                                     "Error fetching cubic measurements: %s", str(err)
                                 )
@@ -854,10 +866,8 @@ async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
             new_update_interval,
         )
 
-        # Force immediate update after reload
-        hass.async_create_task(coordinator.async_refresh())
-
-    # Reload entry
+    # Reloading tears down and recreates the coordinator with the new
+    # interval and performs its own first refresh.
     await hass.config_entries.async_reload(entry.entry_id)
 
 

--- a/custom_components/lksystems/sensor.py
+++ b/custom_components/lksystems/sensor.py
@@ -933,23 +933,27 @@ class LKCubicSensor(AbstractLkCubicSensor):
         value = None
 
         if self._data_source == "configuration":
-            if self._data_key in self._coordinator.data["cubic_configuration"]:
-                value = self._coordinator.data["cubic_configuration"][self._data_key]
+            cubic_configuration = self._coordinator.data.get("cubic_configuration") or {}
+            if self._data_key in cubic_configuration:
+                value = cubic_configuration[self._data_key]
             elif "." in self._data_key:
                 keys = self._data_key.split(".")
-                value = self._coordinator.data["cubic_configuration"]
+                value = cubic_configuration
                 for key in keys:
                     value = value.get(key, None)
                     if value is None:
                         break
         elif self._data_source == "measurement":
+            cubic_last_measurement = (
+                self._coordinator.data.get("cubic_last_measurement") or {}
+            )
             _LOGGER.debug("Getting measurement for key: %s", self._data_key)
-            _LOGGER.debug(self._coordinator.data["cubic_last_measurement"])
-            if self._data_key in self._coordinator.data["cubic_last_measurement"]:
-                value = self._coordinator.data["cubic_last_measurement"][self._data_key]
+            _LOGGER.debug(cubic_last_measurement)
+            if self._data_key in cubic_last_measurement:
+                value = cubic_last_measurement[self._data_key]
             elif "." in self._data_key:
                 keys = self._data_key.split(".")
-                value = self._coordinator.data["cubic_last_measurement"]
+                value = cubic_last_measurement
                 for key in keys:
                     value = value.get(key, None)
                     if value is None:

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,7 @@
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = function
 testpaths = tests
+# tests_ha/ is deliberately excluded here: pytest-homeassistant-custom-component
+# registers a global autouse cleanup fixture the moment it's importable, which
+# collides with tests/ (see requirements_test.txt). Run it explicitly:
+#   pytest tests_ha/ -v

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,9 +1,16 @@
-pytest==8.3.3
+pytest==8.3.4
 pytest-asyncio==0.24.0
-# aiohttp is pinned (rather than following manifest.json's >=3.9.1) because
-# aioresponses mocks aiohttp's internals and breaks on newer aiohttp releases
-# that changed ClientResponse's constructor (e.g. the added `stream_writer`
-# kwarg). Bump together with aioresponses once upstream compatibility lands.
-aiohttp==3.9.1
+# Pinned to match pytest-homeassistant-custom-component 0.13.205's own pin
+# (which pulls in homeassistant==2025.1.4). Verified aioresponses 0.7.9 still
+# works correctly against this aiohttp release (see tests/test_pylksystems.py).
+aiohttp==3.11.11
 aioresponses==0.7.9
 python-dateutil>=2.8.2
+
+# Home Assistant test harness, used by tests_ha/ to exercise the pieces of
+# custom_components/lksystems that import `homeassistant` directly
+# (__init__.py, climate.py, sensor.py, config_flow.py, services.py) and so
+# can't use the tests/conftest.py importlib-bypass trick. Pinned to the
+# release that pins homeassistant==2025.1.4, close to the minimum HA version
+# declared in hacs.json (2025.1.1). Requires Python >=3.12.
+pytest-homeassistant-custom-component==0.13.205

--- a/tests_ha/__init__.py
+++ b/tests_ha/__init__.py
@@ -1,0 +1,1 @@
+"""Home-Assistant-dependent tests for the LK Systems integration."""

--- a/tests_ha/conftest.py
+++ b/tests_ha/conftest.py
@@ -5,13 +5,46 @@ entirely), these tests run against the real thing via
 pytest-homeassistant-custom-component, so they can exercise
 custom_components/lksystems/__init__.py, climate.py, sensor.py,
 config_flow.py and services.py directly.
+
+FakeLKSystemsManager below is a hand-written stand-in for
+pylksystems.LKSystemsManager - it lets these tests exercise the HA-layer
+logic that calls the API client without touching pylksystems itself
+(that's covered separately by tests/test_pylksystems.py, with real HTTP
+mocking via aioresponses).
 """
 
 from __future__ import annotations
 
+import asyncio
+import time
+
 import pytest
 
 pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _warm_up_aiohttp_shutdown_thread():
+    """Work around a false-positive in the HA plugin's thread-leak check.
+
+    aiohttp lazily spawns a one-time, global "_run_safe_shutdown_loop"
+    background thread the first time any ClientSession/TCPConnector is
+    created in the process. pytest-homeassistant-custom-component's
+    autouse verify_cleanup fixture snapshots threads before/after every
+    test and fails whichever test happens to trigger that first-ever
+    creation, since there's no way to mark it as expected (unlike
+    lingering tasks/timers, which do have opt-out fixtures). Triggering
+    it once here, at session scope, means it always happens before any
+    test's snapshot instead of inside a random one.
+    """
+    import aiohttp
+
+    async def _touch() -> None:
+        async with aiohttp.ClientSession():
+            pass
+
+    asyncio.run(_touch())
+    yield
 
 
 @pytest.fixture(autouse=True)
@@ -24,3 +57,291 @@ def auto_enable_custom_integrations(enable_custom_integrations):
     in the repo's custom_components/ directory.
     """
     yield
+
+
+class FakeLKSystemsManager:
+    """Stand-in for pylksystems.LKSystemsManager.
+
+    Mirrors the real client's public surface (the async context manager,
+    login(), the get_*() calls and the attributes they populate) with
+    in-memory, test-controlled data instead of real HTTP calls.
+    """
+
+    def __init__(self, username=None, password=None):
+        self.username = username
+        self.password = password
+
+        self.jwt_token = None
+        self.refresh_token = None
+        self.userid = None
+
+        self.user_structure: dict = {}
+        self.device_measurements: dict = {}
+        self.device_configurations: dict = {}
+        self.hub_devices: dict = {}
+        self.cubic_secure_messurement: dict | None = None
+        self.cubic_secure_configuration: dict | None = None
+
+        # Per-call canned data, keyed by device/hub identity. Tests set
+        # these before triggering a coordinator update.
+        self.measurements_by_device: dict[str, dict] = {}
+        self.configurations_by_device: dict[str, dict] = {}
+        self.hub_devices_by_hub: dict[str, dict] = {}
+        self.cubic_measurement_data: dict | None = None
+        self.cubic_configuration_data: dict | None = None
+
+        # Configurable outcomes for each call, so tests can force failures.
+        self.login_result = True
+        self.get_user_structure_result = True
+        self.get_device_measurement_result = True
+        self.get_device_configuration_result = True
+        self.get_hub_devices_result = True
+        self.get_cubic_secure_measurement_result = True
+        self.get_cubic_secure_configuration_result = True
+        self.set_thermostat_temperature_result: dict = {
+            "success": True,
+            "data": {},
+            "error": None,
+        }
+
+        # Call log, for tests that want to assert *what* was called.
+        self.calls: list[tuple] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        return None
+
+    async def login(self):
+        self.calls.append(("login",))
+        if self.login_result:
+            self.jwt_token = "fake-jwt-token"
+            self.refresh_token = "fake-refresh-token"
+            self.userid = "fake-user-id"
+        return self.login_result
+
+    async def get_user_structure(self):
+        self.calls.append(("get_user_structure",))
+        return self.get_user_structure_result
+
+    async def get_device_measurement(self, device_identity, force_update=False):
+        self.calls.append(("get_device_measurement", device_identity, force_update))
+        if self.get_device_measurement_result:
+            self.device_measurements[device_identity] = self.measurements_by_device.get(
+                device_identity, {}
+            )
+        return self.get_device_measurement_result
+
+    async def get_device_configuration(self, device_identity, force_update=False):
+        self.calls.append(
+            ("get_device_configuration", device_identity, force_update)
+        )
+        if self.get_device_configuration_result:
+            self.device_configurations[device_identity] = (
+                self.configurations_by_device.get(device_identity, {})
+            )
+        return self.get_device_configuration_result
+
+    async def get_hub_devices(self, hub_id):
+        self.calls.append(("get_hub_devices", hub_id))
+        if self.get_hub_devices_result:
+            self.hub_devices = self.hub_devices_by_hub.get(hub_id, {"devices": []})
+        return self.get_hub_devices_result
+
+    async def get_cubic_secure_measurement(self, device_identity, force_update=False):
+        self.calls.append(
+            ("get_cubic_secure_measurement", device_identity, force_update)
+        )
+        if self.get_cubic_secure_measurement_result:
+            self.cubic_secure_messurement = self.cubic_measurement_data
+        return self.get_cubic_secure_measurement_result
+
+    async def get_cubic_secure_configuration(
+        self, device_identity, force_update=False
+    ):
+        self.calls.append(
+            ("get_cubic_secure_configuration", device_identity, force_update)
+        )
+        if self.get_cubic_secure_configuration_result:
+            self.cubic_secure_configuration = self.cubic_configuration_data
+        return self.get_cubic_secure_configuration_result
+
+    async def set_thermostat_temperature(self, device_id, temperature):
+        self.calls.append(("set_thermostat_temperature", device_id, temperature))
+        return self.set_thermostat_temperature_result
+
+    async def cubic_secure_close_valve(self, cubic_identity):
+        self.calls.append(("cubic_secure_close_valve", cubic_identity))
+
+    async def cubic_secure_open_valve(self, cubic_identity):
+        self.calls.append(("cubic_secure_open_valve", cubic_identity))
+
+    async def cubic_secure_pause_leak_detection(self, cubic_identity, seconds):
+        self.calls.append(
+            ("cubic_secure_pause_leak_detection", cubic_identity, seconds)
+        )
+
+    async def cubic_secure_set_pressure_test_schedule(
+        self, cubic_identity, hour, minute
+    ):
+        self.calls.append(
+            ("cubic_secure_set_pressure_test_schedule", cubic_identity, hour, minute)
+        )
+
+    async def cubic_secure_set_thresholds(self, cubic_identity, thresholds):
+        self.calls.append(("cubic_secure_set_thresholds", cubic_identity, thresholds))
+
+
+# --- Sample device identities used across tests ---------------------------
+
+CUBIC_IDENTITY = "cubic-secure-1"
+THERMOSTAT_MAC = "AA:BB:CC:DD:EE:01"
+SENSOR_MAC = "AA:BB:CC:DD:EE:02"
+HUB_IDENTITY = "arc-hub-1"
+HUB_CHILD_MAC = "AA:BB:CC:DD:EE:03"
+
+
+def build_user_structure() -> dict:
+    """A realistic realestate structure: one cubicsecure, one standalone
+    thermostat, one standalone plain sensor, and one hub with a child
+    sensor - exercising every branch of the coordinator's device loop.
+    """
+    now = int(time.time())
+    return {
+        "realestateId": "realestate-1",
+        "name": "Test House",
+        "city": "Testville",
+        "address": "1 Test Street",
+        "zip": "12345",
+        "country": "SE",
+        "ownerId": "owner-1",
+        "cacheUpdated": now,
+        "realestateMachines": [
+            {
+                "identity": CUBIC_IDENTITY,
+                "deviceGroup": "cubic",
+                "deviceType": "cubicsecure",
+                "deviceRole": "cubicsecure",
+                "zone": {"zoneId": "zone-cubic", "zoneName": "Utility Room"},
+            },
+            {
+                "identity": THERMOSTAT_MAC,
+                "mac": THERMOSTAT_MAC,
+                "deviceGroup": "arc",
+                "deviceType": "arc-sense",
+                "deviceRole": "arc-tune",
+                "zone": {"zoneId": "zone-living", "zoneName": "Living Room"},
+            },
+            {
+                "identity": SENSOR_MAC,
+                "mac": SENSOR_MAC,
+                "deviceGroup": "arc",
+                "deviceType": "arc-sense",
+                "deviceRole": "arc-node",
+                "zone": {"zoneId": "zone-bed", "zoneName": "Bedroom"},
+            },
+            {
+                "identity": HUB_IDENTITY,
+                "mac": HUB_IDENTITY,
+                "deviceGroup": "arc",
+                "deviceType": "arc-hub",
+                "deviceRole": "arc-hub",
+                "name": "Test Hub",
+            },
+        ],
+    }
+
+
+def build_measurements_by_device() -> dict:
+    return {
+        THERMOSTAT_MAC: {
+            "currentTemperature": 205,  # 20.5°C
+            "desiredTemperature": 215,  # 21.5°C
+            "currentHumidity": 450,
+            "currentBattery": 90,
+            "currentRssi": -50,
+            "connectionState": "Connected",
+        },
+        SENSOR_MAC: {
+            "currentTemperature": 190,  # 19.0°C
+            "currentHumidity": 400,
+            "currentBattery": 75,
+            "currentRssi": -60,
+            "connectionState": "Connected",
+        },
+    }
+
+
+def build_hub_devices_by_hub() -> dict:
+    return {
+        HUB_IDENTITY: {
+            "devices": [
+                {
+                    "mac": HUB_CHILD_MAC,
+                    "deviceTitle": {
+                        "identity": HUB_CHILD_MAC,
+                        "deviceGroup": "arc",
+                        "deviceType": "arc-sense",
+                        "deviceRole": "arc-node",
+                        "parentIdentity": HUB_IDENTITY,
+                        "zone": {"zoneId": "zone-kitchen", "zoneName": "Kitchen"},
+                    },
+                    "measurement": {
+                        "currentTemperature": 220,
+                        "currentHumidity": 500,
+                        "currentBattery": 60,
+                        "currentRssi": -70,
+                        "connectionState": "Connected",
+                    },
+                }
+            ]
+        }
+    }
+
+
+def build_cubic_measurement() -> dict:
+    return {
+        "cacheUpdated": int(time.time()),
+        "volumeTotalDay": 120,
+        "volumeTotal": 45000,
+        "tempWaterAverage": 185,
+        "tempWaterMin": 170,
+        "tempWaterMax": 210,
+        "waterPressure": 3200,
+        "tempAmbient": 210,
+        "lastStatus": int(time.time()),
+        "leak": {
+            "leakState": "NoLeak",
+            "meanFlow": 0.0,
+            "dateStartedAt": int(time.time()),
+            "dateUpdatedAt": int(time.time()),
+            "acknowledged": False,
+        },
+    }
+
+
+def build_cubic_configuration() -> dict:
+    return {
+        "cacheUpdated": int(time.time()),
+        "valveState": "open",
+        "firmwareVersion": "1.2.3",
+        "hardwareVersion": 4,
+    }
+
+
+def configure_fake_manager_with_sample_data(manager: FakeLKSystemsManager) -> None:
+    """Populate a FakeLKSystemsManager with the sample fixture data above."""
+    manager.user_structure = build_user_structure()
+    manager.measurements_by_device = build_measurements_by_device()
+    manager.hub_devices_by_hub = build_hub_devices_by_hub()
+    manager.cubic_measurement_data = build_cubic_measurement()
+    manager.cubic_configuration_data = build_cubic_configuration()
+
+
+@pytest.fixture
+def fake_manager() -> FakeLKSystemsManager:
+    """A FakeLKSystemsManager pre-populated with a realistic structure."""
+    manager = FakeLKSystemsManager()
+    configure_fake_manager_with_sample_data(manager)
+    return manager

--- a/tests_ha/conftest.py
+++ b/tests_ha/conftest.py
@@ -1,0 +1,26 @@
+"""Shared fixtures for the Home-Assistant-dependent LK Systems test suite.
+
+Unlike tests/conftest.py (which sidesteps importing `homeassistant`
+entirely), these tests run against the real thing via
+pytest-homeassistant-custom-component, so they can exercise
+custom_components/lksystems/__init__.py, climate.py, sensor.py,
+config_flow.py and services.py directly.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest_plugins = "pytest_homeassistant_custom_component"
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Make custom_components/lksystems loadable as a real integration.
+
+    Without this, Home Assistant's test harness only ever sees its
+    built-in integrations - `enable_custom_integrations` (provided by
+    pytest-homeassistant-custom-component) tells the loader to also look
+    in the repo's custom_components/ directory.
+    """
+    yield

--- a/tests_ha/test_config_flow.py
+++ b/tests_ha/test_config_flow.py
@@ -1,0 +1,94 @@
+"""Tests for the LK Systems config flow.
+
+These exercise the config/options flow machinery end to end through a real
+(test-mode) Home Assistant core, proving out the tests_ha/
+pytest-homeassistant-custom-component infra. `async_step_user` doesn't
+currently call `validate_input` before creating an entry (see
+config_flow.py) so no LK Systems API mocking is needed here yet - these
+tests describe the flow's actual current behavior, not its API calls.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.data_entry_flow import FlowResultType
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.lksystems.const import (
+    CONF_UPDATE_INTERVAL,
+    DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+)
+
+USER_INPUT = {
+    CONF_USERNAME: "user@example.com",
+    CONF_PASSWORD: "hunter2",
+    CONF_UPDATE_INTERVAL: DEFAULT_UPDATE_INTERVAL,
+}
+
+
+async def test_user_step_shows_form(hass):
+    """The initial step shows the user credentials form."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+
+async def test_user_step_creates_entry(hass):
+    """Submitting valid credentials creates a config entry.
+
+    async_setup_entry is patched out so the newly-created entry doesn't
+    trigger a real coordinator refresh (and a real network call) as a
+    side effect of this config-flow-only test.
+    """
+    with patch(
+        "custom_components.lksystems.async_setup_entry", return_value=True
+    ):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN, context={"source": "user"}
+        )
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], USER_INPUT
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "LK Systems (user@example.com)"
+    assert result["data"] == USER_INPUT
+
+
+async def test_user_step_duplicate_username_aborts(hass):
+    """A second entry for the same username is rejected."""
+    MockConfigEntry(domain=DOMAIN, data=USER_INPUT).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], USER_INPUT
+    )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
+
+
+async def test_options_flow_updates_interval(hass):
+    """The options flow can change the update interval on an existing entry."""
+    entry = MockConfigEntry(domain=DOMAIN, data=USER_INPUT)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "init"
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], {CONF_UPDATE_INTERVAL: 30}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"] == {CONF_UPDATE_INTERVAL: 30}

--- a/tests_ha/test_config_flow.py
+++ b/tests_ha/test_config_flow.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from unittest.mock import patch
 
+from homeassistant.config_entries import SOURCE_REAUTH
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.data_entry_flow import FlowResultType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -92,3 +93,84 @@ async def test_options_flow_updates_interval(hass):
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["data"] == {CONF_UPDATE_INTERVAL: 30}
+
+
+async def test_reauth_shows_form(hass):
+    """Triggering reauth (as done in __init__.py on auth failure) shows
+    a pre-filled credentials form."""
+    entry = MockConfigEntry(domain=DOMAIN, data=USER_INPUT)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_REAUTH, "entry_id": entry.entry_id},
+        data=entry.data,
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth"
+
+
+async def test_reauth_success_updates_entry_and_reloads(hass, fake_manager):
+    """Valid new credentials update the entry and reload it.
+
+    Both the config flow's own validate_input() call and the coordinator's
+    refresh (triggered by the reload that follows) go through
+    LKSystemsManager, so both import sites need patching.
+    """
+    entry = MockConfigEntry(domain=DOMAIN, data=USER_INPUT)
+    entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_REAUTH, "entry_id": entry.entry_id},
+        data=entry.data,
+    )
+
+    new_creds = {
+        CONF_USERNAME: USER_INPUT[CONF_USERNAME],
+        CONF_PASSWORD: "new-password",
+    }
+    with (
+        patch(
+            "custom_components.lksystems.config_flow.LKSystemsManager",
+            return_value=fake_manager,
+        ),
+        patch(
+            "custom_components.lksystems.LKSystemsManager", return_value=fake_manager
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], new_creds
+        )
+        await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[CONF_PASSWORD] == "new-password"
+
+
+async def test_reauth_invalid_auth_reshows_form_with_error(hass, fake_manager):
+    """A failed login during reauth re-shows the form with an error."""
+    entry = MockConfigEntry(domain=DOMAIN, data=USER_INPUT)
+    entry.add_to_hass(hass)
+    fake_manager.login_result = False
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_REAUTH, "entry_id": entry.entry_id},
+        data=entry.data,
+    )
+
+    with patch(
+        "custom_components.lksystems.config_flow.LKSystemsManager",
+        return_value=fake_manager,
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_USERNAME: USER_INPUT[CONF_USERNAME], CONF_PASSWORD: "wrong"},
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "reauth"
+    assert result["errors"] == {"base": "invalid_auth"}

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -196,6 +196,49 @@ class TestAsyncUpdateData:
         assert TOKEN_STORAGE[entry.entry_id]["jwt"] == "fake-jwt-token"
 
 
+class TestCubicFetchFailureFallback:
+    """A failure partway through fetching the cubic measurement/configuration
+    used to leave "cubic_last_measurement"/"cubic_configuration" out of the
+    returned data entirely, since the keys are only assigned after the calls
+    that can raise. sensor.py indexes both keys directly, so every cubic
+    sensor crashed with a KeyError while Home Assistant was adding it.
+    """
+
+    async def test_configuration_fetch_failure_still_yields_both_keys(
+        self, hass, fake_manager
+    ):
+        fake_manager.get_cubic_secure_configuration = AsyncMock(
+            side_effect=RuntimeError("boom")
+        )
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            data = await coordinator._async_update_data()
+
+        assert "cubic_last_measurement" in data
+        assert "cubic_configuration" in data
+        assert data["cubic_configuration"] is None
+
+    async def test_configuration_fetch_failure_falls_back_to_previous_data(
+        self, hass, fake_manager
+    ):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            good_data = await coordinator._async_update_data()
+        coordinator.async_set_updated_data(good_data)
+
+        fake_manager.get_cubic_secure_configuration = AsyncMock(
+            side_effect=RuntimeError("boom")
+        )
+        with _patch_manager(fake_manager):
+            data = await coordinator._async_update_data()
+
+        assert data["cubic_configuration"] == good_data["cubic_configuration"]
+
+
 class TestForceDeviceUpdate:
     async def test_success_updates_stored_data(self, hass, fake_manager):
         entry = _make_entry(hass)

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -1,0 +1,288 @@
+"""Tests for is_token_valid() and LKSystemCoordinator in __init__.py.
+
+The LK Systems API client itself (pylksystems) is mocked out via
+FakeLKSystemsManager (see conftest.py) - these tests are only concerned
+with the coordinator's own logic: building the response structure from
+whatever the client returns, token caching, and error handling.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+from datetime import timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.lksystems import (
+    TOKEN_STORAGE,
+    LKSystemCoordinator,
+    is_token_valid,
+)
+from custom_components.lksystems.const import (
+    CONF_UPDATE_INTERVAL,
+    DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+)
+
+from .conftest import (
+    CUBIC_IDENTITY,
+    HUB_CHILD_MAC,
+    HUB_IDENTITY,
+    SENSOR_MAC,
+    THERMOSTAT_MAC,
+)
+
+
+def _make_token(expires_in_seconds: float) -> str:
+    """Build a JWT-shaped (but unsigned) token with a controllable exp claim.
+
+    is_token_valid() never checks the signature, only the middle segment.
+    """
+    exp = dt_util.utcnow().timestamp() + expires_in_seconds
+    payload = base64.b64encode(json.dumps({"exp": exp}).encode()).rstrip(b"=").decode()
+    return f"header.{payload}.signature"
+
+
+def _patch_manager(manager):
+    return patch("custom_components.lksystems.LKSystemsManager", return_value=manager)
+
+
+@pytest.fixture(autouse=True)
+def _clear_token_storage():
+    """TOKEN_STORAGE is a module-level global - keep tests isolated."""
+    TOKEN_STORAGE.clear()
+    yield
+    TOKEN_STORAGE.clear()
+
+
+class TestIsTokenValid:
+    def test_none_and_empty_are_invalid(self):
+        assert is_token_valid(None) is False
+        assert is_token_valid("") is False
+
+    def test_malformed_token_is_invalid(self):
+        assert is_token_valid("not-a-jwt") is False
+
+    def test_unparsable_payload_is_invalid(self):
+        assert is_token_valid("a.b.c") is False
+
+    def test_future_expiry_is_valid(self):
+        assert is_token_valid(_make_token(3600)) is True
+
+    def test_past_expiry_is_invalid(self):
+        assert is_token_valid(_make_token(-3600)) is False
+
+    def test_expiry_within_five_minute_margin_is_invalid(self):
+        # is_token_valid requires more than 5 minutes of remaining validity.
+        assert is_token_valid(_make_token(60)) is False
+
+
+def _make_entry(hass, update_interval=None):
+    data = {CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"}
+    if update_interval is not None:
+        data[CONF_UPDATE_INTERVAL] = update_interval
+    entry = MockConfigEntry(domain=DOMAIN, data=data)
+    entry.add_to_hass(hass)
+    return entry
+
+
+class TestCoordinatorConstruction:
+    async def test_uses_configured_update_interval(self, hass):
+        entry = _make_entry(hass, update_interval=15)
+        coordinator = LKSystemCoordinator(hass, entry)
+        assert coordinator.update_interval == timedelta(minutes=15)
+
+    async def test_defaults_to_default_update_interval(self, hass):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+        assert coordinator.update_interval == timedelta(
+            minutes=DEFAULT_UPDATE_INTERVAL
+        )
+
+
+class TestAsyncUpdateData:
+    async def test_missing_credentials_raises_auth_failed(self, hass):
+        entry = MockConfigEntry(domain=DOMAIN, data={})
+        entry.add_to_hass(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with pytest.raises(ConfigEntryAuthFailed):
+            await coordinator._async_update_data()
+
+    async def test_login_failure_raises_auth_failed(self, hass, fake_manager):
+        fake_manager.login_result = False
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            with pytest.raises(ConfigEntryAuthFailed):
+                await coordinator._async_update_data()
+
+    async def test_get_user_structure_failure_raises_update_failed(
+        self, hass, fake_manager
+    ):
+        fake_manager.get_user_structure_result = False
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            with pytest.raises(UpdateFailed):
+                await coordinator._async_update_data()
+
+    async def test_builds_full_structure_from_client_data(self, hass, fake_manager):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            data = await coordinator._async_update_data()
+
+        assert data["realestateId"] == "realestate-1"
+
+        # Cubic Secure device
+        assert data["cubic_machine_info"]["identity"] == CUBIC_IDENTITY
+        assert data["cubic_last_measurement"]["volumeTotal"] == 45000
+        assert data["cubic_configuration"]["valveState"] == "open"
+
+        # Standalone Arc devices (thermostat + plain sensor)
+        macs = {d.get("mac") for d in data["devices"]}
+        assert THERMOSTAT_MAC in macs
+        assert SENSOR_MAC in macs
+        thermostat_device = next(
+            d for d in data["devices"] if d.get("mac") == THERMOSTAT_MAC
+        )
+        assert thermostat_device["measurement"]["desiredTemperature"] == 215
+
+        # Hub + its child device
+        assert HUB_IDENTITY in data["hub_data"]
+        hub_macs = {
+            d.get("mac") for d in data["hub_data"][HUB_IDENTITY]["devices"]
+        }
+        assert HUB_CHILD_MAC in hub_macs
+
+    async def test_valid_stored_token_skips_login(self, hass, fake_manager):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+        TOKEN_STORAGE[entry.entry_id] = {
+            "jwt": _make_token(3600),
+            "refresh": "stored-refresh",
+            "userid": "stored-user",
+        }
+
+        with _patch_manager(fake_manager):
+            await coordinator._async_update_data()
+
+        assert ("login",) not in fake_manager.calls
+
+    async def test_expired_stored_token_triggers_login(self, hass, fake_manager):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+        TOKEN_STORAGE[entry.entry_id] = {
+            "jwt": _make_token(-3600),
+            "refresh": "stored-refresh",
+            "userid": "stored-user",
+        }
+
+        with _patch_manager(fake_manager):
+            await coordinator._async_update_data()
+
+        assert ("login",) in fake_manager.calls
+        assert TOKEN_STORAGE[entry.entry_id]["jwt"] == "fake-jwt-token"
+
+
+class TestForceDeviceUpdate:
+    async def test_success_updates_stored_data(self, hass, fake_manager):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            data = await coordinator._async_update_data()
+        coordinator.async_set_updated_data(data)
+
+        fake_manager.measurements_by_device[THERMOSTAT_MAC] = {
+            **fake_manager.measurements_by_device[THERMOSTAT_MAC],
+            "currentTemperature": 250,
+        }
+
+        with _patch_manager(fake_manager):
+            result = await coordinator.force_device_update(THERMOSTAT_MAC)
+
+        assert result is True
+        assert (
+            coordinator.data["device_details"][THERMOSTAT_MAC]["measurement"][
+                "currentTemperature"
+            ]
+            == 250
+        )
+
+    async def test_measurement_fetch_failure_returns_false(self, hass, fake_manager):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+        fake_manager.get_device_measurement_result = False
+
+        with _patch_manager(fake_manager):
+            result = await coordinator.force_device_update(THERMOSTAT_MAC)
+
+        assert result is False
+
+    async def test_login_failure_returns_false(self, hass, fake_manager):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+        fake_manager.login_result = False
+
+        with _patch_manager(fake_manager):
+            result = await coordinator.force_device_update(THERMOSTAT_MAC)
+
+        assert result is False
+
+
+class TestSetThermostatTemperature:
+    async def test_success_returns_true_and_refreshes(self, hass, fake_manager):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            result = await coordinator.set_thermostat_temperature(
+                THERMOSTAT_MAC, 225
+            )
+
+        assert result is True
+        assert ("set_thermostat_temperature", THERMOSTAT_MAC, 225) in fake_manager.calls
+        # async_refresh() was called as a side effect
+        assert coordinator.data is not None
+
+    async def test_api_failure_returns_false(self, hass, fake_manager):
+        fake_manager.set_thermostat_temperature_result = {
+            "success": False,
+            "data": None,
+            "error": "boom",
+        }
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            result = await coordinator.set_thermostat_temperature(
+                THERMOSTAT_MAC, 225
+            )
+
+        assert result is False
+
+    async def test_unexpected_exception_returns_false(self, hass, fake_manager):
+        fake_manager.set_thermostat_temperature = AsyncMock(
+            side_effect=RuntimeError("boom")
+        )
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            result = await coordinator.set_thermostat_temperature(
+                THERMOSTAT_MAC, 225
+            )
+
+        assert result is False

--- a/tests_ha/test_integration_setup.py
+++ b/tests_ha/test_integration_setup.py
@@ -10,7 +10,7 @@ slugified entity_ids, so these don't depend on HA's naming/slugify rules.
 
 from __future__ import annotations
 
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import entity_registry as er
@@ -101,6 +101,24 @@ async def test_cubic_secure_sensors_reflect_client_data(hass, fake_manager):
 
     assert hass.states.get(volume_id).state == "45000"
     assert hass.states.get(valve_id).state == "open"
+
+
+async def test_cubic_sensors_survive_a_configuration_fetch_failure(
+    hass, fake_manager
+):
+    """A transient failure fetching the cubic configuration used to leave
+    "cubic_configuration" out of the coordinator's data entirely, and
+    sensor.py indexed it directly - crashing every cubic sensor with a
+    KeyError while Home Assistant was adding it.
+    """
+    fake_manager.get_cubic_secure_configuration = AsyncMock(
+        side_effect=RuntimeError("boom")
+    )
+
+    await _setup_entry(hass, fake_manager)
+
+    valve_id = _entity_id(hass, "sensor", f"LkUid_valveState_{CUBIC_IDENTITY}")
+    assert hass.states.get(valve_id) is not None
 
 
 async def test_set_temperature_service_calls_coordinator(hass, fake_manager):

--- a/tests_ha/test_integration_setup.py
+++ b/tests_ha/test_integration_setup.py
@@ -1,0 +1,153 @@
+"""End-to-end config-entry setup tests.
+
+These drive a real (test-mode) hass through hass.config_entries.async_setup,
+so the coordinator's first refresh, and both the sensor.py and climate.py
+platforms' async_setup_entry() + entity classes, all run for real against
+FakeLKSystemsManager's canned data (see conftest.py). Entities are looked
+up by their unique_id via the entity registry rather than by guessing
+slugified entity_ids, so these don't depend on HA's naming/slugify rules.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.lksystems.const import DOMAIN
+
+from .conftest import (
+    CUBIC_IDENTITY,
+    HUB_CHILD_MAC,
+    HUB_IDENTITY,
+    SENSOR_MAC,
+    THERMOSTAT_MAC,
+)
+
+
+async def _setup_entry(hass, manager) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
+    )
+    entry.add_to_hass(hass)
+    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def _entity_id(hass, platform: str, unique_id: str) -> str:
+    entity_id = er.async_get(hass).async_get_entity_id(platform, DOMAIN, unique_id)
+    assert entity_id is not None, f"no {platform} entity registered for {unique_id!r}"
+    return entity_id
+
+
+async def test_thermostat_entity_reflects_client_data(hass, fake_manager):
+    await _setup_entry(hass, fake_manager)
+
+    entity_id = _entity_id(
+        hass, "climate", f"{DOMAIN}_{THERMOSTAT_MAC}_thermostat"
+    )
+    state = hass.states.get(entity_id)
+
+    assert state.attributes["current_temperature"] == 20.5
+    assert state.attributes["temperature"] == 21.5
+
+
+async def test_standalone_sensor_entities_reflect_client_data(hass, fake_manager):
+    await _setup_entry(hass, fake_manager)
+
+    temperature_id = _entity_id(
+        hass, "sensor", f"{DOMAIN}_{SENSOR_MAC}_temperature"
+    )
+    humidity_id = _entity_id(hass, "sensor", f"{DOMAIN}_{SENSOR_MAC}_humidity")
+    battery_id = _entity_id(hass, "sensor", f"{DOMAIN}_{SENSOR_MAC}_battery")
+    rssi_id = _entity_id(hass, "sensor", f"{DOMAIN}_{SENSOR_MAC}_rssi")
+
+    assert hass.states.get(temperature_id).state == "19.0"
+    assert hass.states.get(humidity_id).state == "40.0"
+    assert hass.states.get(battery_id).state == "75"
+    assert hass.states.get(rssi_id).state == "-60"
+
+
+async def test_hub_and_hub_child_entities_are_created(hass, fake_manager):
+    """The hub entity itself is created, but its status is currently
+    always unavailable: the coordinator never stores a "measurement" (and
+    so no connectionState) for the arc-hub device itself, only for its
+    children - LKArcHubEntity.native_value has no data source that ever
+    matches. Asserting the entity exists at all, since that's the part
+    this suite is meant to cover; the value gap is a separate bug (see
+    TODO.local.md).
+    """
+    await _setup_entry(hass, fake_manager)
+
+    hub_status_id = _entity_id(hass, "sensor", f"{DOMAIN}_{HUB_IDENTITY}_status")
+    assert hass.states.get(hub_status_id).state == "unknown"
+
+    child_temperature_id = _entity_id(
+        hass, "sensor", f"{DOMAIN}_{HUB_CHILD_MAC}_temperature"
+    )
+    assert hass.states.get(child_temperature_id).state == "22.0"
+
+
+async def test_cubic_secure_sensors_reflect_client_data(hass, fake_manager):
+    await _setup_entry(hass, fake_manager)
+
+    volume_id = _entity_id(hass, "sensor", f"LkUid_volumeTotal_{CUBIC_IDENTITY}")
+    valve_id = _entity_id(hass, "sensor", f"LkUid_valveState_{CUBIC_IDENTITY}")
+
+    assert hass.states.get(volume_id).state == "45000"
+    assert hass.states.get(valve_id).state == "open"
+
+
+async def test_set_temperature_service_calls_coordinator(hass, fake_manager):
+    await _setup_entry(hass, fake_manager)
+    entity_id = _entity_id(hass, "climate", f"{DOMAIN}_{THERMOSTAT_MAC}_thermostat")
+
+    with patch(
+        "custom_components.lksystems.LKSystemsManager", return_value=fake_manager
+    ):
+        await hass.services.async_call(
+            "climate",
+            "set_temperature",
+            {"entity_id": entity_id, "temperature": 22.5},
+            blocking=True,
+        )
+
+    assert (
+        "set_thermostat_temperature",
+        THERMOSTAT_MAC,
+        225,
+    ) in fake_manager.calls
+
+
+async def test_refresh_device_service_forces_a_device_update(hass, fake_manager):
+    await _setup_entry(hass, fake_manager)
+
+    with patch(
+        "custom_components.lksystems.LKSystemsManager", return_value=fake_manager
+    ):
+        await hass.services.async_call(
+            DOMAIN,
+            "refresh_device",
+            {"device_id": THERMOSTAT_MAC},
+            blocking=True,
+        )
+
+    assert (
+        "get_device_measurement",
+        THERMOSTAT_MAC,
+        True,
+    ) in fake_manager.calls
+
+
+async def test_unload_entry_removes_coordinator(hass, fake_manager):
+    entry = await _setup_entry(hass, fake_manager)
+
+    assert await hass.config_entries.async_unload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entry.entry_id not in hass.data[DOMAIN]

--- a/tests_ha/test_services.py
+++ b/tests_ha/test_services.py
@@ -1,0 +1,157 @@
+"""Tests for the service call handlers registered by services.py.
+
+The valve/threshold/schedule services operate on Cubic Secure devices, so
+each test sets up a full config entry (giving us a real HA device created
+from AbstractLkCubicSensor.device_info, which is the only device_info in
+this integration that carries a serial_number - see close_valve() et al.
+reading device_entry.serial_number) and drives the services through
+hass.services.async_call().
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import device_registry as dr
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.lksystems.const import DOMAIN
+
+from .conftest import CUBIC_IDENTITY
+
+
+def _patch_services_manager(manager):
+    return patch(
+        "custom_components.lksystems.services.LKSystemsManager", return_value=manager
+    )
+
+
+async def _setup_entry_and_get_cubic_device(hass, manager):
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
+    )
+    entry.add_to_hass(hass)
+    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    device_entry = dr.async_get(hass).async_get_device(
+        identifiers={(DOMAIN, CUBIC_IDENTITY)}
+    )
+    assert device_entry is not None
+    assert device_entry.serial_number == CUBIC_IDENTITY
+    return entry, device_entry
+
+
+async def test_close_valve_calls_client(hass, fake_manager):
+    _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
+
+    with _patch_services_manager(fake_manager):
+        await hass.services.async_call(
+            DOMAIN, "close_valve", {"device_id": device_entry.id}, blocking=True
+        )
+
+    assert ("cubic_secure_close_valve", CUBIC_IDENTITY) in fake_manager.calls
+
+
+async def test_open_valve_calls_client(hass, fake_manager):
+    _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
+
+    with _patch_services_manager(fake_manager):
+        await hass.services.async_call(
+            DOMAIN, "open_valve", {"device_id": device_entry.id}, blocking=True
+        )
+
+    assert ("cubic_secure_open_valve", CUBIC_IDENTITY) in fake_manager.calls
+
+
+async def test_pause_leak_detection_calls_client(hass, fake_manager):
+    _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
+
+    with _patch_services_manager(fake_manager):
+        await hass.services.async_call(
+            DOMAIN,
+            "pause_leak_detection",
+            {"device_id": device_entry.id, "seconds": 1800},
+            blocking=True,
+        )
+
+    assert (
+        "cubic_secure_pause_leak_detection",
+        CUBIC_IDENTITY,
+        1800,
+    ) in fake_manager.calls
+
+
+async def test_set_pressure_test_schedule_calls_client(hass, fake_manager):
+    _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
+
+    with _patch_services_manager(fake_manager):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_pressure_test_schedule",
+            {"device_id": device_entry.id, "hour": 3, "minute": 30},
+            blocking=True,
+        )
+
+    assert (
+        "cubic_secure_set_pressure_test_schedule",
+        CUBIC_IDENTITY,
+        3,
+        30,
+    ) in fake_manager.calls
+
+
+async def test_set_thresholds_calls_client_with_defaults(hass, fake_manager):
+    _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
+
+    with _patch_services_manager(fake_manager):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_thresholds",
+            {"device_id": device_entry.id},
+            blocking=True,
+        )
+
+    threshold_calls = [
+        c for c in fake_manager.calls if c[0] == "cubic_secure_set_thresholds"
+    ]
+    assert len(threshold_calls) == 1
+    assert threshold_calls[0][1] == CUBIC_IDENTITY
+    thresholds = threshold_calls[0][2]
+    assert thresholds["pressure"]["sensitivity"] == 0.3
+    assert thresholds["leakLarge"]["threshold"] == 1500.0
+
+
+async def test_close_valve_login_failure_does_not_raise(hass, fake_manager):
+    """Handler catches the login failure inside its try/except and just logs."""
+    _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
+    fake_manager.login_result = False
+
+    with _patch_services_manager(fake_manager):
+        await hass.services.async_call(
+            DOMAIN, "close_valve", {"device_id": device_entry.id}, blocking=True
+        )
+
+    assert not any(c[0] == "cubic_secure_close_valve" for c in fake_manager.calls)
+
+
+async def test_close_valve_unknown_device_raises(hass, fake_manager):
+    """Documents current (buggy) behavior: device_entry.serial_number is
+    read before the handler's own try/except, so an unrecognized
+    device_id crashes with an AttributeError instead of being handled
+    gracefully. Not fixed here - see TODO.local.md.
+    """
+    await _setup_entry_and_get_cubic_device(hass, fake_manager)
+
+    with _patch_services_manager(fake_manager):
+        with pytest.raises(Exception):
+            await hass.services.async_call(
+                DOMAIN,
+                "close_valve",
+                {"device_id": "not-a-real-device-id"},
+                blocking=True,
+            )


### PR DESCRIPTION
> **Stacked on #44.** This branch is built on top of `feature/pytest-homeassistant-test-infra` (opened separately as #44), since exercising this bug needs a real coordinator/entity-setup flow. GitHub can't target a fork-only branch as the base for a cross-repo PR, so this still shows as based on `main` and its "Files changed" tab currently includes #44's commits too — please review #44 on its own first. Once #44 merges (via a regular merge or rebase, not squash, so the commit SHAs are preserved), this diff will automatically shrink to just the fix + regression tests below.
>
> Until then, the "Files changed" tab here shows #44's commits mixed in. To review just this PR's own change, see the isolated diff for the single fix commit instead: https://github.com/angoyd/ha-lksystems/pull/43/commits/5eba93626fce78a597348e4990f8a410b0f097a8

## Bug

Changing the update interval (e.g. 5 → 10 minutes) via the Configure dialog triggered a reload that logged errors like:

```
ERROR (MainThread) [homeassistant.components.sensor] Error adding entity sensor.cubic_secure_tvattstugan_leak_state for domain sensor with platform lksystems
  File "/config/custom_components/lksystems/sensor.py", line 948, in native_value
```

for every `cubic_secure_*` sensor.

## Root cause

If fetching the cubic secure measurement/configuration raised partway through (e.g. a transient network error, or the forced re-fetch when the cache is stale), the exception was caught and logged, but `"cubic_last_measurement"`/`"cubic_configuration"` were left out of the coordinator's returned data entirely — those keys are only assigned *after* the calls that can raise. `sensor.py`'s `native_value` indexed both keys directly (`self._coordinator.data["cubic_configuration"]`), so every cubic sensor crashed with a `KeyError` while Home Assistant was adding it.

This got easier to hit once #40 made changing the interval via the options dialog actually take effect: `async_update_options()` kicked off a redundant `coordinator.async_refresh()` on the *old* coordinator right before `async_reload()` tore it down and recreated it (with its own first refresh) — two concurrent fetches against the same device, one of which failed.

## Fix

- Coordinator: on a fetch failure, backfill `cubic_last_measurement`/`cubic_configuration` from the previous update (or `None`) so the returned data is always structurally complete.
- `sensor.py`: read both keys via `.get()` instead of direct indexing, as a second line of defense.
- Drop the now-redundant `async_refresh()` call in `async_update_options()` — `async_reload()` already performs its own first refresh.

## Tests

Added two coordinator-level regression tests and one full config-entry-setup test (in `tests_ha/`, from #44) that reproduces the exact `KeyError`/log output from the crash. All three were verified to fail against the pre-fix code and pass with it.

```
tests/          25 passed
tests_ha/       44 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
