### PR TITLE
Retry with backoff on LK API 429 responses

### DIFF
--- a/custom_components/lksystems/pylksystems/__init__.py
+++ b/custom_components/lksystems/pylksystems/__init__.py
@@ -39,7 +39,7 @@ REQUEST_TIMEOUT = ClientTimeout(total=20)
 RATE_LIMIT_STATUS = 429
 RATE_LIMIT_MAX_RETRIES = 3
 RATE_LIMIT_DEFAULT_BACKOFF = 5.0  # seconds, used when no Retry-After header
-RATE_LIMIT_MIN_BACKOFF = 1.0  # floor, in case Retry-After is 0 or tiny
+RATE_LIMIT_MIN_BACKOFF = 1.0  # seconds; see _rate_limit_backoff() for why
 
 
 def _rate_limit_backoff(response) -> float:

--- a/custom_components/lksystems/pylksystems/__init__.py
+++ b/custom_components/lksystems/pylksystems/__init__.py
@@ -216,8 +216,9 @@ class LKSystemsManager:
                         )
                         return False, None
 
-                # Outside the `async with` - the connection is released
-                # before waiting out the backoff, not held open for it.
+                # Deliberately kept outside the `async with` above - moving
+                # it back in would hold the connection open for the whole
+                # backoff instead of releasing it first.
                 await self._sleep_before_retry(endpoint, delay, attempt)
                 attempt += 1
 

--- a/custom_components/lksystems/pylksystems/__init__.py
+++ b/custom_components/lksystems/pylksystems/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 from datetime import datetime, timedelta
 import json
@@ -32,6 +33,27 @@ def _redact_headers(headers: dict) -> dict:
 # slow/unresponsive LK API call stall an entire coordinator update for up to
 # 5 minutes before it even fails - fail fast instead.
 REQUEST_TIMEOUT = ClientTimeout(total=20)
+
+# LK's cloud API rate-limiting (429) during a burst of activity is routine,
+# not a genuine error - retry with backoff rather than failing immediately.
+RATE_LIMIT_STATUS = 429
+RATE_LIMIT_MAX_RETRIES = 3
+RATE_LIMIT_DEFAULT_BACKOFF = 5.0  # seconds, used when no Retry-After header
+
+
+def _rate_limit_backoff(response) -> float:
+    """Return the delay to wait before retrying a 429 response.
+
+    Honors the Retry-After header (seconds) when LK's API provides one,
+    falling back to a default backoff otherwise.
+    """
+    retry_after = response.headers.get("Retry-After")
+    if retry_after is not None:
+        try:
+            return float(retry_after)
+        except ValueError:
+            pass
+    return RATE_LIMIT_DEFAULT_BACKOFF
 
 
 # Add the missing LKSystemsError class
@@ -108,6 +130,21 @@ class LKSystemsManager:
 
     async def handle_client_error(self, endpoint, headers, error):
         """Handle ClientError and log relevant information."""
