### PR TITLE
Add system_health.py support

### DIFF
--- a/custom_components/lksystems/pylksystems/__init__.py
+++ b/custom_components/lksystems/pylksystems/__init__.py
@@ -75,12 +75,14 @@ class LKThresholds(TypedDict):
 class LKSystemsManager:
     """LKSystems manager."""
 
+    BASE_URL = "https://link2.lk.nu/"
+
     def __init__(self, username, password) -> None:
         """Initialize the LK systems manager."""
         if username is None or password is None:
             raise ValueError("Username and password must be provided.")
         self.session = None
-        self.base_url = "https://link2.lk.nu/"
+        self.base_url = self.BASE_URL
         self.username = username
         self.password = password
         self.userid = None

--- a/custom_components/lksystems/pylksystems/__init__.py
+++ b/custom_components/lksystems/pylksystems/__init__.py
@@ -82,7 +82,6 @@ class LKSystemsManager:
         if username is None or password is None:
             raise ValueError("Username and password must be provided.")
         self.session = None
-        self.base_url = self.BASE_URL
         self.username = username
         self.password = password
         self.userid = None
@@ -112,7 +111,7 @@ class LKSystemsManager:
         """Handle ClientError and log relevant information."""
         _LOGGER.error(
             "An error occurred during the request. URL: %s, Headers: %s. Error: %s",
-            self.base_url + endpoint,
+            self.BASE_URL + endpoint,
             _redact_headers(headers),
             error,
         )
@@ -140,7 +139,7 @@ class LKSystemsManager:
             }
 
             async with self.session.get(
-                self.base_url + endpoint, headers=headers
+                self.BASE_URL + endpoint, headers=headers
             ) as response:
                 response.raise_for_status()
                 if response.status == 200:
@@ -150,7 +149,7 @@ class LKSystemsManager:
 
                 _LOGGER.error(
                     "Obtaining data from URL %s failed with status code %d",
-                    self.base_url + endpoint,
+                    self.BASE_URL + endpoint,
                     response.status,
                 )
                 return False, None
@@ -169,7 +168,7 @@ class LKSystemsManager:
             }
 
             async with self.session.post(
-                self.base_url + endpoint, json=payload, headers=headers
+                self.BASE_URL + endpoint, json=payload, headers=headers
             ) as response:
                 response.raise_for_status()
                 if response.status in [200, 201]:
@@ -179,7 +178,7 @@ class LKSystemsManager:
 
                 _LOGGER.error(
                     "Posting data to URL %s failed with status code %d",
-                    self.base_url + endpoint,
+                    self.BASE_URL + endpoint,
                     response.status,
                 )
                 return False, None
@@ -196,7 +195,7 @@ class LKSystemsManager:
             headers = {**self._get_headers()}
             # Define headers with the encoded credentials
             async with self.session.post(
-                self.base_url + endpoint, json=payload, headers=headers
+                self.BASE_URL + endpoint, json=payload, headers=headers
             ) as response:
                 data = await response.json()
                 if response.status == 200:
@@ -208,7 +207,7 @@ class LKSystemsManager:
                         "authorization": f"Bearer {self.jwt_token}",
                     }
                     async with self.session.get(
-                        self.base_url + endpointUserId, headers=headers
+                        self.BASE_URL + endpointUserId, headers=headers
                     ) as responseUserid:
                         responseUserid.raise_for_status()
                         if responseUserid.status == 200:
@@ -218,7 +217,7 @@ class LKSystemsManager:
 
                         _LOGGER.error(
                             "Obtaining data from URL %s failed with status code %d",
-                            self.base_url + endpoint,
+                            self.BASE_URL + endpoint,
                             responseUserid.status,
                         )
                         return False
@@ -376,7 +375,7 @@ class LKSystemsManager:
 
             _LOGGER.debug("Fetching detailed device information from API")
             async with self.session.get(
-                self.base_url + endpoint, headers=headers
+                self.BASE_URL + endpoint, headers=headers
             ) as response:
                 response.raise_for_status()
                 if response.status == 200:
@@ -472,7 +471,7 @@ class LKSystemsManager:
 
                 _LOGGER.error(
                     "Obtaining devices data from URL %s failed with status code %d",
-                    self.base_url + endpoint,
+                    self.BASE_URL + endpoint,
                     response.status,
                 )
                 # Even if API call fails, return True if we have devices from structure
