### PR TITLE
Support multiple Cubic Secure devices on one account (#29)

### DIFF
--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -57,12 +57,20 @@ class LkStructureResp(TypedDict):
     zip: str
     country: str
     ownerId: str
-    cubic_machine_info: LkStructureMashine
-    cubic_last_measurement: LkCubicSecureResp
-    cubic_configuration: LKCubicSecureConfigResp
+    cubic_devices: Dict[str, "LkCubicDeviceData"]
     cacheUpdated: int
     update_time: str
     next_update_time: str
+
+
+class LkCubicDeviceData(TypedDict):
+    """Per-Cubic-Secure-device data, keyed by device identity in
+    LkStructureResp.cubic_devices so multiple devices on one account
+    don't share a single overwritable slot."""
+
+    machine_info: LkStructureMashine
+    last_measurement: LkCubicSecureResp
+    configuration: LKCubicSecureConfigResp
 
 
 class LKCubicSecureConfigResp(TypedDict):
@@ -210,7 +218,6 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         # Store for later reference
         self._update_interval_minutes = update_interval_minutes
         self._entry = entry
-        self._cubic_identity = None
         self._last_update_time = dt_util.now()
         self._entry_id = entry.entry_id
 
@@ -441,16 +448,10 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                     "country": lk_inst.user_structure["country"],
                     "ownerId": lk_inst.user_structure["ownerId"],
                     "cacheUpdated": lk_inst.user_structure["cacheUpdated"],
-                    "cubic_machine_info": next(
-                        (
-                            x
-                            for x in lk_inst.user_structure["realestateMachines"]
-                            if x["deviceType"] == "cubicsecure"
-                            and x["deviceRole"] == "cubicsecure"
-                        ),
-                        None,
-                    ),
-                    "cubic_last_messurement": None,
+                    # Keyed by device identity so multiple Cubic Secure
+                    # devices on the same account don't overwrite each
+                    # other's machine_info/last_measurement/configuration.
+                    "cubic_devices": {},
                     "devices": [],
                     "device_details": {},  # Will store detailed information about each device
                     "update_time": self._last_update_time.isoformat(),
@@ -576,17 +577,18 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                             machine.get("deviceType") == "cubicsecure"
                             and machine.get("deviceRole") == "cubicsecure"
                         ):
-                            resp["cubic_machine_info"] = machine
-                            self._cubic_identity = device_identity
+                            # Keyed by device_identity: multiple Cubic Secure
+                            # devices on the same account each get their own
+                            # entry instead of overwriting a shared one.
+                            resp["cubic_devices"][device_identity] = {
+                                "machine_info": machine
+                            }
 
                             # Try to get cubic measurements but don't fail if not available
                             try:
-                                if await lk_inst.get_cubic_secure_measurement(
+                                await lk_inst.get_cubic_secure_measurement(
                                     device_identity
-                                ):
-                                    resp["cubic_last_messurement"] = (
-                                        lk_inst.cubic_secure_messurement
-                                    )
+                                )
 
                                 if lk_inst.cubic_secure_messurement is not None:
                                     # Get time as unix timestamp
@@ -602,7 +604,7 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                                             "Cubic secure measurement is older than update interval, force update"
                                         )
                                         if not await lk_inst.get_cubic_secure_measurement(
-                                            self._cubic_identity, force_update=True
+                                            device_identity, force_update=True
                                         ):
                                             _LOGGER.error(
                                                 "Failed to get cubic secure measurement, abort update"
@@ -611,11 +613,11 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                                                 "Unknown error get_cubic_secure_measurement"
                                             )
 
