### PR TITLE
Rename lastStatus sensor to Last Device Report

### DIFF
--- a/custom_components/lksystems/const.py
+++ b/custom_components/lksystems/const.py
@@ -101,7 +101,7 @@ LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
     ),
     "lastStatus": SensorEntityDescription(
         key="lastStatus",
-        name="Last Status",
+        name="Last Data Sent",
         icon="mdi:information-outline",
         device_class=SensorDeviceClass.TIMESTAMP,
         unit_of_measurement=None,

--- a/custom_components/lksystems/const.py
+++ b/custom_components/lksystems/const.py
@@ -101,7 +101,7 @@ LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
     ),
     "lastStatus": SensorEntityDescription(
         key="lastStatus",
-        name="Last Data Sent",
+        name="Last Device Report",
         icon="mdi:information-outline",
         device_class=SensorDeviceClass.TIMESTAMP,
         unit_of_measurement=None,

--- a/tests_ha/conftest.py
+++ b/tests_ha/conftest.py
@@ -17,8 +17,14 @@ from __future__ import annotations
 
 import asyncio
 import time
+from unittest.mock import patch
 
 import pytest
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.lksystems.const import DOMAIN
 
 pytest_plugins = "pytest_homeassistant_custom_component"
 
@@ -345,3 +351,35 @@ def fake_manager() -> FakeLKSystemsManager:
     manager = FakeLKSystemsManager()
     configure_fake_manager_with_sample_data(manager)
     return manager
+
+
+async def setup_entry(
+    hass, manager: FakeLKSystemsManager, options: dict | None = None
+) -> MockConfigEntry:
+    """Drive a real config-entry setup against a FakeLKSystemsManager.
+
+    Runs the coordinator's first refresh and both the sensor.py and
+    climate.py platforms' async_setup_entry() for real, so tests can inspect
+    the entities/entity registry they actually produce.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
+        options=options or {},
+    )
+    entry.add_to_hass(hass)
+    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def entity_id(hass, platform: str, unique_id: str) -> str:
+    """Look up an entity_id by platform/unique_id via the entity registry.
+
+    Entities are looked up this way, rather than by guessing slugified
+    entity_ids, so tests don't depend on HA's naming/slugify rules.
+    """
+    found = er.async_get(hass).async_get_entity_id(platform, DOMAIN, unique_id)
+    assert found is not None, f"no {platform} entity registered for {unique_id!r}"
+    return found

--- a/tests_ha/test_integration_setup.py
+++ b/tests_ha/test_integration_setup.py
@@ -12,10 +12,6 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.helpers import entity_registry as er
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
 from custom_components.lksystems.const import DOMAIN
 
 from .conftest import (
@@ -24,25 +20,9 @@ from .conftest import (
     HUB_IDENTITY,
     SENSOR_MAC,
     THERMOSTAT_MAC,
+    entity_id as _entity_id,
+    setup_entry as _setup_entry,
 )
-
-
-async def _setup_entry(hass, manager) -> MockConfigEntry:
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
-    )
-    entry.add_to_hass(hass)
-    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-    return entry
-
-
-def _entity_id(hass, platform: str, unique_id: str) -> str:
-    entity_id = er.async_get(hass).async_get_entity_id(platform, DOMAIN, unique_id)
-    assert entity_id is not None, f"no {platform} entity registered for {unique_id!r}"
-    return entity_id
 
 
 async def test_thermostat_entity_reflects_client_data(hass, fake_manager):

--- a/tests_ha/test_sensor.py
+++ b/tests_ha/test_sensor.py
@@ -1,0 +1,49 @@
+"""Tests for sensor.py entity naming.
+
+Exercises entity names against a real config-entry setup (see
+test_integration_setup.py's _setup_entry pattern), looking entities up by
+their unique_id via the entity registry rather than guessing slugified
+entity_ids.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.lksystems.const import DOMAIN
+
+from .conftest import CUBIC_IDENTITY
+
+
+async def _setup_entry(hass, manager) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
+    )
+    entry.add_to_hass(hass)
+    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def _entity_id(hass, unique_id: str) -> str:
+    entity_id = er.async_get(hass).async_get_entity_id("sensor", DOMAIN, unique_id)
+    assert entity_id is not None, f"no sensor entity registered for {unique_id!r}"
+    return entity_id
+
+
+async def test_last_status_sensor_name_says_what_it_represents(hass, fake_manager):
+    """lastStatus is the device's last data transmission to LK's cloud
+    (confirmed against the LK app's own "Last data sent" wording - see
+    issue #55), not a generic "status" - the entity name should say so."""
+    await _setup_entry(hass, fake_manager)
+
+    entity_id = _entity_id(hass, f"LkUid_lastStatus_{CUBIC_IDENTITY}")
+    state = hass.states.get(entity_id)
+
+    assert state.attributes["friendly_name"] == "Cubic Secure Utility Room Last Data Sent"

--- a/tests_ha/test_sensor.py
+++ b/tests_ha/test_sensor.py
@@ -12,8 +12,8 @@ from .conftest import CUBIC_IDENTITY, entity_id as _entity_id, setup_entry as _s
 
 async def test_last_status_sensor_name_says_what_it_represents(hass, fake_manager):
     """lastStatus is the device's last data transmission to LK's cloud
-    (confirmed against the LK app's own "Last data sent" wording - see
-    issue #55), not a generic "status" - the entity name should say so."""
+    (confirmed against the LK app's own "Last data sent" wording), not a
+    generic "status" - the entity name should say so."""
     await _setup_entry(hass, fake_manager)
 
     entity_id = _entity_id(hass, "sensor", f"LkUid_lastStatus_{CUBIC_IDENTITY}")

--- a/tests_ha/test_sensor.py
+++ b/tests_ha/test_sensor.py
@@ -11,12 +11,12 @@ from .conftest import CUBIC_IDENTITY, entity_id as _entity_id, setup_entry as _s
 
 
 async def test_last_status_sensor_name_says_what_it_represents(hass, fake_manager):
-    """lastStatus is the device's last data transmission to LK's cloud
-    (confirmed against the LK app's own "Last data sent" wording), not a
-    generic "status" - the entity name should say so."""
+    """lastStatus is when the device itself last reported to LK's cloud,
+    not a generic "status" and not something the integration sends -
+    the entity name should say so without implying either of those."""
     await _setup_entry(hass, fake_manager)
 
     entity_id = _entity_id(hass, "sensor", f"LkUid_lastStatus_{CUBIC_IDENTITY}")
     state = hass.states.get(entity_id)
 
-    assert state.attributes["friendly_name"] == "Cubic Secure Utility Room Last Data Sent"
+    assert state.attributes["friendly_name"] == "Cubic Secure Utility Room Last Device Report"

--- a/tests_ha/test_sensor.py
+++ b/tests_ha/test_sensor.py
@@ -1,40 +1,13 @@
 """Tests for sensor.py entity naming.
 
-Exercises entity names against a real config-entry setup (see
-test_integration_setup.py's _setup_entry pattern), looking entities up by
-their unique_id via the entity registry rather than guessing slugified
-entity_ids.
+Exercises entity names against a real config-entry setup, looking entities
+up by their unique_id via the entity registry rather than guessing
+slugified entity_ids.
 """
 
 from __future__ import annotations
 
-from unittest.mock import patch
-
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.helpers import entity_registry as er
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
-from custom_components.lksystems.const import DOMAIN
-
-from .conftest import CUBIC_IDENTITY
-
-
-async def _setup_entry(hass, manager) -> MockConfigEntry:
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
-    )
-    entry.add_to_hass(hass)
-    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-    return entry
-
-
-def _entity_id(hass, unique_id: str) -> str:
-    entity_id = er.async_get(hass).async_get_entity_id("sensor", DOMAIN, unique_id)
-    assert entity_id is not None, f"no sensor entity registered for {unique_id!r}"
-    return entity_id
+from .conftest import CUBIC_IDENTITY, entity_id as _entity_id, setup_entry as _setup_entry
 
 
 async def test_last_status_sensor_name_says_what_it_represents(hass, fake_manager):
@@ -43,7 +16,7 @@ async def test_last_status_sensor_name_says_what_it_represents(hass, fake_manage
     issue #55), not a generic "status" - the entity name should say so."""
     await _setup_entry(hass, fake_manager)
 
-    entity_id = _entity_id(hass, f"LkUid_lastStatus_{CUBIC_IDENTITY}")
+    entity_id = _entity_id(hass, "sensor", f"LkUid_lastStatus_{CUBIC_IDENTITY}")
     state = hass.states.get(entity_id)
 
     assert state.attributes["friendly_name"] == "Cubic Secure Utility Room Last Data Sent"


### PR DESCRIPTION
Closes #55 (partially - see below).

"Last Status" didn't say what the sensor actually represents. Confirmed against the LK app (see comments on #55): the sensor's timestamp exactly matches the app's own "Last data sent" reading for the same device/moment, so it's the device's last data transmission to LK's cloud - not a generic status field.

Landed first as "Last Data Sent", then renamed again to "Last Device Report" after review: the integration itself doesn't send anything, it only relays what the device already sent to LK's cloud - "Last Data Sent" read as if the integration were the sender. "Last Device Report" names the actual source of the timestamp instead.

`cacheUpdated` (the sibling sensor raised in the same issue) is deliberately left alone here - its "LK server cache 'as of' time" meaning is inferred only from how this codebase's own staleness check uses it, not verified against anything LK shows a user directly the way `lastStatus` was, so it stays unconfirmed pending #33.

TDD'd via `tests_ha/test_sensor.py` (confirmed RED at each rename - asserted the old `friendly_name` before the corresponding `const.py` change). Full suite passes: 49/49 in `tests_ha/`, 25/25 in `tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)