@@ -513,7 +512,7 @@ class LKSystemsManager:
             }
 
             async with self.session.get(
-                self.base_url + endpoint, headers=headers
+                self.BASE_URL + endpoint, headers=headers
             ) as response:
                 response.raise_for_status()
                 if response.status == 200:
@@ -523,7 +522,7 @@ class LKSystemsManager:
 
                 _LOGGER.error(
                     "Obtaining hub devices from URL %s failed with status code %d",
-                    self.base_url + endpoint,
+                    self.BASE_URL + endpoint,
                     response.status,
                 )
                 return False
@@ -557,7 +556,7 @@ class LKSystemsManager:
             )
 
             async with self.session.get(
-                self.base_url + endpoint, headers=headers
+                self.BASE_URL + endpoint, headers=headers
             ) as response:
                 response.raise_for_status()
                 if response.status == 200:
@@ -572,7 +571,7 @@ class LKSystemsManager:
 
                 _LOGGER.error(
                     "Obtaining Arc Sense measurement from URL %s failed with status code %d",
-                    self.base_url + endpoint,
+                    self.BASE_URL + endpoint,
                     response.status,
                 )
                 return False
@@ -601,7 +600,7 @@ class LKSystemsManager:
             )
 
             async with self.session.get(
-                self.base_url + endpoint, headers=headers
+                self.BASE_URL + endpoint, headers=headers
             ) as response:
                 response.raise_for_status()
                 if response.status == 200:
@@ -616,7 +615,7 @@ class LKSystemsManager:
 
                 _LOGGER.error(
                     "Obtaining Arc Sense configuration from URL %s failed with status code %d",
-                    self.base_url + endpoint,
+                    self.BASE_URL + endpoint,
                     response.status,
                 )
                 return False
@@ -649,7 +648,7 @@ class LKSystemsManager:
             # _LOGGER.info("Fetching measurement data for device %s", device_identity)
 
             async with self.session.get(
-                self.base_url + endpoint, headers=headers
+                self.BASE_URL + endpoint, headers=headers
             ) as response:
                 response.raise_for_status()
                 if response.status == 200:
@@ -662,7 +661,7 @@ class LKSystemsManager:
 
                 _LOGGER.error(
                     "Obtaining device measurement from URL %s failed with status code %d",
-                    self.base_url + endpoint,
+                    self.BASE_URL + endpoint,
                     response.status,
                 )
                 return False
@@ -695,7 +694,7 @@ class LKSystemsManager:
             _LOGGER.debug("Fetching configuration data for device %s", device_identity)
 
             async with self.session.get(
-                self.base_url + endpoint, headers=headers
+                self.BASE_URL + endpoint, headers=headers
             ) as response:
                 response.raise_for_status()
                 if response.status == 200:
@@ -704,7 +703,7 @@ class LKSystemsManager:
 
                 _LOGGER.error(
                     "Obtaining device configuration from URL %s failed with status code %d",
-                    self.base_url + endpoint,
+                    self.BASE_URL + endpoint,
                     response.status,
                 )
                 return False
@@ -731,7 +730,7 @@ class LKSystemsManager:
             _LOGGER.debug("Fetching title data for device %s", device_identity)
 
             async with self.session.get(
-                self.base_url + endpoint, headers=headers
+                self.BASE_URL + endpoint, headers=headers
             ) as response:
                 response.raise_for_status()
                 if response.status == 200:
@@ -743,7 +742,7 @@ class LKSystemsManager:
 
                 _LOGGER.error(
                     "Obtaining device title from URL %s failed with status code %d",
-                    self.base_url + endpoint,
+                    self.BASE_URL + endpoint,
                     response.status,
                 )
                 return False
@@ -810,7 +809,7 @@ class LKSystemsManager:
                 )
 
                 async with self.session.post(
-                    self.base_url + endpoint, json=update_data, headers=headers
+                    self.BASE_URL + endpoint, json=update_data, headers=headers
                 ) as response:
                     response.raise_for_status()
                     if response.status == 200:

--- a/custom_components/lksystems/system_health.py
+++ b/custom_components/lksystems/system_health.py
@@ -21,6 +21,9 @@ def async_register(
 
 async def system_health_info(hass: HomeAssistant) -> dict[str, Any]:
     """Get info for the system health info page."""
+    # HA's system_health API registers one callback per domain, not per
+    # config entry - with more than one LK Systems account configured, only
+    # this first one's health is ever reported.
     coordinator = next(iter(hass.data[DOMAIN].values()))
 
     return {

--- a/custom_components/lksystems/system_health.py
+++ b/custom_components/lksystems/system_health.py
@@ -1,0 +1,32 @@
+"""Provide info to system health for the LK Systems integration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components import system_health
+from homeassistant.core import HomeAssistant, callback
+
+from .const import DOMAIN
+from .pylksystems import LKSystemsManager
+
+
+@callback
+def async_register(
+    hass: HomeAssistant, register: system_health.SystemHealthRegistration
+) -> None:
+    """Register system health callbacks."""
+    register.async_register_info(system_health_info)
+
+
+async def system_health_info(hass: HomeAssistant) -> dict[str, Any]:
+    """Get info for the system health info page."""
+    coordinator = next(iter(hass.data[DOMAIN].values()))
+
+    return {
+        "can_reach_server": await system_health.async_check_can_reach_url(
+            hass, LKSystemsManager.BASE_URL
+        ),
+        "last_update_success": coordinator.last_update_success,
+        "update_interval": str(coordinator.update_interval),
+    }

--- a/tests_ha/conftest.py
+++ b/tests_ha/conftest.py
@@ -17,8 +17,14 @@ from __future__ import annotations
 
 import asyncio
 import time
+from unittest.mock import patch
 
 import pytest
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.lksystems.const import DOMAIN
 
 pytest_plugins = "pytest_homeassistant_custom_component"
 
@@ -345,3 +351,35 @@ def fake_manager() -> FakeLKSystemsManager:
     manager = FakeLKSystemsManager()
     configure_fake_manager_with_sample_data(manager)
     return manager
+
+
+async def setup_entry(
+    hass, manager: FakeLKSystemsManager, options: dict | None = None
+) -> MockConfigEntry:
+    """Drive a real config-entry setup against a FakeLKSystemsManager.
+
+    Runs the coordinator's first refresh and both the sensor.py and
+    climate.py platforms' async_setup_entry() for real, so tests can inspect
+    the entities/entity registry they actually produce.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
+        options=options or {},
+    )
+    entry.add_to_hass(hass)
+    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def entity_id(hass, platform: str, unique_id: str) -> str:
+    """Look up an entity_id by platform/unique_id via the entity registry.
+
+    Entities are looked up this way, rather than by guessing slugified
+    entity_ids, so tests don't depend on HA's naming/slugify rules.
+    """
+    found = er.async_get(hass).async_get_entity_id(platform, DOMAIN, unique_id)
+    assert found is not None, f"no {platform} entity registered for {unique_id!r}"
+    return found

--- a/tests_ha/test_integration_setup.py
+++ b/tests_ha/test_integration_setup.py
@@ -12,10 +12,6 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.helpers import entity_registry as er
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
 from custom_components.lksystems.const import DOMAIN
 
 from .conftest import (
@@ -24,25 +20,9 @@ from .conftest import (
     HUB_IDENTITY,
     SENSOR_MAC,
     THERMOSTAT_MAC,
+    entity_id as _entity_id,
+    setup_entry as _setup_entry,
 )
-
-
-async def _setup_entry(hass, manager) -> MockConfigEntry:
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
-    )
-    entry.add_to_hass(hass)
-    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-    return entry
-
-
-def _entity_id(hass, platform: str, unique_id: str) -> str:
-    entity_id = er.async_get(hass).async_get_entity_id(platform, DOMAIN, unique_id)
-    assert entity_id is not None, f"no {platform} entity registered for {unique_id!r}"
-    return entity_id
 
 
 async def test_thermostat_entity_reflects_client_data(hass, fake_manager):

--- a/tests_ha/test_system_health.py
+++ b/tests_ha/test_system_health.py
@@ -1,0 +1,96 @@
+"""Tests for system_health.py.
+
+Exercises system_health_info() directly against a real config-entry setup
+(see test_integration_setup.py's _setup_entry pattern), and async_register()
+against a fake SystemHealthRegistration to check it wires up the callback.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import aiohttp
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.lksystems.const import CONF_UPDATE_INTERVAL, DOMAIN
+from custom_components.lksystems.pylksystems import LKSystemsManager
+from custom_components.lksystems.system_health import (
+    async_register,
+    system_health_info,
+)
+
+
+async def _setup_entry(hass, manager, options: dict | None = None) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
+        options=options or {},
+    )
+    entry.add_to_hass(hass)
+    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+async def test_system_health_reports_last_update_success(hass, fake_manager, aioclient_mock):
+    aioclient_mock.get(LKSystemsManager.BASE_URL)
+    await _setup_entry(hass, fake_manager)
+
+    info = await system_health_info(hass)
+
+    assert info["last_update_success"] is True
+
+
+async def test_system_health_reports_update_interval(hass, fake_manager, aioclient_mock):
+    aioclient_mock.get(LKSystemsManager.BASE_URL)
+    await _setup_entry(hass, fake_manager, options={CONF_UPDATE_INTERVAL: 15})
+
+    info = await system_health_info(hass)
+
+    assert info["update_interval"] == "0:15:00"
+
+
+async def test_system_health_reports_last_update_failure(hass, fake_manager, aioclient_mock):
+    aioclient_mock.get(LKSystemsManager.BASE_URL)
+    entry = await _setup_entry(hass, fake_manager)
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    fake_manager.get_user_structure_result = False
+    await coordinator.async_refresh()
+
+    info = await system_health_info(hass)
+
+    assert info["last_update_success"] is False
+
+
+async def test_system_health_reports_reachable_server(hass, fake_manager, aioclient_mock):
+    aioclient_mock.get(LKSystemsManager.BASE_URL)
+    await _setup_entry(hass, fake_manager)
+
+    info = await system_health_info(hass)
+
+    assert info["can_reach_server"] == "ok"
+
+
+async def test_system_health_reports_unreachable_server(hass, fake_manager, aioclient_mock):
+    aioclient_mock.get(LKSystemsManager.BASE_URL, exc=aiohttp.ClientError("boom"))
+    await _setup_entry(hass, fake_manager)
+
+    info = await system_health_info(hass)
+
+    assert info["can_reach_server"]["type"] == "failed"
+
+
+async def test_async_register_registers_info_callback():
+    registered = {}
+
+    class FakeRegistration:
+        def async_register_info(self, info_callback, info_url=None):
+            registered["callback"] = info_callback
+            registered["info_url"] = info_url
+
+    async_register(hass=None, register=FakeRegistration())
+
+    assert registered["callback"] is system_health_info

--- a/tests_ha/test_system_health.py
+++ b/tests_ha/test_system_health.py
@@ -1,17 +1,13 @@
 """Tests for system_health.py.
 
-Exercises system_health_info() directly against a real config-entry setup
-(see test_integration_setup.py's _setup_entry pattern), and async_register()
-against a fake SystemHealthRegistration to check it wires up the callback.
+Exercises system_health_info() directly against a real config-entry setup,
+and async_register() against a fake SystemHealthRegistration to check it
+wires up the callback.
 """
 
 from __future__ import annotations
 
-from unittest.mock import patch
-
 import aiohttp
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.lksystems.const import CONF_UPDATE_INTERVAL, DOMAIN
 from custom_components.lksystems.pylksystems import LKSystemsManager
@@ -20,18 +16,7 @@ from custom_components.lksystems.system_health import (
     system_health_info,
 )
 
-
-async def _setup_entry(hass, manager, options: dict | None = None) -> MockConfigEntry:
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
-        options=options or {},
-    )
-    entry.add_to_hass(hass)
-    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-    return entry
+from .conftest import setup_entry as _setup_entry
 
 
 async def test_system_health_reports_last_update_success(hass, fake_manager, aioclient_mock):
@@ -89,7 +74,6 @@ async def test_async_register_registers_info_callback():
     class FakeRegistration:
         def async_register_info(self, info_callback, info_url=None):
             registered["callback"] = info_callback
-            registered["info_url"] = info_url
 
     async_register(hass=None, register=FakeRegistration())
 


### PR DESCRIPTION
Closes #48.

Registers a `system_health` info callback so Settings → System → Repairs shows at-a-glance integration status instead of requiring a dig through logs:
- Whether the LK cloud API is currently reachable
- Whether the last coordinator update succeeded
- The update interval currently in effect

`LKSystemsManager.base_url` was only ever an instance attribute set from a literal in `__init__`, with no way to reference it without constructing a manager (which requires credentials). Hoisted it to a `BASE_URL` class constant so `system_health.py` (and its tests) can reference the same URL the client actually calls.

TDD'd via `tests_ha/test_system_health.py`, using the `aioclient_mock` fixture to mock the reachability check's real HTTP call rather than hitting the network. Full suite passes: 54/54 in `tests_ha/`, 25/25 in `tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)