-                                resp["cubic_last_measurement"] = (
-                                    lk_inst.cubic_secure_messurement
-                                )
+                                resp["cubic_devices"][device_identity][
+                                    "last_measurement"
+                                ] = lk_inst.cubic_secure_messurement
                                 if not await lk_inst.get_cubic_secure_configuration(
-                                    self._cubic_identity
+                                    device_identity
                                 ):
                                     _LOGGER.error(
                                         "Failed to get cubic secure configuration, abort update"
@@ -637,7 +639,7 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                                             "Cubic secure configuration is older than update interval, force update"
                                         )
                                         if not await lk_inst.get_cubic_secure_configuration(
-                                            self._cubic_identity, force_update=True
+                                            device_identity, force_update=True
                                         ):
                                             _LOGGER.error(
                                                 "Failed to get cubic secure configuration, abort update"
@@ -646,21 +648,26 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                                                 "Unknown error get_cubic_secure_configuration"
                                             )
 
-                                resp["cubic_configuration"] = (
-                                    lk_inst.cubic_secure_configuration
-                                )
+                                resp["cubic_devices"][device_identity][
+                                    "configuration"
+                                ] = lk_inst.cubic_secure_configuration
                             except Exception as err:
                                 # Sensors index these keys directly, so they
-                                # must exist even on failure; reuse the last
-                                # known values if we have them.
-                                previous_data = self.data or {}
-                                resp.setdefault(
-                                    "cubic_last_measurement",
-                                    previous_data.get("cubic_last_measurement"),
+                                # must exist even on failure; reuse this
+                                # device's last known values if we have them.
+                                previous_device_data = (
+                                    (self.data or {})
+                                    .get("cubic_devices", {})
+                                    .get(device_identity, {})
                                 )
-                                resp.setdefault(
-                                    "cubic_configuration",
-                                    previous_data.get("cubic_configuration"),
+                                device_entry = resp["cubic_devices"][device_identity]
+                                device_entry.setdefault(
+                                    "last_measurement",
+                                    previous_device_data.get("last_measurement"),
+                                )
+                                device_entry.setdefault(
+                                    "configuration",
+                                    previous_device_data.get("configuration"),
                                 )
                                 _LOGGER.warning(
                                     "Error fetching cubic measurements: %s", str(err)

--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -448,9 +448,6 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                     "country": lk_inst.user_structure["country"],
                     "ownerId": lk_inst.user_structure["ownerId"],
                     "cacheUpdated": lk_inst.user_structure["cacheUpdated"],
-                    # Keyed by device identity so multiple Cubic Secure
-                    # devices on the same account don't overwrite each
-                    # other's machine_info/last_measurement/configuration.
                     "cubic_devices": {},
                     "devices": [],
                     "device_details": {},  # Will store detailed information about each device
@@ -577,9 +574,6 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                             machine.get("deviceType") == "cubicsecure"
                             and machine.get("deviceRole") == "cubicsecure"
                         ):
-                            # Keyed by device_identity: multiple Cubic Secure
-                            # devices on the same account each get their own
-                            # entry instead of overwriting a shared one.
                             resp["cubic_devices"][device_identity] = {
                                 "machine_info": machine
                             }

--- a/custom_components/lksystems/sensor.py
+++ b/custom_components/lksystems/sensor.py
@@ -50,7 +50,6 @@ async def async_setup_entry(
     """Set up LK Systems sensor based on a config entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
 
-    entities = []
     processed_devices = set()  # Track processed devices to avoid duplicates
     created_entity_ids = set()  # Track entity IDs to avoid duplicates
 
@@ -70,61 +69,102 @@ async def async_setup_entry(
             device_title = device.get("deviceTitle", {})
 
             if device_title.get("deviceType") == "cubicsecure":
+                device_identity = device_title.get("identity")
                 _LOGGER.debug(
                     "Setting up LK Cubic sensors for %s",
-                    coordinator.data["cubic_machine_info"]["zone"]["zoneName"],
+                    coordinator.data["cubic_devices"][device_identity][
+                        "machine_info"
+                    ]["zone"]["zoneName"],
                 )
+                cubic_entities = []
                 for key, description in LK_CUBICSECURE_SENSORS.items():
                     if key == "volumetotal":
-                        entities.append(LKCubicSensor(coordinator, description))
+                        cubic_entities.append(
+                            LKCubicSensor(coordinator, description, device_identity)
+                        )
                     if key == "volumetotalday":
-                        entities.append(LKCubicSensor(coordinator, description))
+                        cubic_entities.append(
+                            LKCubicSensor(coordinator, description, device_identity)
+                        )
                     if key == "tempWaterAverage":
-                        entities.append(LKCubicSensor(coordinator, description))
+                        cubic_entities.append(
+                            LKCubicSensor(coordinator, description, device_identity)
+                        )
                     if key == "tempWaterMin":
-                        entities.append(LKCubicSensor(coordinator, description))
+                        cubic_entities.append(
+                            LKCubicSensor(coordinator, description, device_identity)
+                        )
                     if key == "tempWaterMax":
-                        entities.append(LKCubicSensor(coordinator, description))
+                        cubic_entities.append(
+                            LKCubicSensor(coordinator, description, device_identity)
+                        )
                     if key == "waterPressure":
-                        entities.append(LKCubicSensor(coordinator, description))
+                        cubic_entities.append(
+                            LKCubicSensor(coordinator, description, device_identity)
+                        )
                     if key == "ambientTemp":
-                        entities.append(LKCubicSensor(coordinator, description))
+                        cubic_entities.append(
+                            LKCubicSensor(coordinator, description, device_identity)
+                        )
                     if key == "lastStatus":
-                        entities.append(LKCubicSensor(coordinator, description))
+                        cubic_entities.append(
+                            LKCubicSensor(coordinator, description, device_identity)
+                        )
                     if key == "cacheUpdated":
-                        entities.append(LKCubicSensor(coordinator, description))
+                        cubic_entities.append(
+                            LKCubicSensor(coordinator, description, device_identity)
+                        )
                     if key == "leak.leakState":
-                        entities.append(LKCubicSensor(coordinator, description))
+                        cubic_entities.append(
+                            LKCubicSensor(coordinator, description, device_identity)
+                        )
                     if key == "leak.meanFlow":
-                        entities.append(LKCubicSensor(coordinator, description))
+                        cubic_entities.append(
+                            LKCubicSensor(coordinator, description, device_identity)
+                        )
                     if key == "leak.dateStartedAt":
-                        entities.append(LKCubicSensor(coordinator, description))
+                        cubic_entities.append(
+                            LKCubicSensor(coordinator, description, device_identity)
+                        )
                     if key == "leak.dateUpdatedAt":
-                        entities.append(LKCubicSensor(coordinator, description))
+                        cubic_entities.append(
+                            LKCubicSensor(coordinator, description, device_identity)
+                        )
                     if key == "leak.acknowledged":
-                        entities.append(LKCubicSensor(coordinator, description))
+                        cubic_entities.append(
+                            LKCubicSensor(coordinator, description, device_identity)
+                        )
 
                 for key, description in LK_CUBICSECURE_CONFIG_SENSORS.items():
                     if key == "valveState":
-                        entities.append(
+                        cubic_entities.append(
                             LKCubicSensor(
-                                coordinator, description, data_source="configuration"
+                                coordinator,
+                                description,
+                                device_identity,
+                                data_source="configuration",
                             )
                         )
                     if key == "firmwareVersion":
-                        entities.append(
+                        cubic_entities.append(
                             LKCubicSensor(
-                                coordinator, description, data_source="configuration"
+                                coordinator,
+                                description,
+                                device_identity,
+                                data_source="configuration",
                             )
                         )
                     if key == "hardwareVersion":
-                        entities.append(
+                        cubic_entities.append(
                             LKCubicSensor(
-                                coordinator, description, data_source="configuration"
+                                coordinator,
+                                description,
+                                device_identity,
+                                data_source="configuration",
                             )
                         )
 
-                async_add_entities(entities, True)
+                async_add_entities(cubic_entities, True)
 
             # Collect all hubs
             if device_title.get("deviceType") == "arc-hub":
@@ -855,19 +895,21 @@ class AbstractLkCubicSensor(CoordinatorEntity[LKSystemCoordinator], SensorEntity
         self,
         coordinator: LKSystemCoordinator,
         description: SensorEntityDescription,
+        device_identity: str,
     ) -> None:
         """Initialize the sensor."""
         _LOGGER.debug("Creating %s sensor", description.name)
         super().__init__(coordinator)
         self._coordinator = coordinator
         self._device_model = CUBIC_SECURE_MODEL
-        self._device_name = (
-            f"Cubic Secure {coordinator.data['cubic_machine_info']['zone']['zoneName']}"
-        )
-        self._id = coordinator.data["cubic_machine_info"]["identity"]
+        self._id = device_identity
+        machine_info = coordinator.data["cubic_devices"][device_identity][
+            "machine_info"
+        ]
+        self._device_name = f"Cubic Secure {machine_info['zone']['zoneName']}"
         self.entity_description = description
         self.native_unit_of_measurement = description.native_unit_of_measurement
-        self._attr_unique_id = f"LkUid_{description.key}_{coordinator.data['cubic_machine_info']['identity']}"
+        self._attr_unique_id = f"LkUid_{description.key}_{device_identity}"
         self._attr_extra_state_attributes = {}
 
     @property
@@ -890,14 +932,17 @@ class LKCubicSensor(AbstractLkCubicSensor):
         self,
         coordinator: LKSystemCoordinator,
         description: SensorEntityDescription,
+        device_identity: str,
         data_source: str = "measurement",
     ) -> None:
         """Initialize the sensor."""
-        super().__init__(coordinator=coordinator, description=description)
+        super().__init__(
+            coordinator=coordinator,
+            description=description,
+            device_identity=device_identity,
+        )
         self._data_source = data_source
         self._data_key = description.key
-        self._attr_unique_id = f"LkUid_{description.key}_{coordinator.data['cubic_machine_info']['identity']}"
-        # self.native_unit_of_measurement = description.native_unit_of_measurement
         self._attr_extra_state_attributes = {}
 
         if "update_time" in self._coordinator.data:
@@ -931,9 +976,12 @@ class LKCubicSensor(AbstractLkCubicSensor):
     def native_value(self) -> Any | None:
         """Get the latest state value."""
         value = None
+        device_data = self._coordinator.data.get("cubic_devices", {}).get(
+            self._id, {}
+        )
 
         if self._data_source == "configuration":
-            cubic_configuration = self._coordinator.data.get("cubic_configuration") or {}
+            cubic_configuration = device_data.get("configuration") or {}
             if self._data_key in cubic_configuration:
                 value = cubic_configuration[self._data_key]
             elif "." in self._data_key:
@@ -944,9 +992,7 @@ class LKCubicSensor(AbstractLkCubicSensor):
                     if value is None:
                         break
         elif self._data_source == "measurement":
-            cubic_last_measurement = (
-                self._coordinator.data.get("cubic_last_measurement") or {}
-            )
+            cubic_last_measurement = device_data.get("last_measurement") or {}
             _LOGGER.debug("Getting measurement for key: %s", self._data_key)
             _LOGGER.debug(cubic_last_measurement)
             if self._data_key in cubic_last_measurement:

--- a/tests_ha/conftest.py
+++ b/tests_ha/conftest.py
@@ -266,9 +266,8 @@ def build_user_structure() -> dict:
 
 def build_user_structure_with_two_cubic_devices() -> dict:
     """Same as build_user_structure(), but with a second Cubic Secure
-    machine registered under the same property - reproducing the account
-    layout from issue #29 (two Cubic Secure devices, e.g. "Kitchen" and
-    "Garage", registered under one realestate).
+    machine registered under the same property - two Cubic Secure devices
+    (e.g. "Kitchen" and "Garage") registered under one realestate.
     """
     structure = build_user_structure()
     structure["realestateMachines"].append(
@@ -398,7 +397,7 @@ def fake_manager() -> FakeLKSystemsManager:
 @pytest.fixture
 def fake_manager_with_two_cubic_devices() -> FakeLKSystemsManager:
     """A FakeLKSystemsManager pre-populated with two Cubic Secure devices
-    registered under the same property (issue #29).
+    registered under the same property.
     """
     manager = FakeLKSystemsManager()
     configure_fake_manager_with_two_cubic_devices(manager)

--- a/tests_ha/conftest.py
+++ b/tests_ha/conftest.py
@@ -89,6 +89,12 @@ class FakeLKSystemsManager:
         self.hub_devices_by_hub: dict[str, dict] = {}
         self.cubic_measurement_data: dict | None = None
         self.cubic_configuration_data: dict | None = None
+        # Per-cubic-device overrides, keyed by device identity - takes
+        # precedence over the single cubic_measurement_data/
+        # cubic_configuration_data above when set for that identity, so
+        # single-device tests can keep using the simpler singular fields.
+        self.cubic_measurements_by_device: dict[str, dict] = {}
+        self.cubic_configurations_by_device: dict[str, dict] = {}
 
         # Configurable outcomes for each call, so tests can force failures.
         self.login_result = True
@@ -154,7 +160,9 @@ class FakeLKSystemsManager:
             ("get_cubic_secure_measurement", device_identity, force_update)
         )
         if self.get_cubic_secure_measurement_result:
-            self.cubic_secure_messurement = self.cubic_measurement_data
+            self.cubic_secure_messurement = self.cubic_measurements_by_device.get(
+                device_identity, self.cubic_measurement_data
+            )
         return self.get_cubic_secure_measurement_result
 
     async def get_cubic_secure_configuration(
@@ -164,7 +172,9 @@ class FakeLKSystemsManager:
             ("get_cubic_secure_configuration", device_identity, force_update)
         )
         if self.get_cubic_secure_configuration_result:
-            self.cubic_secure_configuration = self.cubic_configuration_data
+            self.cubic_secure_configuration = self.cubic_configurations_by_device.get(
+                device_identity, self.cubic_configuration_data
+            )
         return self.get_cubic_secure_configuration_result
 
     async def set_thermostat_temperature(self, device_id, temperature):
@@ -196,6 +206,7 @@ class FakeLKSystemsManager:
 # --- Sample device identities used across tests ---------------------------
 
 CUBIC_IDENTITY = "cubic-secure-1"
+CUBIC_IDENTITY_2 = "cubic-secure-2"
 THERMOSTAT_MAC = "AA:BB:CC:DD:EE:01"
 SENSOR_MAC = "AA:BB:CC:DD:EE:02"
 HUB_IDENTITY = "arc-hub-1"
@@ -253,6 +264,25 @@ def build_user_structure() -> dict:
     }
 
 
+def build_user_structure_with_two_cubic_devices() -> dict:
+    """Same as build_user_structure(), but with a second Cubic Secure
+    machine registered under the same property - reproducing the account
+    layout from issue #29 (two Cubic Secure devices, e.g. "Kitchen" and
+    "Garage", registered under one realestate).
+    """
+    structure = build_user_structure()
+    structure["realestateMachines"].append(
+        {
+            "identity": CUBIC_IDENTITY_2,
+            "deviceGroup": "cubic",
+            "deviceType": "cubicsecure",
+            "deviceRole": "cubicsecure",
+            "zone": {"zoneId": "zone-cubic-2", "zoneName": "Garage"},
+        }
+    )
+    return structure
+
+
 def build_measurements_by_device() -> dict:
     return {
         THERMOSTAT_MAC: {
@@ -300,11 +330,11 @@ def build_hub_devices_by_hub() -> dict:
     }
 
 
-def build_cubic_measurement() -> dict:
+def build_cubic_measurement(volume_total: int = 45000) -> dict:
     return {
         "cacheUpdated": int(time.time()),
         "volumeTotalDay": 120,
-        "volumeTotal": 45000,
+        "volumeTotal": volume_total,
         "tempWaterAverage": 185,
         "tempWaterMin": 170,
         "tempWaterMax": 210,
@@ -321,10 +351,10 @@ def build_cubic_measurement() -> dict:
     }
 
 
-def build_cubic_configuration() -> dict:
+def build_cubic_configuration(valve_state: str = "open") -> dict:
     return {
         "cacheUpdated": int(time.time()),
-        "valveState": "open",
+        "valveState": valve_state,
         "firmwareVersion": "1.2.3",
         "hardwareVersion": 4,
     }
@@ -339,9 +369,37 @@ def configure_fake_manager_with_sample_data(manager: FakeLKSystemsManager) -> No
     manager.cubic_configuration_data = build_cubic_configuration()
 
 
+def configure_fake_manager_with_two_cubic_devices(manager: FakeLKSystemsManager) -> None:
+    """Populate a FakeLKSystemsManager with two Cubic Secure devices, each
+    with distinct measurement/configuration data so tests can tell them
+    apart (see build_user_structure_with_two_cubic_devices()).
+    """
+    manager.user_structure = build_user_structure_with_two_cubic_devices()
+    manager.measurements_by_device = build_measurements_by_device()
+    manager.hub_devices_by_hub = build_hub_devices_by_hub()
+    manager.cubic_measurements_by_device = {
+        CUBIC_IDENTITY: build_cubic_measurement(volume_total=45000),
+        CUBIC_IDENTITY_2: build_cubic_measurement(volume_total=99000),
+    }
+    manager.cubic_configurations_by_device = {
+        CUBIC_IDENTITY: build_cubic_configuration(valve_state="open"),
+        CUBIC_IDENTITY_2: build_cubic_configuration(valve_state="closed"),
+    }
+
+
 @pytest.fixture
 def fake_manager() -> FakeLKSystemsManager:
     """A FakeLKSystemsManager pre-populated with a realistic structure."""
     manager = FakeLKSystemsManager()
     configure_fake_manager_with_sample_data(manager)
+    return manager
+
+
+@pytest.fixture
+def fake_manager_with_two_cubic_devices() -> FakeLKSystemsManager:
+    """A FakeLKSystemsManager pre-populated with two Cubic Secure devices
+    registered under the same property (issue #29).
+    """
+    manager = FakeLKSystemsManager()
+    configure_fake_manager_with_two_cubic_devices(manager)
     return manager

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -33,6 +33,7 @@ from custom_components.lksystems.const import (
 
 from .conftest import (
     CUBIC_IDENTITY,
+    CUBIC_IDENTITY_2,
     HUB_CHILD_MAC,
     HUB_IDENTITY,
     SENSOR_MAC,
@@ -146,9 +147,10 @@ class TestAsyncUpdateData:
         assert data["realestateId"] == "realestate-1"
 
         # Cubic Secure device
-        assert data["cubic_machine_info"]["identity"] == CUBIC_IDENTITY
-        assert data["cubic_last_measurement"]["volumeTotal"] == 45000
-        assert data["cubic_configuration"]["valveState"] == "open"
+        cubic_device = data["cubic_devices"][CUBIC_IDENTITY]
+        assert cubic_device["machine_info"]["identity"] == CUBIC_IDENTITY
+        assert cubic_device["last_measurement"]["volumeTotal"] == 45000
+        assert cubic_device["configuration"]["valveState"] == "open"
 
         # Standalone Arc devices (thermostat + plain sensor)
         macs = {d.get("mac") for d in data["devices"]}
@@ -216,9 +218,10 @@ class TestCubicFetchFailureFallback:
         with _patch_manager(fake_manager):
             data = await coordinator._async_update_data()
 
-        assert "cubic_last_measurement" in data
-        assert "cubic_configuration" in data
-        assert data["cubic_configuration"] is None
+        cubic_device = data["cubic_devices"][CUBIC_IDENTITY]
+        assert "last_measurement" in cubic_device
+        assert "configuration" in cubic_device
+        assert cubic_device["configuration"] is None
 
     async def test_configuration_fetch_failure_falls_back_to_previous_data(
         self, hass, fake_manager
@@ -236,7 +239,56 @@ class TestCubicFetchFailureFallback:
         with _patch_manager(fake_manager):
             data = await coordinator._async_update_data()
 
-        assert data["cubic_configuration"] == good_data["cubic_configuration"]
+        assert (
+            data["cubic_devices"][CUBIC_IDENTITY]["configuration"]
+            == good_data["cubic_devices"][CUBIC_IDENTITY]["configuration"]
+        )
+
+
+class TestMultipleCubicSecureDevices:
+    """Regression coverage for issue #29: two Cubic Secure devices
+    registered under the same property used to stomp on each other, since
+    the coordinator kept a single unkeyed slot for machine_info/
+    last_measurement/configuration instead of one per device identity.
+    """
+
+    async def test_both_devices_keep_their_own_machine_info(
+        self, hass, fake_manager_with_two_cubic_devices
+    ):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager_with_two_cubic_devices):
+            data = await coordinator._async_update_data()
+
+        assert set(data["cubic_devices"]) == {CUBIC_IDENTITY, CUBIC_IDENTITY_2}
+        assert (
+            data["cubic_devices"][CUBIC_IDENTITY]["machine_info"]["zone"]["zoneName"]
+            == "Utility Room"
+        )
+        assert (
+            data["cubic_devices"][CUBIC_IDENTITY_2]["machine_info"]["zone"][
+                "zoneName"
+            ]
+            == "Garage"
+        )
+
+    async def test_both_devices_keep_their_own_measurement_and_configuration(
+        self, hass, fake_manager_with_two_cubic_devices
+    ):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager_with_two_cubic_devices):
+            data = await coordinator._async_update_data()
+
+        first = data["cubic_devices"][CUBIC_IDENTITY]
+        second = data["cubic_devices"][CUBIC_IDENTITY_2]
+
+        assert first["last_measurement"]["volumeTotal"] == 45000
+        assert second["last_measurement"]["volumeTotal"] == 99000
+        assert first["configuration"]["valveState"] == "open"
+        assert second["configuration"]["valveState"] == "closed"
 
 
 class TestForceDeviceUpdate:

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -246,10 +246,10 @@ class TestCubicFetchFailureFallback:
 
 
 class TestMultipleCubicSecureDevices:
-    """Regression coverage for issue #29: two Cubic Secure devices
-    registered under the same property used to stomp on each other, since
-    the coordinator kept a single unkeyed slot for machine_info/
-    last_measurement/configuration instead of one per device identity.
+    """Two Cubic Secure devices registered under the same property used to
+    stomp on each other, since the coordinator kept a single unkeyed slot
+    for machine_info/last_measurement/configuration instead of one per
+    device identity.
     """
 
     async def test_both_devices_keep_their_own_machine_info(

--- a/tests_ha/test_integration_setup.py
+++ b/tests_ha/test_integration_setup.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, patch
 
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
@@ -20,6 +21,7 @@ from custom_components.lksystems.const import DOMAIN
 
 from .conftest import (
     CUBIC_IDENTITY,
+    CUBIC_IDENTITY_2,
     HUB_CHILD_MAC,
     HUB_IDENTITY,
     SENSOR_MAC,
@@ -119,6 +121,39 @@ async def test_cubic_sensors_survive_a_configuration_fetch_failure(
 
     valve_id = _entity_id(hass, "sensor", f"LkUid_valveState_{CUBIC_IDENTITY}")
     assert hass.states.get(valve_id) is not None
+
+
+async def test_two_cubic_secure_devices_get_independent_entities(
+    hass, fake_manager_with_two_cubic_devices
+):
+    """Regression test for issue #29: two Cubic Secure devices registered
+    under the same property used to collapse into one, because both
+    the coordinator and the sensor entities kept a single unkeyed slot
+    instead of one per device identity - the second device's entities got
+    the first device's data (or a duplicate unique_id HA silently dropped),
+    while the first device's own entities went stale.
+    """
+    await _setup_entry(hass, fake_manager_with_two_cubic_devices)
+
+    volume_id_1 = _entity_id(hass, "sensor", f"LkUid_volumeTotal_{CUBIC_IDENTITY}")
+    valve_id_1 = _entity_id(hass, "sensor", f"LkUid_valveState_{CUBIC_IDENTITY}")
+    volume_id_2 = _entity_id(hass, "sensor", f"LkUid_volumeTotal_{CUBIC_IDENTITY_2}")
+    valve_id_2 = _entity_id(hass, "sensor", f"LkUid_valveState_{CUBIC_IDENTITY_2}")
+
+    assert hass.states.get(volume_id_1).state == "45000"
+    assert hass.states.get(valve_id_1).state == "open"
+    assert hass.states.get(volume_id_2).state == "99000"
+    assert hass.states.get(valve_id_2).state == "closed"
+
+    device_registry = dr.async_get(hass)
+    device_1 = device_registry.async_get_device(identifiers={(DOMAIN, CUBIC_IDENTITY)})
+    device_2 = device_registry.async_get_device(
+        identifiers={(DOMAIN, CUBIC_IDENTITY_2)}
+    )
+    assert device_1 is not None
+    assert device_2 is not None
+    assert device_1.id != device_2.id
+    assert device_2.name == "Cubic Secure Garage"
 
 
 async def test_set_temperature_service_calls_coordinator(hass, fake_manager):

--- a/tests_ha/test_integration_setup.py
+++ b/tests_ha/test_integration_setup.py
@@ -126,12 +126,12 @@ async def test_cubic_sensors_survive_a_configuration_fetch_failure(
 async def test_two_cubic_secure_devices_get_independent_entities(
     hass, fake_manager_with_two_cubic_devices
 ):
-    """Regression test for issue #29: two Cubic Secure devices registered
-    under the same property used to collapse into one, because both
-    the coordinator and the sensor entities kept a single unkeyed slot
-    instead of one per device identity - the second device's entities got
-    the first device's data (or a duplicate unique_id HA silently dropped),
-    while the first device's own entities went stale.
+    """Two Cubic Secure devices registered under the same property used to
+    collapse into one, because both the coordinator and the sensor
+    entities kept a single unkeyed slot instead of one per device identity
+    - the second device's entities got the first device's data (or a
+    duplicate unique_id HA silently dropped), while the first device's own
+    entities went stale.
     """
     await _setup_entry(hass, fake_manager_with_two_cubic_devices)
 


### PR DESCRIPTION
Fixes angoyd/ha-lksystems#29.

## Root cause

Confirmed from the reporter's account diagnostics: two `cubicsecure`
machines are registered under a single `realestate`. The coordinator
(`_async_update_data`) and `sensor.py`'s `AbstractLkCubicSensor`/
`LKCubicSensor` treated Cubic Secure data as a singleton
(`resp["cubic_machine_info"]`, `self._cubic_identity`,
`resp["cubic_last_measurement"]`, `resp["cubic_configuration"]`)
instead of keying it by device identity the way Arc devices already
are (`device_details`). Each iteration of the device loop overwrote
the previous device's slot, and `sensor.py` built two batches of
entities that both computed the same `unique_id` from that single
overwritten slot — Home Assistant silently rejected the second batch
as a duplicate, leaving the first device's entities stale while only
the second stayed live.

## Fix

Rekey both files around a new `resp["cubic_devices"][device_identity]`
dict (`machine_info`/`last_measurement`/`configuration` per device),
and thread `device_identity` through the sensor constructors so each
device's entities read their own slot and compute a unique `unique_id`.

## Testing

Built test-driven: extended `tests_ha/conftest.py`'s
`FakeLKSystemsManager` with per-device cubic measurement/configuration
data, added a two-device fixture reproducing the account layout from
the issue, and wrote coordinator + integration-setup tests that
reproduce the exact duplicate-`unique_id` symptom from the report
before the fix (confirmed RED against the pre-fix code), then confirmed
GREEN after. Full suite: 72/72 passing (`tests_ha/` + `tests/`).

Was previously stacked on #43 (fork-internal PR, since GitHub won't
take an unmerged fork branch as a base on the upstream repo) - now
that #43 has merged, this is opened directly against `main`.