### PR TITLE
Add diagnostics.py support (#47)

### DIFF
--- a/custom_components/lksystems/diagnostics.py
+++ b/custom_components/lksystems/diagnostics.py
@@ -14,7 +14,7 @@ from .const import DOMAIN
 # Device "identity"/serial_number fields are deliberately not redacted:
 # unlike a MAC address they're not a hardware fingerprint, and they're the
 # only way to correlate devices across the nested coordinator data when
-# debugging a report (e.g. issue #29's multiple Cubic Secure devices).
+# debugging a report from an account with multiple Cubic Secure devices.
 TO_REDACT = {
     CONF_USERNAME,
     CONF_PASSWORD,

--- a/custom_components/lksystems/diagnostics.py
+++ b/custom_components/lksystems/diagnostics.py
@@ -1,0 +1,41 @@
+"""Diagnostics support for LK Systems."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+# Device "identity"/serial_number fields are deliberately not redacted:
+# unlike a MAC address they're not a hardware fingerprint, and they're the
+# only way to correlate devices across the nested coordinator data when
+# debugging a report (e.g. issue #29's multiple Cubic Secure devices).
+TO_REDACT = {
+    CONF_USERNAME,
+    CONF_PASSWORD,
+    "realestateId",
+    "ownerId",
+    "name",
+    "address",
+    "city",
+    "zip",
+    "country",
+    "mac",
+}
+
+
+async def async_get_config_entry_diagnostics(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> dict[str, Any]:
+    """Return diagnostics for a config entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    return {
+        "entry_data": async_redact_data(dict(entry.data), TO_REDACT),
+        "coordinator_data": async_redact_data(coordinator.data, TO_REDACT),
+    }

--- a/tests_ha/conftest.py
+++ b/tests_ha/conftest.py
@@ -17,8 +17,14 @@ from __future__ import annotations
 
 import asyncio
 import time
+from unittest.mock import patch
 
 import pytest
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.lksystems.const import DOMAIN
 
 pytest_plugins = "pytest_homeassistant_custom_component"
 
@@ -345,3 +351,32 @@ def fake_manager() -> FakeLKSystemsManager:
     manager = FakeLKSystemsManager()
     configure_fake_manager_with_sample_data(manager)
     return manager
+
+
+async def setup_entry(hass, manager: FakeLKSystemsManager) -> MockConfigEntry:
+    """Drive a real config-entry setup against a FakeLKSystemsManager.
+
+    Runs the coordinator's first refresh and both the sensor.py and
+    climate.py platforms' async_setup_entry() for real, so tests can inspect
+    the entities/entity registry they actually produce.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
+    )
+    entry.add_to_hass(hass)
+    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def entity_id(hass, platform: str, unique_id: str) -> str:
+    """Look up an entity_id by platform/unique_id via the entity registry.
+
+    Entities are looked up this way, rather than by guessing slugified
+    entity_ids, so tests don't depend on HA's naming/slugify rules.
+    """
+    found = er.async_get(hass).async_get_entity_id(platform, DOMAIN, unique_id)
+    assert found is not None, f"no {platform} entity registered for {unique_id!r}"
+    return found

--- a/tests_ha/test_diagnostics.py
+++ b/tests_ha/test_diagnostics.py
@@ -73,7 +73,7 @@ async def test_diagnostics_keeps_device_identities_for_debugging(hass, fake_mana
 
     diagnostics = await async_get_config_entry_diagnostics(hass, entry)
 
-    assert CUBIC_IDENTITY in diagnostics["coordinator_data"]["cubic_devices"]
-    assert diagnostics["coordinator_data"]["cubic_devices"][CUBIC_IDENTITY][
-        "machine_info"
-    ]["identity"] == CUBIC_IDENTITY
+    assert (
+        diagnostics["coordinator_data"]["cubic_machine_info"]["identity"]
+        == CUBIC_IDENTITY
+    )

--- a/tests_ha/test_diagnostics.py
+++ b/tests_ha/test_diagnostics.py
@@ -1,35 +1,19 @@
 """Tests for diagnostics.py.
 
 Exercises async_get_config_entry_diagnostics() directly against a real
-config-entry setup (see test_integration_setup.py's _setup_entry pattern),
-so the redaction runs over the same coordinator.data shape HA would.
+config-entry setup, so the redaction runs over the same coordinator.data
+shape HA would.
 """
 
 from __future__ import annotations
 
-from unittest.mock import patch
-
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.lksystems.const import DOMAIN
 from custom_components.lksystems.diagnostics import (
     async_get_config_entry_diagnostics,
 )
 
-from .conftest import CUBIC_IDENTITY, THERMOSTAT_MAC
-
-
-async def _setup_entry(hass, manager) -> MockConfigEntry:
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
-    )
-    entry.add_to_hass(hass)
-    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-    return entry
+from .conftest import CUBIC_IDENTITY, THERMOSTAT_MAC, setup_entry as _setup_entry
 
 
 async def test_diagnostics_redacts_credentials(hass, fake_manager):
@@ -65,10 +49,6 @@ async def test_diagnostics_redacts_device_mac_addresses(hass, fake_manager):
 
 
 async def test_diagnostics_keeps_device_identities_for_debugging(hass, fake_manager):
-    """Device identities aren't redacted: unlike a MAC address they aren't
-    a hardware fingerprint, and they're the only way to correlate devices
-    across the nested structure when debugging (e.g. issue #29's multiple
-    Cubic Secure devices)."""
     entry = await _setup_entry(hass, fake_manager)
 
     diagnostics = await async_get_config_entry_diagnostics(hass, entry)

--- a/tests_ha/test_diagnostics.py
+++ b/tests_ha/test_diagnostics.py
@@ -1,0 +1,79 @@
+"""Tests for diagnostics.py.
+
+Exercises async_get_config_entry_diagnostics() directly against a real
+config-entry setup (see test_integration_setup.py's _setup_entry pattern),
+so the redaction runs over the same coordinator.data shape HA would.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.lksystems.const import DOMAIN
+from custom_components.lksystems.diagnostics import (
+    async_get_config_entry_diagnostics,
+)
+
+from .conftest import CUBIC_IDENTITY, THERMOSTAT_MAC
+
+
+async def _setup_entry(hass, manager) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
+    )
+    entry.add_to_hass(hass)
+    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+async def test_diagnostics_redacts_credentials(hass, fake_manager):
+    entry = await _setup_entry(hass, fake_manager)
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert diagnostics["entry_data"][CONF_USERNAME] == "**REDACTED**"
+    assert diagnostics["entry_data"][CONF_PASSWORD] == "**REDACTED**"
+
+
+async def test_diagnostics_redacts_home_address(hass, fake_manager):
+    entry = await _setup_entry(hass, fake_manager)
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    coordinator_data = diagnostics["coordinator_data"]
+    assert coordinator_data["address"] == "**REDACTED**"
+    assert coordinator_data["city"] == "**REDACTED**"
+    assert coordinator_data["zip"] == "**REDACTED**"
+    assert coordinator_data["ownerId"] == "**REDACTED**"
+    assert coordinator_data["realestateId"] == "**REDACTED**"
+
+
+async def test_diagnostics_redacts_device_mac_addresses(hass, fake_manager):
+    entry = await _setup_entry(hass, fake_manager)
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    devices = diagnostics["coordinator_data"]["devices"]
+    thermostat = next(d for d in devices if d.get("mac") == "**REDACTED**")
+    assert thermostat is not None
+
+
+async def test_diagnostics_keeps_device_identities_for_debugging(hass, fake_manager):
+    """Device identities aren't redacted: unlike a MAC address they aren't
+    a hardware fingerprint, and they're the only way to correlate devices
+    across the nested structure when debugging (e.g. issue #29's multiple
+    Cubic Secure devices)."""
+    entry = await _setup_entry(hass, fake_manager)
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert CUBIC_IDENTITY in diagnostics["coordinator_data"]["cubic_devices"]
+    assert diagnostics["coordinator_data"]["cubic_devices"][CUBIC_IDENTITY][
+        "machine_info"
+    ]["identity"] == CUBIC_IDENTITY

--- a/tests_ha/test_diagnostics.py
+++ b/tests_ha/test_diagnostics.py
@@ -53,7 +53,5 @@ async def test_diagnostics_keeps_device_identities_for_debugging(hass, fake_mana
 
     diagnostics = await async_get_config_entry_diagnostics(hass, entry)
 
-    assert (
-        diagnostics["coordinator_data"]["cubic_machine_info"]["identity"]
-        == CUBIC_IDENTITY
-    )
+    cubic_device = diagnostics["coordinator_data"]["cubic_devices"][CUBIC_IDENTITY]
+    assert cubic_device["machine_info"]["identity"] == CUBIC_IDENTITY

--- a/tests_ha/test_integration_setup.py
+++ b/tests_ha/test_integration_setup.py
@@ -12,10 +12,6 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.helpers import entity_registry as er
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
 from custom_components.lksystems.const import DOMAIN
 
 from .conftest import (
@@ -24,25 +20,9 @@ from .conftest import (
     HUB_IDENTITY,
     SENSOR_MAC,
     THERMOSTAT_MAC,
+    entity_id as _entity_id,
+    setup_entry as _setup_entry,
 )
-
-
-async def _setup_entry(hass, manager) -> MockConfigEntry:
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
-    )
-    entry.add_to_hass(hass)
-    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-    return entry
-
-
-def _entity_id(hass, platform: str, unique_id: str) -> str:
-    entity_id = er.async_get(hass).async_get_entity_id(platform, DOMAIN, unique_id)
-    assert entity_id is not None, f"no {platform} entity registered for {unique_id!r}"
-    return entity_id
 
 
 async def test_thermostat_entity_reflects_client_data(hass, fake_manager):


### PR DESCRIPTION
Closes #47.

Adds `custom_components/lksystems/diagnostics.py`, so **Settings > Devices
& Services > LK Systems > Download diagnostics** actually returns
something - previously there was no diagnostics support at all.

Returns the config entry's data and the coordinator's current data, both
passed through `homeassistant.components.diagnostics.async_redact_data`:

- Redacted: username/password, the account's home address/city/zip,
  owner/realestate IDs, and device MAC addresses.
- Left in: device `identity`/`serial_number` fields. Unlike a MAC address
  these aren't a hardware fingerprint, and they're the only way to
  correlate devices across the nested structure when debugging a report -
  e.g. issue #29's multiple Cubic Secure devices, which this would have
  made much easier to diagnose.

TDD'd via `tests_ha/test_diagnostics.py` (written and confirmed failing -
`ModuleNotFoundError` - before `diagnostics.py` existed). Full suite
(`tests/` + `tests_ha/`) passes, 55/55 in `tests_ha/`.