### PR TITLE
Use has_entity_name consistently across all entities

### DIFF
--- a/custom_components/lksystems/climate.py
+++ b/custom_components/lksystems/climate.py
@@ -131,14 +131,21 @@ class LKThermostat(CoordinatorEntity, ClimateEntity):
         
         # Create unique ID
         self._attr_unique_id = f"{DOMAIN}_{device_identity}_thermostat"
-        
-        # Set name
-        self._attr_name = f"LK {zone_name} Thermostat"
-        
+
+        # has_entity_name: the thermostat is the only entity on its
+        # device, so per HA convention for a device's sole/primary entity,
+        # its own name is left unset - the displayed name is just the
+        # device name below (also drops the redundant "Thermostat" suffix
+        # that used to be baked into both the entity and device name here,
+        # matching the device-naming convention sensor.py's Arc entities
+        # use for this same physical device).
+        self._attr_has_entity_name = True
+        self._attr_name = None
+
         # Set up device info
         device_info = {
             "identifiers": {(DOMAIN, device_identity)},
-            "name": self._attr_name,
+            "name": f"LK {zone_name}",
             "manufacturer": "LK Systems",
             "model": device_type,
             "sw_version": None,

--- a/custom_components/lksystems/climate.py
+++ b/custom_components/lksystems/climate.py
@@ -105,6 +105,7 @@ class LKThermostat(CoordinatorEntity, ClimateEntity):
     _attr_min_temp = 5.0
     _attr_max_temp = 30.0
     _attr_target_temperature_step = 0.5
+    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -132,13 +133,9 @@ class LKThermostat(CoordinatorEntity, ClimateEntity):
         # Create unique ID
         self._attr_unique_id = f"{DOMAIN}_{device_identity}_thermostat"
 
-        # has_entity_name: the thermostat is the only entity on its
-        # device, so per HA convention for a device's sole/primary entity,
-        # its own name is left unset - the displayed name is just the
-        # device name below. The device name has no entity-type suffix,
-        # matching the device-naming convention sensor.py's Arc entities
-        # use for this same physical device.
-        self._attr_has_entity_name = True
+        # The thermostat is the only entity on its device, so per HA
+        # convention for a device's sole/primary entity, its own name is
+        # left unset - the displayed name is just the device name below.
         self._attr_name = None
 
         # Set up device info

--- a/custom_components/lksystems/climate.py
+++ b/custom_components/lksystems/climate.py
@@ -135,10 +135,9 @@ class LKThermostat(CoordinatorEntity, ClimateEntity):
         # has_entity_name: the thermostat is the only entity on its
         # device, so per HA convention for a device's sole/primary entity,
         # its own name is left unset - the displayed name is just the
-        # device name below (also drops the redundant "Thermostat" suffix
-        # that used to be baked into both the entity and device name here,
+        # device name below. The device name has no entity-type suffix,
         # matching the device-naming convention sensor.py's Arc entities
-        # use for this same physical device).
+        # use for this same physical device.
         self._attr_has_entity_name = True
         self._attr_name = None
 

--- a/custom_components/lksystems/sensor.py
+++ b/custom_components/lksystems/sensor.py
@@ -42,6 +42,15 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 
+def _resolve_device_name(device_title: dict, fallback: str) -> str:
+    """Return the device's own display name, falling back to a default.
+
+    Not every device has a friendly "name" in deviceTitle - fall back so
+    the device (as opposed to any one entity on it) is never unnamed.
+    """
+    return device_title.get("name") or fallback
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
@@ -389,6 +398,8 @@ async def async_setup_entry(
 class LKArcSensorEntity(CoordinatorEntity, SensorEntity):
     """Representation of an LK Systems sensor entity."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: LKSystemCoordinator,
@@ -434,23 +445,20 @@ class LKArcSensorEntity(CoordinatorEntity, SensorEntity):
         # Set entity unique ID (must be consistent and unique)
         self._attr_unique_id = f"{DOMAIN}_{device_identity}_{entity_key}"
 
-        # has_entity_name: the entity's own name is just its suffix (e.g.
-        # "Temperature") - HA combines it with the device name below to
-        # build the displayed name, rather than this class baking the
+        # The entity's own name is just its suffix (e.g. "Temperature") -
+        # has_entity_name means HA combines it with the device name below
+        # to build the displayed name, rather than this class baking the
         # device name into its own _attr_name.
-        self._attr_has_entity_name = True
         self._attr_name = name_suffix
 
-        friendly_name = device_title.get("name")
-        if friendly_name:
-            device_name = friendly_name
-        else:
-            room_name = (
-                device_title.get("zone", {}).get("zoneName")
-                if device_title.get("zone")
-                else None
-            )
-            device_name = f"LK {room_name}" if room_name else "LK Sensor"
+        room_name = (
+            device_title.get("zone", {}).get("zoneName")
+            if device_title.get("zone")
+            else None
+        )
+        device_name = _resolve_device_name(
+            device_title, f"LK {room_name}" if room_name else "LK Sensor"
+        )
 
         # Get zone info for naming
         zone_name = None
@@ -719,6 +727,8 @@ class LKArcSensorEntity(CoordinatorEntity, SensorEntity):
 class LKArcHubEntity(CoordinatorEntity, SensorEntity):
     """Representation of an LK Systems ARC Hub entity."""
 
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: LKSystemCoordinator,
@@ -755,13 +765,8 @@ class LKArcHubEntity(CoordinatorEntity, SensorEntity):
         # Create unique ID using identity if available, otherwise mac
         self._attr_unique_id = f"{DOMAIN}_{device_identity}_{entity_key}"
 
-        # has_entity_name: see LKArcSensorEntity.__init__ for why the
-        # device name is kept separate from the entity's own name.
-        self._attr_has_entity_name = True
         self._attr_name = name_suffix
-
-        friendly_name = device_title.get("name")
-        device_name = friendly_name if friendly_name else "LK ARC Hub"
+        device_name = _resolve_device_name(device_title, "LK ARC Hub")
 
         # Set up device info
         device_info = {

--- a/custom_components/lksystems/sensor.py
+++ b/custom_components/lksystems/sensor.py
@@ -434,20 +434,23 @@ class LKArcSensorEntity(CoordinatorEntity, SensorEntity):
         # Set entity unique ID (must be consistent and unique)
         self._attr_unique_id = f"{DOMAIN}_{device_identity}_{entity_key}"
 
-        # Set entity name using friendly name if available
+        # has_entity_name: the entity's own name is just its suffix (e.g.
+        # "Temperature") - HA combines it with the device name below to
+        # build the displayed name, rather than this class baking the
+        # device name into its own _attr_name.
+        self._attr_has_entity_name = True
+        self._attr_name = name_suffix
+
         friendly_name = device_title.get("name")
         if friendly_name:
-            self._attr_name = f"{friendly_name} {name_suffix}"
+            device_name = friendly_name
         else:
             room_name = (
                 device_title.get("zone", {}).get("zoneName")
                 if device_title.get("zone")
                 else None
             )
-            if room_name:
-                self._attr_name = f"LK {room_name} {name_suffix}"
-            else:
-                self._attr_name = f"LK Sensor {name_suffix}"
+            device_name = f"LK {room_name}" if room_name else "LK Sensor"
 
         # Get zone info for naming
         zone_name = None
@@ -457,7 +460,7 @@ class LKArcSensorEntity(CoordinatorEntity, SensorEntity):
         # Set up device info with proper connection to parent if available
         device_info = {
             "identifiers": {(DOMAIN, device_identity)},
-            "name": self._attr_name.replace(f" {name_suffix}", ""),
+            "name": device_name,
             "manufacturer": "LK Systems",
             "model": device_type,
         }
@@ -752,17 +755,18 @@ class LKArcHubEntity(CoordinatorEntity, SensorEntity):
         # Create unique ID using identity if available, otherwise mac
         self._attr_unique_id = f"{DOMAIN}_{device_identity}_{entity_key}"
 
-        # Set name - use device name if available
+        # has_entity_name: see LKArcSensorEntity.__init__ for why the
+        # device name is kept separate from the entity's own name.
+        self._attr_has_entity_name = True
+        self._attr_name = name_suffix
+
         friendly_name = device_title.get("name")
-        if friendly_name:
-            self._attr_name = f"{friendly_name} {name_suffix}"
-        else:
-            self._attr_name = f"LK ARC Hub {name_suffix}"
+        device_name = friendly_name if friendly_name else "LK ARC Hub"
 
         # Set up device info
         device_info = {
             "identifiers": {(DOMAIN, device_identity)},
-            "name": self._attr_name.replace(f" {name_suffix}", ""),
+            "name": device_name,
             "manufacturer": "LK Systems",
             "model": device_type,
             "sw_version": None,

--- a/tests_ha/conftest.py
+++ b/tests_ha/conftest.py
@@ -438,7 +438,7 @@ def fake_manager_with_two_cubic_devices() -> FakeLKSystemsManager:
     return manager
 
 
-async def setup_entry(hass, manager: FakeLKSystemsManager) -> MockConfigEntry:
+
 def get_issue(hass, issue_id: str):
     """Look up a repair issue by id via the issue registry."""
     return ir.async_get(hass).async_get_issue(DOMAIN, issue_id)

--- a/tests_ha/conftest.py
+++ b/tests_ha/conftest.py
@@ -17,8 +17,14 @@ from __future__ import annotations
 
 import asyncio
 import time
+from unittest.mock import patch
 
 import pytest
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.lksystems.const import DOMAIN
 
 pytest_plugins = "pytest_homeassistant_custom_component"
 
@@ -345,3 +351,32 @@ def fake_manager() -> FakeLKSystemsManager:
     manager = FakeLKSystemsManager()
     configure_fake_manager_with_sample_data(manager)
     return manager
+
+
+async def setup_entry(hass, manager: FakeLKSystemsManager) -> MockConfigEntry:
+    """Drive a real config-entry setup against a FakeLKSystemsManager.
+
+    Runs the coordinator's first refresh and both the sensor.py and
+    climate.py platforms' async_setup_entry() for real, so tests can inspect
+    the entities/entity registry they actually produce.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
+    )
+    entry.add_to_hass(hass)
+    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def entity_id(hass, platform: str, unique_id: str) -> str:
+    """Look up an entity_id by platform/unique_id via the entity registry.
+
+    Entities are looked up this way, rather than by guessing slugified
+    entity_ids, so tests don't depend on HA's naming/slugify rules.
+    """
+    found = er.async_get(hass).async_get_entity_id(platform, DOMAIN, unique_id)
+    assert found is not None, f"no {platform} entity registered for {unique_id!r}"
+    return found

--- a/tests_ha/test_climate.py
+++ b/tests_ha/test_climate.py
@@ -2,8 +2,7 @@
 
 LKThermostat is the sole entity on its device, so it follows Home
 Assistant's convention for a device's primary entity: has_entity_name=True
-with name=None, so the entity's displayed name is just the device name
-(issue #49).
+with name=None, so the entity's displayed name is just the device name.
 """
 
 from __future__ import annotations

--- a/tests_ha/test_climate.py
+++ b/tests_ha/test_climate.py
@@ -1,0 +1,77 @@
+"""Tests for climate.py entity naming.
+
+LKThermostat is the sole entity on its device, so it follows Home
+Assistant's convention for a device's primary entity: has_entity_name=True
+with name=None, so the entity's displayed name is just the device name
+(issue #49).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.lksystems.const import DOMAIN
+
+from .conftest import THERMOSTAT_MAC
+
+
+async def _setup_entry(hass, manager) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
+    )
+    entry.add_to_hass(hass)
+    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def _entity_id(hass, unique_id: str) -> str:
+    entity_id = er.async_get(hass).async_get_entity_id("climate", DOMAIN, unique_id)
+    assert entity_id is not None, f"no climate entity registered for {unique_id!r}"
+    return entity_id
+
+
+class TestThermostatHasEntityName:
+    async def test_has_entity_name_is_true(self, hass, fake_manager):
+        await _setup_entry(hass, fake_manager)
+        entity_id = _entity_id(hass, f"{DOMAIN}_{THERMOSTAT_MAC}_thermostat")
+
+        entity = er.async_get(hass).async_get(entity_id)
+
+        assert entity.has_entity_name is True
+
+    async def test_entity_name_is_none(self, hass, fake_manager):
+        """The thermostat is the only entity on its device, so its own
+        name is unset - HA displays just the device name, per convention
+        for a device's primary/sole entity."""
+        await _setup_entry(hass, fake_manager)
+        entity_id = _entity_id(hass, f"{DOMAIN}_{THERMOSTAT_MAC}_thermostat")
+
+        entity = er.async_get(hass).async_get(entity_id)
+
+        assert entity.original_name is None
+
+    async def test_device_name_has_no_redundant_suffix(self, hass, fake_manager):
+        await _setup_entry(hass, fake_manager)
+        _entity_id(hass, f"{DOMAIN}_{THERMOSTAT_MAC}_thermostat")
+
+        device = dr.async_get(hass).async_get_device(
+            identifiers={(DOMAIN, THERMOSTAT_MAC)}
+        )
+
+        assert device.name == "LK Living Room"
+
+    async def test_friendly_name_is_just_the_device_name(self, hass, fake_manager):
+        await _setup_entry(hass, fake_manager)
+        entity_id = _entity_id(hass, f"{DOMAIN}_{THERMOSTAT_MAC}_thermostat")
+
+        state = hass.states.get(entity_id)
+
+        assert state.attributes["friendly_name"] == "LK Living Room"

--- a/tests_ha/test_climate.py
+++ b/tests_ha/test_climate.py
@@ -8,42 +8,22 @@ with name=None, so the entity's displayed name is just the device name
 
 from __future__ import annotations
 
-from unittest.mock import patch
-
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.lksystems.const import DOMAIN
 
-from .conftest import THERMOSTAT_MAC
-
-
-async def _setup_entry(hass, manager) -> MockConfigEntry:
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
-    )
-    entry.add_to_hass(hass)
-    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-    return entry
-
-
-def _entity_id(hass, unique_id: str) -> str:
-    entity_id = er.async_get(hass).async_get_entity_id("climate", DOMAIN, unique_id)
-    assert entity_id is not None, f"no climate entity registered for {unique_id!r}"
-    return entity_id
+from .conftest import THERMOSTAT_MAC, entity_id, setup_entry
 
 
 class TestThermostatHasEntityName:
     async def test_has_entity_name_is_true(self, hass, fake_manager):
-        await _setup_entry(hass, fake_manager)
-        entity_id = _entity_id(hass, f"{DOMAIN}_{THERMOSTAT_MAC}_thermostat")
+        await setup_entry(hass, fake_manager)
+        climate_entity_id = entity_id(
+            hass, "climate", f"{DOMAIN}_{THERMOSTAT_MAC}_thermostat"
+        )
 
-        entity = er.async_get(hass).async_get(entity_id)
+        entity = er.async_get(hass).async_get(climate_entity_id)
 
         assert entity.has_entity_name is True
 
@@ -51,16 +31,18 @@ class TestThermostatHasEntityName:
         """The thermostat is the only entity on its device, so its own
         name is unset - HA displays just the device name, per convention
         for a device's primary/sole entity."""
-        await _setup_entry(hass, fake_manager)
-        entity_id = _entity_id(hass, f"{DOMAIN}_{THERMOSTAT_MAC}_thermostat")
+        await setup_entry(hass, fake_manager)
+        climate_entity_id = entity_id(
+            hass, "climate", f"{DOMAIN}_{THERMOSTAT_MAC}_thermostat"
+        )
 
-        entity = er.async_get(hass).async_get(entity_id)
+        entity = er.async_get(hass).async_get(climate_entity_id)
 
         assert entity.original_name is None
 
     async def test_device_name_has_no_redundant_suffix(self, hass, fake_manager):
-        await _setup_entry(hass, fake_manager)
-        _entity_id(hass, f"{DOMAIN}_{THERMOSTAT_MAC}_thermostat")
+        await setup_entry(hass, fake_manager)
+        entity_id(hass, "climate", f"{DOMAIN}_{THERMOSTAT_MAC}_thermostat")
 
         device = dr.async_get(hass).async_get_device(
             identifiers={(DOMAIN, THERMOSTAT_MAC)}
@@ -69,9 +51,11 @@ class TestThermostatHasEntityName:
         assert device.name == "LK Living Room"
 
     async def test_friendly_name_is_just_the_device_name(self, hass, fake_manager):
-        await _setup_entry(hass, fake_manager)
-        entity_id = _entity_id(hass, f"{DOMAIN}_{THERMOSTAT_MAC}_thermostat")
+        await setup_entry(hass, fake_manager)
+        climate_entity_id = entity_id(
+            hass, "climate", f"{DOMAIN}_{THERMOSTAT_MAC}_thermostat"
+        )
 
-        state = hass.states.get(entity_id)
+        state = hass.states.get(climate_entity_id)
 
         assert state.attributes["friendly_name"] == "LK Living Room"

--- a/tests_ha/test_integration_setup.py
+++ b/tests_ha/test_integration_setup.py
@@ -12,10 +12,6 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.helpers import entity_registry as er
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
 from custom_components.lksystems.const import DOMAIN
 
 from .conftest import (
@@ -24,25 +20,9 @@ from .conftest import (
     HUB_IDENTITY,
     SENSOR_MAC,
     THERMOSTAT_MAC,
+    entity_id as _entity_id,
+    setup_entry as _setup_entry,
 )
-
-
-async def _setup_entry(hass, manager) -> MockConfigEntry:
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
-    )
-    entry.add_to_hass(hass)
-    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-    return entry
-
-
-def _entity_id(hass, platform: str, unique_id: str) -> str:
-    entity_id = er.async_get(hass).async_get_entity_id(platform, DOMAIN, unique_id)
-    assert entity_id is not None, f"no {platform} entity registered for {unique_id!r}"
-    return entity_id
 
 
 async def test_thermostat_entity_reflects_client_data(hass, fake_manager):

--- a/tests_ha/test_sensor.py
+++ b/tests_ha/test_sensor.py
@@ -8,6 +8,7 @@ slugified entity_ids.
 from __future__ import annotations
 
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 
 from custom_components.lksystems.const import DOMAIN
 

--- a/tests_ha/test_sensor.py
+++ b/tests_ha/test_sensor.py
@@ -28,7 +28,7 @@ def _device_name(hass, identity: str) -> str:
 class TestArcSensorHasEntityName:
     """Only AbstractLkCubicSensor set has_entity_name - the Arc sensor/hub
     classes baked the device's own name into each entity's full name
-    string instead (issue #49)."""
+    string instead."""
 
     async def test_temperature_sensor_has_entity_name(self, hass, fake_manager):
         await setup_entry(hass, fake_manager)

--- a/tests_ha/test_sensor.py
+++ b/tests_ha/test_sensor.py
@@ -1,41 +1,22 @@
 """Tests for sensor.py entity naming.
 
-Exercises entity/device names against a real config-entry setup (see
-test_integration_setup.py's _setup_entry pattern), looking entities up by
-their unique_id via the entity registry rather than guessing slugified
-entity_ids.
+Exercises entity/device names against a real config-entry setup, looking
+entities up by their unique_id via the entity registry rather than
+guessing slugified entity_ids.
 """
 
 from __future__ import annotations
 
-from unittest.mock import patch
-
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
-from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.lksystems.const import DOMAIN
 
-from .conftest import HUB_IDENTITY, THERMOSTAT_MAC
-
-
-async def _setup_entry(hass, manager) -> MockConfigEntry:
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
-    )
-    entry.add_to_hass(hass)
-    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-    return entry
+from .conftest import HUB_IDENTITY, THERMOSTAT_MAC, entity_id, setup_entry
 
 
 def _entity_entry(hass, unique_id: str):
-    entity_id = er.async_get(hass).async_get_entity_id("sensor", DOMAIN, unique_id)
-    assert entity_id is not None, f"no sensor entity registered for {unique_id!r}"
-    return er.async_get(hass).async_get(entity_id)
+    return er.async_get(hass).async_get(entity_id(hass, "sensor", unique_id))
 
 
 def _device_name(hass, identity: str) -> str:
@@ -50,7 +31,7 @@ class TestArcSensorHasEntityName:
     string instead (issue #49)."""
 
     async def test_temperature_sensor_has_entity_name(self, hass, fake_manager):
-        await _setup_entry(hass, fake_manager)
+        await setup_entry(hass, fake_manager)
 
         entity = _entity_entry(hass, f"{DOMAIN}_{THERMOSTAT_MAC}_temperature")
 
@@ -58,7 +39,7 @@ class TestArcSensorHasEntityName:
         assert entity.original_name == "Temperature"
 
     async def test_device_name_excludes_the_entity_suffix(self, hass, fake_manager):
-        await _setup_entry(hass, fake_manager)
+        await setup_entry(hass, fake_manager)
         # Force the entity to be created before asserting on its device.
         _entity_entry(hass, f"{DOMAIN}_{THERMOSTAT_MAC}_temperature")
 
@@ -68,12 +49,12 @@ class TestArcSensorHasEntityName:
         """The visible name in the UI (device name + entity name) must stay
         the same as before has_entity_name was set - only the split
         between "device" and "entity" parts changes, not the text."""
-        await _setup_entry(hass, fake_manager)
-        entity_id = er.async_get(hass).async_get_entity_id(
-            "sensor", DOMAIN, f"{DOMAIN}_{THERMOSTAT_MAC}_temperature"
+        await setup_entry(hass, fake_manager)
+        temperature_entity_id = entity_id(
+            hass, "sensor", f"{DOMAIN}_{THERMOSTAT_MAC}_temperature"
         )
 
-        state = hass.states.get(entity_id)
+        state = hass.states.get(temperature_entity_id)
 
         assert state.attributes["friendly_name"] == "LK Living Room Temperature"
 
@@ -84,7 +65,7 @@ class TestArcHubHasEntityName:
     exercising the other branch of the friendly_name lookup."""
 
     async def test_status_sensor_has_entity_name(self, hass, fake_manager):
-        await _setup_entry(hass, fake_manager)
+        await setup_entry(hass, fake_manager)
 
         entity = _entity_entry(hass, f"{DOMAIN}_{HUB_IDENTITY}_status")
 
@@ -92,17 +73,15 @@ class TestArcHubHasEntityName:
         assert entity.original_name == "Status"
 
     async def test_device_name_excludes_the_entity_suffix(self, hass, fake_manager):
-        await _setup_entry(hass, fake_manager)
+        await setup_entry(hass, fake_manager)
         _entity_entry(hass, f"{DOMAIN}_{HUB_IDENTITY}_status")
 
         assert _device_name(hass, HUB_IDENTITY) == "Test Hub"
 
     async def test_friendly_name_is_unchanged_by_the_split(self, hass, fake_manager):
-        await _setup_entry(hass, fake_manager)
-        entity_id = er.async_get(hass).async_get_entity_id(
-            "sensor", DOMAIN, f"{DOMAIN}_{HUB_IDENTITY}_status"
-        )
+        await setup_entry(hass, fake_manager)
+        status_entity_id = entity_id(hass, "sensor", f"{DOMAIN}_{HUB_IDENTITY}_status")
 
-        state = hass.states.get(entity_id)
+        state = hass.states.get(status_entity_id)
 
         assert state.attributes["friendly_name"] == "Test Hub Status"

--- a/tests_ha/test_sensor.py
+++ b/tests_ha/test_sensor.py
@@ -1,0 +1,108 @@
+"""Tests for sensor.py entity naming.
+
+Exercises entity/device names against a real config-entry setup (see
+test_integration_setup.py's _setup_entry pattern), looking entities up by
+their unique_id via the entity registry rather than guessing slugified
+entity_ids.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.lksystems.const import DOMAIN
+
+from .conftest import HUB_IDENTITY, THERMOSTAT_MAC
+
+
+async def _setup_entry(hass, manager) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
+    )
+    entry.add_to_hass(hass)
+    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def _entity_entry(hass, unique_id: str):
+    entity_id = er.async_get(hass).async_get_entity_id("sensor", DOMAIN, unique_id)
+    assert entity_id is not None, f"no sensor entity registered for {unique_id!r}"
+    return er.async_get(hass).async_get(entity_id)
+
+
+def _device_name(hass, identity: str) -> str:
+    device = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, identity)})
+    assert device is not None, f"no device registered for identity {identity!r}"
+    return device.name
+
+
+class TestArcSensorHasEntityName:
+    """Only AbstractLkCubicSensor set has_entity_name - the Arc sensor/hub
+    classes baked the device's own name into each entity's full name
+    string instead (issue #49)."""
+
+    async def test_temperature_sensor_has_entity_name(self, hass, fake_manager):
+        await _setup_entry(hass, fake_manager)
+
+        entity = _entity_entry(hass, f"{DOMAIN}_{THERMOSTAT_MAC}_temperature")
+
+        assert entity.has_entity_name is True
+        assert entity.original_name == "Temperature"
+
+    async def test_device_name_excludes_the_entity_suffix(self, hass, fake_manager):
+        await _setup_entry(hass, fake_manager)
+        # Force the entity to be created before asserting on its device.
+        _entity_entry(hass, f"{DOMAIN}_{THERMOSTAT_MAC}_temperature")
+
+        assert _device_name(hass, THERMOSTAT_MAC) == "LK Living Room"
+
+    async def test_friendly_name_is_unchanged_by_the_split(self, hass, fake_manager):
+        """The visible name in the UI (device name + entity name) must stay
+        the same as before has_entity_name was set - only the split
+        between "device" and "entity" parts changes, not the text."""
+        await _setup_entry(hass, fake_manager)
+        entity_id = er.async_get(hass).async_get_entity_id(
+            "sensor", DOMAIN, f"{DOMAIN}_{THERMOSTAT_MAC}_temperature"
+        )
+
+        state = hass.states.get(entity_id)
+
+        assert state.attributes["friendly_name"] == "LK Living Room Temperature"
+
+
+class TestArcHubHasEntityName:
+    """The hub's own "Status" sensor has an explicit device_title["name"]
+    ("Test Hub" - see conftest) rather than falling back to a zone name,
+    exercising the other branch of the friendly_name lookup."""
+
+    async def test_status_sensor_has_entity_name(self, hass, fake_manager):
+        await _setup_entry(hass, fake_manager)
+
+        entity = _entity_entry(hass, f"{DOMAIN}_{HUB_IDENTITY}_status")
+
+        assert entity.has_entity_name is True
+        assert entity.original_name == "Status"
+
+    async def test_device_name_excludes_the_entity_suffix(self, hass, fake_manager):
+        await _setup_entry(hass, fake_manager)
+        _entity_entry(hass, f"{DOMAIN}_{HUB_IDENTITY}_status")
+
+        assert _device_name(hass, HUB_IDENTITY) == "Test Hub"
+
+    async def test_friendly_name_is_unchanged_by_the_split(self, hass, fake_manager):
+        await _setup_entry(hass, fake_manager)
+        entity_id = er.async_get(hass).async_get_entity_id(
+            "sensor", DOMAIN, f"{DOMAIN}_{HUB_IDENTITY}_status"
+        )
+
+        state = hass.states.get(entity_id)
+
+        assert state.attributes["friendly_name"] == "Test Hub Status"


### PR DESCRIPTION
Closes #49.

Only `AbstractLkCubicSensor` (`sensor.py`) set `_attr_has_entity_name = True`. The Arc hub/sensor entities and the climate thermostat entity baked the device's own name into each entity's full `_attr_name` string instead, so they showed up in the UI as one flat name rather than HA's modern "device name + entity name" split.

- **`LKArcSensorEntity` / `LKArcHubEntity`**: entity's own name is now just its suffix (e.g. "Temperature", "Status") with `has_entity_name = True`; the device name (friendly `device_title` name, zone-based fallback, or generic fallback) is set directly on `device_info` instead of being reconstructed by stripping the suffix back out of the concatenated name string. The resulting displayed name (device + entity) is unchanged from before - guard tests assert this byte-for-byte.
- **`LKThermostat`**: the only entity on its device, so per HA convention for a device's sole/primary entity, `_attr_name` is left as `None` (entity displays as just the device name).

**Visible change:** the thermostat's displayed name goes from e.g. "LK Living Room Thermostat" to "LK Living Room". This also fixes a latent inconsistency: when a thermostat device also has Arc sensor entities registered against the same device identity (which is normal - it's one physical device), the two naming schemes used to disagree on the device's own name, and identifiers-based device merging silently applied whichever was registered last. Both now agree.

TDD'd via new `tests_ha/test_sensor.py` and `tests_ha/test_climate.py`, confirmed RED before the `sensor.py`/`climate.py` changes. Full suite passes: 58/58 in `tests_ha/`, 25/25 in `tests/`.

**Heads up:** `tests_ha/test_sensor.py` is a new file also being added, independently, by the still-open #60 (`fix/issue-55-last-status-name`) - whichever of the two merges second will need a small rebase to combine both files' test classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)