+        if (
+            isinstance(error, ClientResponseError)
+            and error.status == RATE_LIMIT_STATUS
+        ):
+            # Routine, expected condition on LK's end, not a genuine error -
+            # log at warning rather than error. Callers going through
+            # _get()/_post() have already retried with backoff by the time
+            # this fires; other call sites that make their own raw request
+            # (e.g. set_device_temperature()) land here on the first 429.
+            _LOGGER.warning(
+                "Rate limited (429) by LK Systems API. URL: %s",
+                self.base_url + endpoint,
+            )
+            return False
+
         _LOGGER.error(
             "An error occurred during the request. URL: %s, Headers: %s. Error: %s",
             self.base_url + endpoint,
@@ -130,60 +167,98 @@ class LKSystemsManager:
     async def _get(self, endpoint):
         """Helper method to perform GET requests."""
         headers = {}
-        try:
-            # Define headers with the JwtToken
-            headers = {
-                **self._get_headers(),
-                "authorization": f"Bearer {self.jwt_token}",
-            }
+        attempt = 0
+        while True:
+            try:
+                # Define headers with the JwtToken
+                headers = {
+                    **self._get_headers(),
+                    "authorization": f"Bearer {self.jwt_token}",
+                }
 
-            async with self.session.get(
-                self.base_url + endpoint, headers=headers
-            ) as response:
-                response.raise_for_status()
-                if response.status == 200:
-                    res = await response.json()
+                async with self.session.get(
+                    self.base_url + endpoint, headers=headers
+                ) as response:
+                    if (
+                        response.status == RATE_LIMIT_STATUS
+                        and attempt < RATE_LIMIT_MAX_RETRIES
+                    ):
+                        delay = _rate_limit_backoff(response)
+                        _LOGGER.warning(
+                            "Rate limited (429) by LK Systems API, retrying %s in "
+                            "%.1fs (attempt %d/%d)",
+                            self.base_url + endpoint,
+                            delay,
+                            attempt + 1,
+                            RATE_LIMIT_MAX_RETRIES,
+                        )
+                        await asyncio.sleep(delay)
+                        attempt += 1
+                        continue
 
-                    return True, res
+                    response.raise_for_status()
+                    if response.status == 200:
+                        res = await response.json()
 
-                _LOGGER.error(
-                    "Obtaining data from URL %s failed with status code %d",
-                    self.base_url + endpoint,
-                    response.status,
-                )
-                return False, None
+                        return True, res
 
-        except (ClientResponseError, ClientError) as error:
-            return (await self.handle_client_error(endpoint, headers, error)), None
+                    _LOGGER.error(
+                        "Obtaining data from URL %s failed with status code %d",
+                        self.base_url + endpoint,
+                        response.status,
+                    )
+                    return False, None
+
+            except (ClientResponseError, ClientError) as error:
+                return (await self.handle_client_error(endpoint, headers, error)), None
 
     async def _post(self, endpoint, payload):
         """Helper method to perform POST requests."""
         headers = {}
-        try:
-            # Define headers with the JwtToken
-            headers = {
-                **self._get_headers(),
-                "authorization": f"Bearer {self.jwt_token}",
-            }
+        attempt = 0
+        while True:
+            try:
+                # Define headers with the JwtToken
+                headers = {
+                    **self._get_headers(),
+                    "authorization": f"Bearer {self.jwt_token}",
+                }
 
-            async with self.session.post(
-                self.base_url + endpoint, json=payload, headers=headers
-            ) as response:
-                response.raise_for_status()
-                if response.status in [200, 201]:
-                    res = await response.json(content_type=None)
+                async with self.session.post(
+                    self.base_url + endpoint, json=payload, headers=headers
+                ) as response:
+                    if (
+                        response.status == RATE_LIMIT_STATUS
+                        and attempt < RATE_LIMIT_MAX_RETRIES
+                    ):
+                        delay = _rate_limit_backoff(response)
+                        _LOGGER.warning(
+                            "Rate limited (429) by LK Systems API, retrying %s in "
+                            "%.1fs (attempt %d/%d)",
+                            self.base_url + endpoint,
+                            delay,
+                            attempt + 1,
+                            RATE_LIMIT_MAX_RETRIES,
+                        )
+                        await asyncio.sleep(delay)
+                        attempt += 1
+                        continue
 
-                    return True, res
+                    response.raise_for_status()
+                    if response.status in [200, 201]:
+                        res = await response.json(content_type=None)
 
-                _LOGGER.error(
-                    "Posting data to URL %s failed with status code %d",
-                    self.base_url + endpoint,
-                    response.status,
-                )
-                return False, None
+                        return True, res
 
-        except (ClientResponseError, ClientError) as error:
-            return (await self.handle_client_error(endpoint, headers, error)), None
+                    _LOGGER.error(
+                        "Posting data to URL %s failed with status code %d",
+                        self.base_url + endpoint,
+                        response.status,
+                    )
+                    return False, None
+
+            except (ClientResponseError, ClientError) as error:
+                return (await self.handle_client_error(endpoint, headers, error)), None
 
     async def login(self):
         """Login to LK systems and get userId"""

--- a/custom_components/lksystems/pylksystems/__init__.py
+++ b/custom_components/lksystems/pylksystems/__init__.py
@@ -39,21 +39,32 @@ REQUEST_TIMEOUT = ClientTimeout(total=20)
 RATE_LIMIT_STATUS = 429
 RATE_LIMIT_MAX_RETRIES = 3
 RATE_LIMIT_DEFAULT_BACKOFF = 5.0  # seconds, used when no Retry-After header
+RATE_LIMIT_MIN_BACKOFF = 1.0  # floor, in case Retry-After is 0 or tiny
 
 
 def _rate_limit_backoff(response) -> float:
     """Return the delay to wait before retrying a 429 response.
 
     Honors the Retry-After header (seconds) when LK's API provides one,
-    falling back to a default backoff otherwise.
+    falling back to a default backoff otherwise. Never returns less than
+    RATE_LIMIT_MIN_BACKOFF - a Retry-After of 0 would otherwise collapse
+    the retry into an immediate one, indistinguishable from not backing
+    off at all.
     """
     retry_after = response.headers.get("Retry-After")
     if retry_after is not None:
         try:
-            return float(retry_after)
+            return max(float(retry_after), RATE_LIMIT_MIN_BACKOFF)
         except ValueError:
             pass
     return RATE_LIMIT_DEFAULT_BACKOFF
+
+
+def _retry_delay_for_response(response, attempt: int) -> float | None:
+    """Return the backoff delay if response is a retryable 429, else None."""
+    if response.status == RATE_LIMIT_STATUS and attempt < RATE_LIMIT_MAX_RETRIES:
+        return _rate_limit_backoff(response)
+    return None
 
 
 # Add the missing LKSystemsError class
@@ -164,6 +175,17 @@ class LKSystemsManager:
             "ocp-apim-subscription-key": "d2d308826cd14e7d92660b28bc7d859c",
         }
 
