### PR TITLE
Clarify already_configured abort message

### DIFF
--- a/custom_components/lksystems/strings.json
+++ b/custom_components/lksystems/strings.json
@@ -16,7 +16,7 @@
             "unknown": "[%key:common::config_flow::error::unknown%]"
         },
         "abort": {
-            "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
+            "already_configured": "This LK Systems account is already configured. One integration entry covers your whole account, including multiple Cubic Secure devices - you don't need to add it again to see additional devices."
         }
     }
 }


### PR DESCRIPTION
Fixes #51.

Adding a second config entry showed HA's generic "device is already
configured" abort text (`common::config_flow::abort::already_configured_device`),
which doesn't explain why. The #29 reporter hit this trying to add a
second Cubic Secure device, with no indication that one integration
entry already covers the whole account - including additional Cubic
Secure devices on it.

Replaces the inherited common string with an integration-specific one
in `strings.json`. The `already_configured` abort *reason* key is
unchanged, so no test changes are needed - this is UI copy only.