### PR TITLE
Surface failures via the repair/issue registry

### DIFF
--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -38,10 +38,17 @@ from .pylksystems import (
     LKPressureThresholds,
 )
 from .redact import mask_username
+from . import repairs
 
 from .services import async_setup_services
 
 _LOGGER = logging.getLogger(__name__)
+
+# Number of consecutive failed updates before a persistent-failure repair
+# issue is raised - a single failed update is routine (network blip, a 429
+# that exhausted its retries) and resolves on its own via the next
+# scheduled poll, so only a run of failures is worth surfacing.
+CONSECUTIVE_FAILURE_THRESHOLD = 3
 
 # Define the platforms we support
 PLATFORMS = [Platform.SENSOR, Platform.CLIMATE]
@@ -213,6 +220,7 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         self._cubic_identity = None
         self._last_update_time = dt_util.now()
         self._entry_id = entry.entry_id
+        self._consecutive_failures = 0
 
         # Initialize coordinator with update interval
         super().__init__(
@@ -377,7 +385,37 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
             _LOGGER.error("Error during forced device update: %s", ex)
             return False
 
-    async def _async_update_data(self) -> LkStructureResp:  # noqa: C901
+    async def _async_update_data(self) -> LkStructureResp:
+        """Fetch the latest data, surfacing persistent failures as repair issues.
+
+        Auth failures raise a repair issue immediately - HA's own reauth
+        flow already treats them as non-transient. A fetch failure only
+        raises one after CONSECUTIVE_FAILURE_THRESHOLD in a row, since a
+        single failed update is routine (network blip, a 429 that
+        exhausted its retries - see issue #53) and resolves on its own via
+        the next scheduled poll.
+        """
+        try:
+            resp = await self._fetch_data()
+        except ConfigEntryAuthFailed:
+            repairs.async_create_auth_failed_issue(self.hass, self._entry_id)
+            raise
+        except UpdateFailed:
+            self._consecutive_failures += 1
+            if self._consecutive_failures >= CONSECUTIVE_FAILURE_THRESHOLD:
+                repairs.async_create_persistent_update_failure_issue(
+                    self.hass, self._entry_id
+                )
+            raise
+        else:
+            self._consecutive_failures = 0
+            repairs.async_clear_auth_failed_issue(self.hass, self._entry_id)
+            repairs.async_clear_persistent_update_failure_issue(
+                self.hass, self._entry_id
+            )
+            return resp
+
+    async def _fetch_data(self) -> LkStructureResp:  # noqa: C901
         """Fetch the latest data from the source."""
         # Record update time at the beginning of update
         self._last_update_time = dt_util.now()

--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -390,10 +390,8 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
 
         Auth failures raise a repair issue immediately - HA's own reauth
         flow already treats them as non-transient. A fetch failure only
-        raises one after CONSECUTIVE_FAILURE_THRESHOLD in a row, since a
-        single failed update is routine (network blip, a 429 that
-        exhausted its retries - see issue #53) and resolves on its own via
-        the next scheduled poll.
+        raises one after CONSECUTIVE_FAILURE_THRESHOLD in a row (see that
+        constant's own comment for why).
         """
         try:
             resp = await self._fetch_data()
@@ -409,10 +407,7 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
             raise
         else:
             self._consecutive_failures = 0
-            repairs.async_clear_auth_failed_issue(self.hass, self._entry_id)
-            repairs.async_clear_persistent_update_failure_issue(
-                self.hass, self._entry_id
-            )
+            repairs.async_clear_all_issues(self.hass, self._entry_id)
             return resp
 
     async def _fetch_data(self) -> LkStructureResp:  # noqa: C901

--- a/custom_components/lksystems/repairs.py
+++ b/custom_components/lksystems/repairs.py
@@ -1,0 +1,61 @@
+"""Repair/issue-registry integration for the LK Systems integration.
+
+Surfaces persistent failures in Settings -> System -> Repairs instead of
+only as log warnings or an entity silently going stale/unavailable (issue
+#50). Each issue is keyed per config entry so multiple accounts don't
+collide, and is cleared automatically once the condition that raised it
+resolves - see coordinator.py's _async_update_data().
+"""
+
+from __future__ import annotations
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import issue_registry as ir
+
+from .const import DOMAIN
+
+
+def _auth_failed_issue_id(entry_id: str) -> str:
+    return f"auth_failed_{entry_id}"
+
+
+def _persistent_update_failure_issue_id(entry_id: str) -> str:
+    return f"persistent_update_failure_{entry_id}"
+
+
+def async_create_auth_failed_issue(hass: HomeAssistant, entry_id: str) -> None:
+    """Raise a repair issue for an authentication failure."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        _auth_failed_issue_id(entry_id),
+        is_fixable=False,
+        severity=ir.IssueSeverity.ERROR,
+        translation_key="auth_failed",
+    )
+
+
+def async_clear_auth_failed_issue(hass: HomeAssistant, entry_id: str) -> None:
+    """Clear the authentication-failure repair issue, if any."""
+    ir.async_delete_issue(hass, DOMAIN, _auth_failed_issue_id(entry_id))
+
+
+def async_create_persistent_update_failure_issue(
+    hass: HomeAssistant, entry_id: str
+) -> None:
+    """Raise a repair issue for a run of consecutive failed updates."""
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        _persistent_update_failure_issue_id(entry_id),
+        is_fixable=False,
+        severity=ir.IssueSeverity.WARNING,
+        translation_key="persistent_update_failure",
+    )
+
+
+def async_clear_persistent_update_failure_issue(
+    hass: HomeAssistant, entry_id: str
+) -> None:
+    """Clear the persistent-update-failure repair issue, if any."""
+    ir.async_delete_issue(hass, DOMAIN, _persistent_update_failure_issue_id(entry_id))

--- a/custom_components/lksystems/repairs.py
+++ b/custom_components/lksystems/repairs.py
@@ -4,7 +4,7 @@ Surfaces persistent failures in Settings -> System -> Repairs instead of
 only as log warnings or an entity silently going stale/unavailable (issue
 #50). Each issue is keyed per config entry so multiple accounts don't
 collide, and is cleared automatically once the condition that raised it
-resolves - see coordinator.py's _async_update_data().
+resolves.
 """
 
 from __future__ import annotations
@@ -15,42 +15,43 @@ from homeassistant.helpers import issue_registry as ir
 from .const import DOMAIN
 
 
-def _auth_failed_issue_id(entry_id: str) -> str:
-    return f"auth_failed_{entry_id}"
+def _issue_id(kind: str, entry_id: str) -> str:
+    return f"{kind}_{entry_id}"
 
 
-def _persistent_update_failure_issue_id(entry_id: str) -> str:
-    return f"persistent_update_failure_{entry_id}"
+def _create_issue(
+    hass: HomeAssistant, entry_id: str, kind: str, severity: ir.IssueSeverity
+) -> None:
+    ir.async_create_issue(
+        hass,
+        DOMAIN,
+        _issue_id(kind, entry_id),
+        is_fixable=False,
+        severity=severity,
+        translation_key=kind,
+    )
+
+
+def _clear_issue(hass: HomeAssistant, entry_id: str, kind: str) -> None:
+    ir.async_delete_issue(hass, DOMAIN, _issue_id(kind, entry_id))
 
 
 def async_create_auth_failed_issue(hass: HomeAssistant, entry_id: str) -> None:
     """Raise a repair issue for an authentication failure."""
-    ir.async_create_issue(
-        hass,
-        DOMAIN,
-        _auth_failed_issue_id(entry_id),
-        is_fixable=False,
-        severity=ir.IssueSeverity.ERROR,
-        translation_key="auth_failed",
-    )
+    _create_issue(hass, entry_id, "auth_failed", ir.IssueSeverity.ERROR)
 
 
 def async_clear_auth_failed_issue(hass: HomeAssistant, entry_id: str) -> None:
     """Clear the authentication-failure repair issue, if any."""
-    ir.async_delete_issue(hass, DOMAIN, _auth_failed_issue_id(entry_id))
+    _clear_issue(hass, entry_id, "auth_failed")
 
 
 def async_create_persistent_update_failure_issue(
     hass: HomeAssistant, entry_id: str
 ) -> None:
     """Raise a repair issue for a run of consecutive failed updates."""
-    ir.async_create_issue(
-        hass,
-        DOMAIN,
-        _persistent_update_failure_issue_id(entry_id),
-        is_fixable=False,
-        severity=ir.IssueSeverity.WARNING,
-        translation_key="persistent_update_failure",
+    _create_issue(
+        hass, entry_id, "persistent_update_failure", ir.IssueSeverity.WARNING
     )
 
 
@@ -58,4 +59,10 @@ def async_clear_persistent_update_failure_issue(
     hass: HomeAssistant, entry_id: str
 ) -> None:
     """Clear the persistent-update-failure repair issue, if any."""
-    ir.async_delete_issue(hass, DOMAIN, _persistent_update_failure_issue_id(entry_id))
+    _clear_issue(hass, entry_id, "persistent_update_failure")
+
+
+def async_clear_all_issues(hass: HomeAssistant, entry_id: str) -> None:
+    """Clear every repair issue this integration can raise for entry_id."""
+    async_clear_auth_failed_issue(hass, entry_id)
+    async_clear_persistent_update_failure_issue(hass, entry_id)

--- a/custom_components/lksystems/repairs.py
+++ b/custom_components/lksystems/repairs.py
@@ -1,10 +1,9 @@
 """Repair/issue-registry integration for the LK Systems integration.
 
 Surfaces persistent failures in Settings -> System -> Repairs instead of
-only as log warnings or an entity silently going stale/unavailable (issue
-#50). Each issue is keyed per config entry so multiple accounts don't
-collide, and is cleared automatically once the condition that raised it
-resolves.
+only as log warnings or an entity silently going stale/unavailable. Each
+issue is keyed per config entry so multiple accounts don't collide, and is
+cleared automatically once the condition that raised it resolves.
 """
 
 from __future__ import annotations

--- a/custom_components/lksystems/strings.json
+++ b/custom_components/lksystems/strings.json
@@ -18,7 +18,15 @@
         "abort": {
             "already_configured": "This LK Systems account is already configured. One integration entry covers your whole account, including multiple Cubic Secure devices - you don't need to add it again to see additional devices."
         }
+    },
+    "issues": {
+        "auth_failed": {
+            "title": "LK Systems authentication failed",
+            "description": "The integration could not log in to your LK Systems account. Go to Settings > Devices & Services, select LK Systems, and follow the reauthentication prompt to re-enter your username and password."
+        },
+        "persistent_update_failure": {
+            "title": "LK Systems repeatedly failed to update",
+            "description": "The integration has failed to fetch data from the LK Systems cloud API several times in a row. Check your internet connection and the LK Systems service status. This clears automatically once an update succeeds."
+        }
     }
 }
-  
-  

--- a/tests_ha/conftest.py
+++ b/tests_ha/conftest.py
@@ -19,6 +19,9 @@ import asyncio
 import time
 
 import pytest
+from homeassistant.helpers import issue_registry as ir
+
+from custom_components.lksystems.const import DOMAIN
 
 pytest_plugins = "pytest_homeassistant_custom_component"
 
@@ -345,3 +348,8 @@ def fake_manager() -> FakeLKSystemsManager:
     manager = FakeLKSystemsManager()
     configure_fake_manager_with_sample_data(manager)
     return manager
+
+
+def get_issue(hass, issue_id: str):
+    """Look up a repair issue by id via the issue registry."""
+    return ir.async_get(hass).async_get_issue(DOMAIN, issue_id)

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -16,6 +16,7 @@ from unittest.mock import AsyncMock, patch
 import pytest
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.exceptions import ConfigEntryAuthFailed
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -194,6 +195,95 @@ class TestAsyncUpdateData:
 
         assert ("login",) in fake_manager.calls
         assert TOKEN_STORAGE[entry.entry_id]["jwt"] == "fake-jwt-token"
+
+
+def _get_issue(hass, issue_id: str):
+    return ir.async_get(hass).async_get_issue(DOMAIN, issue_id)
+
+
+class TestRepairIssues:
+    """A failed update should surface as a repair issue (issue #50) instead
+    of only a log line - auth failures immediately (HA's own reauth flow
+    already treats them as non-transient), fetch failures only after
+    CONSECUTIVE_FAILURE_THRESHOLD in a row (a single failure is routine and
+    resolves on its own via the next scheduled poll)."""
+
+    async def test_auth_failure_raises_a_repair_issue(self, hass):
+        entry = MockConfigEntry(domain=DOMAIN, data={})
+        entry.add_to_hass(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with pytest.raises(ConfigEntryAuthFailed):
+            await coordinator._async_update_data()
+
+        assert _get_issue(hass, f"auth_failed_{entry.entry_id}") is not None
+
+    async def test_successful_update_clears_the_auth_failed_issue(
+        self, hass, fake_manager
+    ):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            f"auth_failed_{entry.entry_id}",
+            is_fixable=False,
+            severity=ir.IssueSeverity.ERROR,
+            translation_key="auth_failed",
+        )
+
+        with _patch_manager(fake_manager):
+            await coordinator._async_update_data()
+
+        assert _get_issue(hass, f"auth_failed_{entry.entry_id}") is None
+
+    async def test_single_fetch_failure_does_not_raise_a_persistent_issue(
+        self, hass, fake_manager
+    ):
+        fake_manager.get_user_structure_result = False
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            with pytest.raises(UpdateFailed):
+                await coordinator._async_update_data()
+
+        assert _get_issue(hass, f"persistent_update_failure_{entry.entry_id}") is None
+
+    async def test_consecutive_fetch_failures_raise_a_persistent_issue(
+        self, hass, fake_manager
+    ):
+        fake_manager.get_user_structure_result = False
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            for _ in range(3):
+                with pytest.raises(UpdateFailed):
+                    await coordinator._async_update_data()
+
+        assert (
+            _get_issue(hass, f"persistent_update_failure_{entry.entry_id}")
+            is not None
+        )
+
+    async def test_successful_update_after_failures_clears_the_persistent_issue(
+        self, hass, fake_manager
+    ):
+        fake_manager.get_user_structure_result = False
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            for _ in range(3):
+                with pytest.raises(UpdateFailed):
+                    await coordinator._async_update_data()
+
+        fake_manager.get_user_structure_result = True
+        with _patch_manager(fake_manager):
+            await coordinator._async_update_data()
+
+        assert _get_issue(hass, f"persistent_update_failure_{entry.entry_id}") is None
 
 
 class TestCubicFetchFailureFallback:

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -31,6 +31,7 @@ from custom_components.lksystems.const import (
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
 )
+from custom_components.lksystems.repairs import _issue_id
 
 from .conftest import (
     CUBIC_IDENTITY,
@@ -38,6 +39,7 @@ from .conftest import (
     HUB_IDENTITY,
     SENSOR_MAC,
     THERMOSTAT_MAC,
+    get_issue,
 )
 
 
@@ -197,10 +199,6 @@ class TestAsyncUpdateData:
         assert TOKEN_STORAGE[entry.entry_id]["jwt"] == "fake-jwt-token"
 
 
-def _get_issue(hass, issue_id: str):
-    return ir.async_get(hass).async_get_issue(DOMAIN, issue_id)
-
-
 class TestRepairIssues:
     """A failed update should surface as a repair issue (issue #50) instead
     of only a log line - auth failures immediately (HA's own reauth flow
@@ -216,7 +214,7 @@ class TestRepairIssues:
         with pytest.raises(ConfigEntryAuthFailed):
             await coordinator._async_update_data()
 
-        assert _get_issue(hass, f"auth_failed_{entry.entry_id}") is not None
+        assert get_issue(hass, _issue_id("auth_failed", entry.entry_id)) is not None
 
     async def test_successful_update_clears_the_auth_failed_issue(
         self, hass, fake_manager
@@ -226,7 +224,7 @@ class TestRepairIssues:
         ir.async_create_issue(
             hass,
             DOMAIN,
-            f"auth_failed_{entry.entry_id}",
+            _issue_id("auth_failed", entry.entry_id),
             is_fixable=False,
             severity=ir.IssueSeverity.ERROR,
             translation_key="auth_failed",
@@ -235,7 +233,7 @@ class TestRepairIssues:
         with _patch_manager(fake_manager):
             await coordinator._async_update_data()
 
-        assert _get_issue(hass, f"auth_failed_{entry.entry_id}") is None
+        assert get_issue(hass, _issue_id("auth_failed", entry.entry_id)) is None
 
     async def test_single_fetch_failure_does_not_raise_a_persistent_issue(
         self, hass, fake_manager
@@ -248,7 +246,10 @@ class TestRepairIssues:
             with pytest.raises(UpdateFailed):
                 await coordinator._async_update_data()
 
-        assert _get_issue(hass, f"persistent_update_failure_{entry.entry_id}") is None
+        assert (
+            get_issue(hass, _issue_id("persistent_update_failure", entry.entry_id))
+            is None
+        )
 
     async def test_consecutive_fetch_failures_raise_a_persistent_issue(
         self, hass, fake_manager
@@ -263,7 +264,7 @@ class TestRepairIssues:
                     await coordinator._async_update_data()
 
         assert (
-            _get_issue(hass, f"persistent_update_failure_{entry.entry_id}")
+            get_issue(hass, _issue_id("persistent_update_failure", entry.entry_id))
             is not None
         )
 
@@ -283,7 +284,10 @@ class TestRepairIssues:
         with _patch_manager(fake_manager):
             await coordinator._async_update_data()
 
-        assert _get_issue(hass, f"persistent_update_failure_{entry.entry_id}") is None
+        assert (
+            get_issue(hass, _issue_id("persistent_update_failure", entry.entry_id))
+            is None
+        )
 
 
 class TestCubicFetchFailureFallback:

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -200,9 +200,9 @@ class TestAsyncUpdateData:
 
 
 class TestRepairIssues:
-    """A failed update should surface as a repair issue (issue #50) instead
-    of only a log line - auth failures immediately (HA's own reauth flow
-    already treats them as non-transient), fetch failures only after
+    """A failed update should surface as a repair issue instead of only a
+    log line - auth failures immediately (HA's own reauth flow already
+    treats them as non-transient), fetch failures only after
     CONSECUTIVE_FAILURE_THRESHOLD in a row (a single failure is routine and
     resolves on its own via the next scheduled poll)."""
 

--- a/tests_ha/test_repairs.py
+++ b/tests_ha/test_repairs.py
@@ -8,61 +8,66 @@ against the issue registry.
 
 from __future__ import annotations
 
+import pytest
 from homeassistant.helpers import issue_registry as ir
 
-from custom_components.lksystems.const import DOMAIN
 from custom_components.lksystems.repairs import (
+    _issue_id,
     async_clear_auth_failed_issue,
     async_clear_persistent_update_failure_issue,
     async_create_auth_failed_issue,
     async_create_persistent_update_failure_issue,
 )
 
+from .conftest import get_issue
 
-def _get_issue(hass, issue_id: str):
-    return ir.async_get(hass).async_get_issue(DOMAIN, issue_id)
+ISSUE_KINDS = [
+    pytest.param(
+        "auth_failed",
+        async_create_auth_failed_issue,
+        async_clear_auth_failed_issue,
+        ir.IssueSeverity.ERROR,
+        id="auth_failed",
+    ),
+    pytest.param(
+        "persistent_update_failure",
+        async_create_persistent_update_failure_issue,
+        async_clear_persistent_update_failure_issue,
+        ir.IssueSeverity.WARNING,
+        id="persistent_update_failure",
+    ),
+]
 
 
-class TestAuthFailedIssue:
-    async def test_create_registers_an_error_severity_issue(self, hass):
-        async_create_auth_failed_issue(hass, "entry-1")
+@pytest.mark.parametrize("kind, create_issue, clear_issue, severity", ISSUE_KINDS)
+class TestIssueLifecycle:
+    async def test_create_registers_issue_with_expected_severity(
+        self, hass, kind, create_issue, clear_issue, severity
+    ):
+        create_issue(hass, "entry-1")
 
-        issue = _get_issue(hass, "auth_failed_entry-1")
+        issue = get_issue(hass, _issue_id(kind, "entry-1"))
         assert issue is not None
-        assert issue.severity == ir.IssueSeverity.ERROR
-        assert issue.translation_key == "auth_failed"
+        assert issue.severity == severity
+        assert issue.translation_key == kind
 
-    async def test_clear_removes_the_issue(self, hass):
-        async_create_auth_failed_issue(hass, "entry-1")
+    async def test_clear_removes_the_issue(
+        self, hass, kind, create_issue, clear_issue, severity
+    ):
+        create_issue(hass, "entry-1")
 
-        async_clear_auth_failed_issue(hass, "entry-1")
+        clear_issue(hass, "entry-1")
 
-        assert _get_issue(hass, "auth_failed_entry-1") is None
+        assert get_issue(hass, _issue_id(kind, "entry-1")) is None
 
-    async def test_clear_without_a_prior_create_does_not_raise(self, hass):
-        async_clear_auth_failed_issue(hass, "entry-never-failed")
+    async def test_clear_without_a_prior_create_does_not_raise(
+        self, hass, kind, create_issue, clear_issue, severity
+    ):
+        clear_issue(hass, "entry-never-failed")
 
-    async def test_issues_are_keyed_per_entry(self, hass):
-        async_create_auth_failed_issue(hass, "entry-1")
+    async def test_issues_are_keyed_per_entry(
+        self, hass, kind, create_issue, clear_issue, severity
+    ):
+        create_issue(hass, "entry-1")
 
-        assert _get_issue(hass, "auth_failed_entry-2") is None
-
-
-class TestPersistentUpdateFailureIssue:
-    async def test_create_registers_a_warning_severity_issue(self, hass):
-        async_create_persistent_update_failure_issue(hass, "entry-1")
-
-        issue = _get_issue(hass, "persistent_update_failure_entry-1")
-        assert issue is not None
-        assert issue.severity == ir.IssueSeverity.WARNING
-        assert issue.translation_key == "persistent_update_failure"
-
-    async def test_clear_removes_the_issue(self, hass):
-        async_create_persistent_update_failure_issue(hass, "entry-1")
-
-        async_clear_persistent_update_failure_issue(hass, "entry-1")
-
-        assert _get_issue(hass, "persistent_update_failure_entry-1") is None
-
-    async def test_clear_without_a_prior_create_does_not_raise(self, hass):
-        async_clear_persistent_update_failure_issue(hass, "entry-never-failed")
+        assert get_issue(hass, _issue_id(kind, "entry-2")) is None

--- a/tests_ha/test_repairs.py
+++ b/tests_ha/test_repairs.py
@@ -1,0 +1,68 @@
+"""Tests for repairs.py's issue-registry helpers.
+
+Coordinator-driven behavior (when a repair issue actually gets raised or
+cleared during an update) is covered separately in test_coordinator.py -
+these tests are only concerned with repairs.py's own create/clear logic
+against the issue registry.
+"""
+
+from __future__ import annotations
+
+from homeassistant.helpers import issue_registry as ir
+
+from custom_components.lksystems.const import DOMAIN
+from custom_components.lksystems.repairs import (
+    async_clear_auth_failed_issue,
+    async_clear_persistent_update_failure_issue,
+    async_create_auth_failed_issue,
+    async_create_persistent_update_failure_issue,
+)
+
+
+def _get_issue(hass, issue_id: str):
+    return ir.async_get(hass).async_get_issue(DOMAIN, issue_id)
+
+
+class TestAuthFailedIssue:
+    async def test_create_registers_an_error_severity_issue(self, hass):
+        async_create_auth_failed_issue(hass, "entry-1")
+
+        issue = _get_issue(hass, "auth_failed_entry-1")
+        assert issue is not None
+        assert issue.severity == ir.IssueSeverity.ERROR
+        assert issue.translation_key == "auth_failed"
+
+    async def test_clear_removes_the_issue(self, hass):
+        async_create_auth_failed_issue(hass, "entry-1")
+
+        async_clear_auth_failed_issue(hass, "entry-1")
+
+        assert _get_issue(hass, "auth_failed_entry-1") is None
+
+    async def test_clear_without_a_prior_create_does_not_raise(self, hass):
+        async_clear_auth_failed_issue(hass, "entry-never-failed")
+
+    async def test_issues_are_keyed_per_entry(self, hass):
+        async_create_auth_failed_issue(hass, "entry-1")
+
+        assert _get_issue(hass, "auth_failed_entry-2") is None
+
+
+class TestPersistentUpdateFailureIssue:
+    async def test_create_registers_a_warning_severity_issue(self, hass):
+        async_create_persistent_update_failure_issue(hass, "entry-1")
+
+        issue = _get_issue(hass, "persistent_update_failure_entry-1")
+        assert issue is not None
+        assert issue.severity == ir.IssueSeverity.WARNING
+        assert issue.translation_key == "persistent_update_failure"
+
+    async def test_clear_removes_the_issue(self, hass):
+        async_create_persistent_update_failure_issue(hass, "entry-1")
+
+        async_clear_persistent_update_failure_issue(hass, "entry-1")
+
+        assert _get_issue(hass, "persistent_update_failure_entry-1") is None
+
+    async def test_clear_without_a_prior_create_does_not_raise(self, hass):
+        async_clear_persistent_update_failure_issue(hass, "entry-never-failed")


### PR DESCRIPTION
Closes #50.

The integration never called into `homeassistant.helpers.issue_registry`, so failures only showed up as log warnings or an entity silently going `unavailable`/stale - no actionable notice in Settings → System → Repairs.

New `repairs.py` registers/clears two per-entry issues:
- **`auth_failed`** (severity error): raised immediately when a coordinator update hits `ConfigEntryAuthFailed` (missing credentials, login failure, or `InvalidAuth` from the client). HA's own reauth flow already treats auth failures as non-transient, so there's no reason to wait.
- **`persistent_update_failure`** (severity warning): raised only after `CONSECUTIVE_FAILURE_THRESHOLD` (3) `UpdateFailed` in a row. A single failed update is routine (network blip, a 429 that exhausted its retries - #53) and resolves on its own via the next scheduled poll, so flagging every isolated failure would just be noise.

Both clear automatically on the next successful update.

`coordinator.py`'s existing ~400-line `_async_update_data()` is renamed to `_fetch_data()` (behavior unchanged) and wrapped by a new, small `_async_update_data()` that does the try/except/issue-registry bookkeeping - this catches every `UpdateFailed`/`ConfigEntryAuthFailed` raise site inside `_fetch_data()` uniformly, rather than needing a `repairs.py` call at each of the several places that can raise one.

`strings.json` gains an `issues` section so the two issues render with real title/description text in the Repairs UI rather than blank/raw keys.

TDD'd via `tests_ha/test_repairs.py` (`repairs.py`'s create/clear helpers against the issue registry directly) and a new `TestRepairIssues` class in `tests_ha/test_coordinator.py` (the coordinator-driven create/clear/threshold behavior). Confirmed RED by stashing the implementation and running both new test files/classes against the unmodified coordinator before restoring it. Full suite passes: 60/60 in `tests_ha/`, 25/25 in `tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)