+    async def _sleep_before_retry(self, endpoint: str, delay: float, attempt: int) -> None:
+        """Log and wait out a 429's backoff before the next retry attempt."""
+        _LOGGER.warning(
+            "Rate limited (429) by LK Systems API, retrying %s in %.1fs (attempt %d/%d)",
+            self.base_url + endpoint,
+            delay,
+            attempt + 1,
+            RATE_LIMIT_MAX_RETRIES,
+        )
+        await asyncio.sleep(delay)
+
     async def _get(self, endpoint):
         """Helper method to perform GET requests."""
         headers = {}
@@ -179,35 +201,25 @@ class LKSystemsManager:
                 async with self.session.get(
                     self.base_url + endpoint, headers=headers
                 ) as response:
-                    if (
-                        response.status == RATE_LIMIT_STATUS
-                        and attempt < RATE_LIMIT_MAX_RETRIES
-                    ):
-                        delay = _rate_limit_backoff(response)
-                        _LOGGER.warning(
-                            "Rate limited (429) by LK Systems API, retrying %s in "
-                            "%.1fs (attempt %d/%d)",
+                    delay = _retry_delay_for_response(response, attempt)
+                    if delay is None:
+                        response.raise_for_status()
+                        if response.status == 200:
+                            res = await response.json()
+
+                            return True, res
+
+                        _LOGGER.error(
+                            "Obtaining data from URL %s failed with status code %d",
                             self.base_url + endpoint,
-                            delay,
-                            attempt + 1,
-                            RATE_LIMIT_MAX_RETRIES,
+                            response.status,
                         )
-                        await asyncio.sleep(delay)
-                        attempt += 1
-                        continue
+                        return False, None
 
-                    response.raise_for_status()
-                    if response.status == 200:
-                        res = await response.json()
-
-                        return True, res
-
-                    _LOGGER.error(
-                        "Obtaining data from URL %s failed with status code %d",
-                        self.base_url + endpoint,
-                        response.status,
-                    )
-                    return False, None
+                # Outside the `async with` - the connection is released
+                # before waiting out the backoff, not held open for it.
+                await self._sleep_before_retry(endpoint, delay, attempt)
+                attempt += 1
 
             except (ClientResponseError, ClientError) as error:
                 return (await self.handle_client_error(endpoint, headers, error)), None
@@ -227,35 +239,23 @@ class LKSystemsManager:
                 async with self.session.post(
                     self.base_url + endpoint, json=payload, headers=headers
                 ) as response:
-                    if (
-                        response.status == RATE_LIMIT_STATUS
-                        and attempt < RATE_LIMIT_MAX_RETRIES
-                    ):
-                        delay = _rate_limit_backoff(response)
-                        _LOGGER.warning(
-                            "Rate limited (429) by LK Systems API, retrying %s in "
-                            "%.1fs (attempt %d/%d)",
+                    delay = _retry_delay_for_response(response, attempt)
+                    if delay is None:
+                        response.raise_for_status()
+                        if response.status in [200, 201]:
+                            res = await response.json(content_type=None)
+
+                            return True, res
+
+                        _LOGGER.error(
+                            "Posting data to URL %s failed with status code %d",
                             self.base_url + endpoint,
-                            delay,
-                            attempt + 1,
-                            RATE_LIMIT_MAX_RETRIES,
+                            response.status,
                         )
-                        await asyncio.sleep(delay)
-                        attempt += 1
-                        continue
+                        return False, None
 
-                    response.raise_for_status()
-                    if response.status in [200, 201]:
-                        res = await response.json(content_type=None)
-
-                        return True, res
-
-                    _LOGGER.error(
-                        "Posting data to URL %s failed with status code %d",
-                        self.base_url + endpoint,
-                        response.status,
-                    )
-                    return False, None
+                await self._sleep_before_retry(endpoint, delay, attempt)
+                attempt += 1
 
             except (ClientResponseError, ClientError) as error:
                 return (await self.handle_client_error(endpoint, headers, error)), None

--- a/tests/test_pylksystems.py
+++ b/tests/test_pylksystems.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import logging
 from unittest.mock import AsyncMock, patch
 
+import pytest
 from aiohttp import ClientConnectionError
 from aioresponses import aioresponses
 
@@ -376,83 +377,104 @@ class TestRateLimitBackoff:
     instead of failing immediately, and log at warning rather than error.
     """
 
-    async def test_429_is_retried_and_eventually_succeeds(self, manager):
+    @pytest.fixture(autouse=True)
+    def mock_sleep(self):
+        """Patch asyncio.sleep for every test in this class - none of them
+        should actually wait out a real backoff delay."""
+        with patch("asyncio.sleep", new=AsyncMock()) as mock:
+            yield mock
+
+    async def test_429_is_retried_and_eventually_succeeds(self, manager, mock_sleep):
         url = BASE_URL + "service/cubic/secure/cubic-1/measurement/0"
 
         with aioresponses() as m:
             m.get(url, status=429, headers={"Retry-After": "1"})
             m.get(url, payload={"flow": 0.0}, status=200)
-            with patch("asyncio.sleep", new=AsyncMock()):
-                async with manager:
-                    result = await manager.get_cubic_secure_measurement("cubic-1")
+            async with manager:
+                result = await manager.get_cubic_secure_measurement("cubic-1")
 
         assert result is True
         assert manager.cubic_secure_messurement == {"flow": 0.0}
 
-    async def test_429_honors_retry_after_header(self, manager):
+    async def test_429_honors_retry_after_header(self, manager, mock_sleep):
         url = BASE_URL + "service/cubic/secure/cubic-1/measurement/0"
 
         with aioresponses() as m:
             m.get(url, status=429, headers={"Retry-After": "7"})
             m.get(url, payload={"flow": 0.0}, status=200)
-            with patch("asyncio.sleep", new=AsyncMock()) as mock_sleep:
-                async with manager:
-                    await manager.get_cubic_secure_measurement("cubic-1")
+            async with manager:
+                await manager.get_cubic_secure_measurement("cubic-1")
 
         mock_sleep.assert_awaited_once_with(7.0)
 
-    async def test_429_without_retry_after_uses_a_default_backoff(self, manager):
+    async def test_429_without_retry_after_uses_a_default_backoff(
+        self, manager, mock_sleep
+    ):
         url = BASE_URL + "service/cubic/secure/cubic-1/measurement/0"
 
         with aioresponses() as m:
             m.get(url, status=429)
             m.get(url, payload={"flow": 0.0}, status=200)
-            with patch("asyncio.sleep", new=AsyncMock()) as mock_sleep:
-                async with manager:
-                    await manager.get_cubic_secure_measurement("cubic-1")
+            async with manager:
+                await manager.get_cubic_secure_measurement("cubic-1")
 
         mock_sleep.assert_awaited_once()
         assert mock_sleep.await_args.args[0] > 0
 
-    async def test_429_exhausting_retries_returns_false(self, manager):
+    async def test_429_with_a_zero_retry_after_still_backs_off(
+        self, manager, mock_sleep
+    ):
+        """A Retry-After of 0 (or anything below the floor) shouldn't
+        collapse the backoff to an immediate retry - that's indistinguishable
+        from not backing off at all, defeating the point of retrying."""
+        url = BASE_URL + "service/cubic/secure/cubic-1/measurement/0"
+
+        with aioresponses() as m:
+            m.get(url, status=429, headers={"Retry-After": "0"})
+            m.get(url, payload={"flow": 0.0}, status=200)
+            async with manager:
+                await manager.get_cubic_secure_measurement("cubic-1")
+
+        mock_sleep.assert_awaited_once()
+        assert mock_sleep.await_args.args[0] > 0
+
+    async def test_429_exhausting_retries_returns_false(self, manager, mock_sleep):
         manager.userid = "user-123"
         url = BASE_URL + "service/users/user/user-123/structure/1"
 
         with aioresponses() as m:
             m.get(url, status=429, repeat=True)
-            with patch("asyncio.sleep", new=AsyncMock()):
-                async with manager:
-                    result = await manager.get_user_structure()
+            async with manager:
+                result = await manager.get_user_structure()
 
         assert result is False
         assert manager.user_structure is None
 
-    async def test_429_exhausting_retries_logs_warning_not_error(self, manager, caplog):
+    async def test_429_exhausting_retries_logs_warning_not_error(
+        self, manager, mock_sleep, caplog
+    ):
         manager.userid = "user-123"
         url = BASE_URL + "service/users/user/user-123/structure/1"
 
         with aioresponses() as m:
             m.get(url, status=429, repeat=True)
-            with patch("asyncio.sleep", new=AsyncMock()):
-                with caplog.at_level(logging.WARNING):
-                    async with manager:
-                        await manager.get_user_structure()
+            with caplog.at_level(logging.WARNING):
+                async with manager:
+                    await manager.get_user_structure()
 
         assert not any(record.levelno >= logging.ERROR for record in caplog.records)
         assert "429" in caplog.text
 
-    async def test_post_429_is_retried_and_eventually_succeeds(self, manager):
-        # cubic_secure_close_valve() goes through the _post() helper (unlike
-        # set_device_temperature(), which makes its own raw session.post()
-        # call and isn't covered by this retry loop).
+    async def test_post_429_is_retried_and_eventually_succeeds(
+        self, manager, mock_sleep
+    ):
         url = BASE_URL + "control/cubic/secure/cubic-1/valve/close"
 
         with aioresponses() as m:
             m.post(url, status=429, headers={"Retry-After": "1"})
             m.post(url, payload={}, status=200)
-            with patch("asyncio.sleep", new=AsyncMock()):
-                async with manager:
-                    result = await manager.cubic_secure_close_valve("cubic-1")
+            async with manager:
+                result = await manager.cubic_secure_close_valve("cubic-1")
 
         assert result is True
 

--- a/tests/test_pylksystems.py
+++ b/tests/test_pylksystems.py
@@ -8,6 +8,7 @@ merge/dedupe, error handling) without ever hitting the real LK Systems API.
 from __future__ import annotations
 
 import logging
+from unittest.mock import AsyncMock, patch
 
 from aiohttp import ClientConnectionError
 from aioresponses import aioresponses
@@ -366,3 +367,106 @@ class TestClientSessionTimeout:
 
         assert timeout.total is not None
         assert timeout.total <= 30
+
+
+class TestRateLimitBackoff:
+    """LK's cloud API rate-limits (429) during bursts of activity - this is
+    an expected, routine condition on LK's end, not a genuine error. The
+    client should retry with backoff (honoring Retry-After when present)
+    instead of failing immediately, and log at warning rather than error.
+    """
+
+    async def test_429_is_retried_and_eventually_succeeds(self, manager):
+        url = BASE_URL + "service/cubic/secure/cubic-1/measurement/0"
+
+        with aioresponses() as m:
+            m.get(url, status=429, headers={"Retry-After": "1"})
+            m.get(url, payload={"flow": 0.0}, status=200)
+            with patch("asyncio.sleep", new=AsyncMock()):
+                async with manager:
+                    result = await manager.get_cubic_secure_measurement("cubic-1")
+
+        assert result is True
+        assert manager.cubic_secure_messurement == {"flow": 0.0}
+
+    async def test_429_honors_retry_after_header(self, manager):
+        url = BASE_URL + "service/cubic/secure/cubic-1/measurement/0"
+
+        with aioresponses() as m:
+            m.get(url, status=429, headers={"Retry-After": "7"})
+            m.get(url, payload={"flow": 0.0}, status=200)
+            with patch("asyncio.sleep", new=AsyncMock()) as mock_sleep:
+                async with manager:
+                    await manager.get_cubic_secure_measurement("cubic-1")
+
+        mock_sleep.assert_awaited_once_with(7.0)
+
+    async def test_429_without_retry_after_uses_a_default_backoff(self, manager):
+        url = BASE_URL + "service/cubic/secure/cubic-1/measurement/0"
+
+        with aioresponses() as m:
+            m.get(url, status=429)
+            m.get(url, payload={"flow": 0.0}, status=200)
+            with patch("asyncio.sleep", new=AsyncMock()) as mock_sleep:
+                async with manager:
+                    await manager.get_cubic_secure_measurement("cubic-1")
+
+        mock_sleep.assert_awaited_once()
+        assert mock_sleep.await_args.args[0] > 0
+
+    async def test_429_exhausting_retries_returns_false(self, manager):
+        manager.userid = "user-123"
+        url = BASE_URL + "service/users/user/user-123/structure/1"
+
+        with aioresponses() as m:
+            m.get(url, status=429, repeat=True)
+            with patch("asyncio.sleep", new=AsyncMock()):
+                async with manager:
+                    result = await manager.get_user_structure()
+
+        assert result is False
+        assert manager.user_structure is None
+
+    async def test_429_exhausting_retries_logs_warning_not_error(self, manager, caplog):
+        manager.userid = "user-123"
+        url = BASE_URL + "service/users/user/user-123/structure/1"
+
+        with aioresponses() as m:
+            m.get(url, status=429, repeat=True)
+            with patch("asyncio.sleep", new=AsyncMock()):
+                with caplog.at_level(logging.WARNING):
+                    async with manager:
+                        await manager.get_user_structure()
+
+        assert not any(record.levelno >= logging.ERROR for record in caplog.records)
+        assert "429" in caplog.text
+
+    async def test_post_429_is_retried_and_eventually_succeeds(self, manager):
+        # cubic_secure_close_valve() goes through the _post() helper (unlike
+        # set_device_temperature(), which makes its own raw session.post()
+        # call and isn't covered by this retry loop).
+        url = BASE_URL + "control/cubic/secure/cubic-1/valve/close"
+
+        with aioresponses() as m:
+            m.post(url, status=429, headers={"Retry-After": "1"})
+            m.post(url, payload={}, status=200)
+            with patch("asyncio.sleep", new=AsyncMock()):
+                async with manager:
+                    result = await manager.cubic_secure_close_valve("cubic-1")
+
+        assert result is True
+
+    async def test_other_error_statuses_still_log_at_error(self, manager, caplog):
+        """Non-429 failures aren't rate-limiting - they keep the existing
+        error-level logging, unaffected by the 429 backoff path."""
+        manager.userid = "user-123"
+        url = BASE_URL + "service/users/user/user-123/structure/1"
+
+        with aioresponses() as m:
+            m.get(url, status=500)
+            with caplog.at_level(logging.ERROR):
+                async with manager:
+                    result = await manager.get_user_structure()
+
+        assert result is False
+        assert any(record.levelno >= logging.ERROR for record in caplog.records)


### PR DESCRIPTION
Closes #53.

LK's cloud API rate-limiting (429) during a burst of activity was treated identically to a genuine server error: no retry, no backoff, and an ERROR-level log for a routine, expected condition on LK's end.

- `_get()`/`_post()` (the request helpers used by most of the client's read/write calls, including the cubic-secure `configuration` endpoint that triggered a real 429 during testing) now retry up to 3 times on a 429, honoring the `Retry-After` header when LK sends one and falling back to a flat 5s backoff otherwise.
- `handle_client_error()` logs a 429 at `warning` instead of `error`.

**Scope note:** a few methods (`set_device_temperature()`, `get_device_measurement()`, others) make their own raw `session.get()`/`post()` calls instead of going through `_get()`/`_post()`, so they aren't covered by the retry loop yet - broadening it to cover them is a larger refactor left out of scope here. `coordinator.py` is untouched: the reported real-world symptom (cubic sensors going `unknown` after a 429 on the `configuration` endpoint) already degrades gracefully via the coordinator's existing per-device fallback, and that endpoint goes through `_get()`, so it's now covered by the retry above - by the time a fetch failure reaches the coordinator's own error handling, retries are already exhausted and it's a genuinely persistent failure.

Backoff is fixed (5s), not exponential, when `Retry-After` is absent - LK's own header is the authoritative signal when present.

TDD'd via `tests/test_pylksystems.py::TestRateLimitBackoff` (confirmed RED before touching `pylksystems/__init__.py`). Full suite passes: 32/32 in `tests/`, 48/48 in `tests_ha/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)