### PR TITLE
Restore last-known state across HA restarts

### DIFF
--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from typing import TypedDict
-from datetime import timedelta
+from datetime import datetime, timedelta
 import asyncio
 import base64
 import json
@@ -213,6 +213,10 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         self._cubic_identity = None
         self._last_update_time = dt_util.now()
         self._entry_id = entry.entry_id
+        # Set on every successful update, left untouched on failure - lets
+        # restored entity state (issue #54) judge its own freshness across
+        # a restart. See restore.py.
+        self.last_successful_fetch: datetime | None = None
 
         # Initialize coordinator with update interval
         super().__init__(
@@ -774,6 +778,7 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                     resp["next_update_time"],
                 )
 
+                self.last_successful_fetch = dt_util.utcnow()
                 return resp
 
         except InvalidAuth as err:

--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -211,9 +211,9 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         self._update_interval_minutes = update_interval_minutes
         self._entry = entry
         self._cubic_identity = None
-        self._last_update_time = dt_util.now()
+        self._last_cloud_fetch_attempt = dt_util.now()
         self._entry_id = entry.entry_id
-        self.last_successful_fetch: datetime | None = None
+        self.last_successful_cloud_fetch: datetime | None = None
 
         # Initialize coordinator with update interval
         super().__init__(
@@ -381,9 +381,10 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
     async def _async_update_data(self) -> LkStructureResp:  # noqa: C901
         """Fetch the latest data from the source."""
         # Record update time at the beginning of update
-        self._last_update_time = dt_util.now()
+        self._last_cloud_fetch_attempt = dt_util.now()
         _LOGGER.info(
-            "Starting LK Systems data update at %s", self._last_update_time.isoformat()
+            "Starting LK Systems data update at %s",
+            self._last_cloud_fetch_attempt.isoformat(),
         )
 
         try:
@@ -454,9 +455,9 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                     "cubic_last_messurement": None,
                     "devices": [],
                     "device_details": {},  # Will store detailed information about each device
-                    "update_time": self._last_update_time.isoformat(),
+                    "update_time": self._last_cloud_fetch_attempt.isoformat(),
                     "next_update_time": (
-                        self._last_update_time + self.update_interval
+                        self._last_cloud_fetch_attempt + self.update_interval
                     ).isoformat(),
                 }
 
@@ -775,7 +776,7 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                     resp["next_update_time"],
                 )
 
-                self.last_successful_fetch = dt_util.utcnow()
+                self.last_successful_cloud_fetch = dt_util.utcnow()
                 return resp
 
         except InvalidAuth as err:

--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -213,9 +213,6 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         self._cubic_identity = None
         self._last_update_time = dt_util.now()
         self._entry_id = entry.entry_id
-        # Set on every successful update, left untouched on failure - lets
-        # restored entity state (issue #54) judge its own freshness across
-        # a restart. See restore.py.
         self.last_successful_fetch: datetime | None = None
 
         # Initialize coordinator with update interval

--- a/custom_components/lksystems/climate.py
+++ b/custom_components/lksystems/climate.py
@@ -20,11 +20,14 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from homeassistant.util import dt as dt_util
 
 from . import LKSystemCoordinator
 from .const import DOMAIN, INTEGRATION_NAME
-from .restore import ATTR_LAST_SUCCESSFUL_FETCH, is_restored_value_fresh
+from .restore import (
+    is_restored_value_fresh,
+    last_successful_fetch_attributes,
+    parse_restored_last_fetch,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -177,9 +180,7 @@ class LKThermostat(CoordinatorEntity, RestoreEntity, ClimateEntity):
         self._restored_target_temperature = last_state.attributes.get(
             ATTR_TEMPERATURE
         )
-        last_fetch = last_state.attributes.get(ATTR_LAST_SUCCESSFUL_FETCH)
-        if last_fetch:
-            self._restored_last_fetch = dt_util.parse_datetime(last_fetch)
+        self._restored_last_fetch = parse_restored_last_fetch(last_state)
 
     def _is_restore_fresh(self) -> bool:
         return is_restored_value_fresh(
@@ -306,11 +307,7 @@ class LKThermostat(CoordinatorEntity, RestoreEntity, ClimateEntity):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Expose the last-successful-fetch timestamp."""
-        if self.coordinator.last_successful_fetch is None:
-            return {}
-        return {
-            ATTR_LAST_SUCCESSFUL_FETCH: self.coordinator.last_successful_fetch.isoformat()
-        }
+        return last_successful_fetch_attributes(self.coordinator.last_successful_fetch)
     
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""

--- a/custom_components/lksystems/climate.py
+++ b/custom_components/lksystems/climate.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any, Optional
 
 from homeassistant.components.climate import (
+    ATTR_CURRENT_TEMPERATURE,
     ClimateEntity,
     ClimateEntityDescription,
     ClimateEntityFeature,
@@ -17,10 +18,13 @@ from homeassistant.const import ATTR_TEMPERATURE, UnitOfTemperature
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
 
 from . import LKSystemCoordinator
 from .const import DOMAIN, INTEGRATION_NAME
+from .restore import ATTR_LAST_SUCCESSFUL_FETCH, is_restored_value_fresh
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -96,7 +100,7 @@ async def async_setup_entry(
         _LOGGER.debug(f"Added {len(entities)} LK Systems climate entities")
 
 
-class LKThermostat(CoordinatorEntity, ClimateEntity):
+class LKThermostat(CoordinatorEntity, RestoreEntity, ClimateEntity):
     """LK Systems thermostat climate entity."""
 
     _attr_temperature_unit = UnitOfTemperature.CELSIUS
@@ -154,7 +158,37 @@ class LKThermostat(CoordinatorEntity, ClimateEntity):
         
         self._attr_device_info = DeviceInfo(**device_info)
         self._attr_hvac_mode = HVACMode.HEAT
-    
+
+        # Restored from the entity's state as of before an HA restart -
+        # see restore.py. Only used as a fallback when the coordinator
+        # doesn't currently have live data for this entity.
+        self._restored_current_temperature = None
+        self._restored_target_temperature = None
+        self._restored_last_fetch = None
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last-known temperatures across an HA restart (issue #54)."""
+        await super().async_added_to_hass()
+
+        last_state = await self.async_get_last_state()
+        if last_state is None:
+            return
+
+        self._restored_current_temperature = last_state.attributes.get(
+            ATTR_CURRENT_TEMPERATURE
+        )
+        self._restored_target_temperature = last_state.attributes.get(
+            ATTR_TEMPERATURE
+        )
+        last_fetch = last_state.attributes.get(ATTR_LAST_SUCCESSFUL_FETCH)
+        if last_fetch:
+            self._restored_last_fetch = dt_util.parse_datetime(last_fetch)
+
+    def _is_restore_fresh(self) -> bool:
+        return is_restored_value_fresh(
+            self._restored_last_fetch, self.coordinator.update_interval
+        )
+
     @property
     def available(self) -> bool:
         """Return if entity is available."""
@@ -182,7 +216,17 @@ class LKThermostat(CoordinatorEntity, ClimateEntity):
     
     @property
     def current_temperature(self) -> Optional[float]:
-        """Return the current temperature."""
+        """Return the current temperature, falling back to the
+        last-restored value (issue #54) if there's no live one."""
+        value = self._live_current_temperature()
+        if value is not None:
+            return value
+        if self._is_restore_fresh():
+            return self._restored_current_temperature
+        return None
+
+    def _live_current_temperature(self) -> Optional[float]:
+        """Return the current temperature from the coordinator's live data."""
         # Find the most recent temperature data
         for device in self.coordinator.data.get("devices", []):
             device_title = device.get("deviceTitle", {})
@@ -210,7 +254,17 @@ class LKThermostat(CoordinatorEntity, ClimateEntity):
     
     @property
     def target_temperature(self) -> Optional[float]:
-        """Return the target temperature."""
+        """Return the target temperature, falling back to the
+        last-restored value (issue #54) if there's no live one."""
+        value = self._live_target_temperature()
+        if value is not None:
+            return value
+        if self._is_restore_fresh():
+            return self._restored_target_temperature
+        return None
+
+    def _live_target_temperature(self) -> Optional[float]:
+        """Return the target temperature from the coordinator's live data."""
         # Find the most recent temperature data
         for device in self.coordinator.data.get("devices", []):
             device_title = device.get("deviceTitle", {})
@@ -249,8 +303,18 @@ class LKThermostat(CoordinatorEntity, ClimateEntity):
                 return HVACAction.HEATING
             else:
                 return HVACAction.IDLE
-                
+
         return None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose the last-successful-fetch timestamp for freshness
+        (issue #54) - see restore.py."""
+        if self.coordinator.last_successful_fetch is None:
+            return {}
+        return {
+            ATTR_LAST_SUCCESSFUL_FETCH: self.coordinator.last_successful_fetch.isoformat()
+        }
     
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""

--- a/custom_components/lksystems/climate.py
+++ b/custom_components/lksystems/climate.py
@@ -25,8 +25,8 @@ from . import LKSystemCoordinator
 from .const import DOMAIN, INTEGRATION_NAME
 from .restore import (
     is_restored_value_fresh,
-    last_successful_fetch_attributes,
-    parse_restored_last_fetch,
+    last_successful_cloud_fetch_attributes,
+    parse_restored_last_cloud_fetch,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -164,7 +164,7 @@ class LKThermostat(CoordinatorEntity, RestoreEntity, ClimateEntity):
 
         self._restored_current_temperature = None
         self._restored_target_temperature = None
-        self._restored_last_fetch = None
+        self._restored_last_cloud_fetch = None
 
     async def async_added_to_hass(self) -> None:
         """Restore the last-known temperatures across an HA restart."""
@@ -180,11 +180,11 @@ class LKThermostat(CoordinatorEntity, RestoreEntity, ClimateEntity):
         self._restored_target_temperature = last_state.attributes.get(
             ATTR_TEMPERATURE
         )
-        self._restored_last_fetch = parse_restored_last_fetch(last_state)
+        self._restored_last_cloud_fetch = parse_restored_last_cloud_fetch(last_state)
 
     def _is_restore_fresh(self) -> bool:
         return is_restored_value_fresh(
-            self._restored_last_fetch, self.coordinator.update_interval
+            self._restored_last_cloud_fetch, self.coordinator.update_interval
         )
 
     @property
@@ -306,8 +306,10 @@ class LKThermostat(CoordinatorEntity, RestoreEntity, ClimateEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Expose the last-successful-fetch timestamp."""
-        return last_successful_fetch_attributes(self.coordinator.last_successful_fetch)
+        """Expose the last-successful-cloud-fetch timestamp."""
+        return last_successful_cloud_fetch_attributes(
+            self.coordinator.last_successful_cloud_fetch
+        )
     
     async def async_set_temperature(self, **kwargs) -> None:
         """Set new target temperature."""

--- a/custom_components/lksystems/climate.py
+++ b/custom_components/lksystems/climate.py
@@ -159,15 +159,12 @@ class LKThermostat(CoordinatorEntity, RestoreEntity, ClimateEntity):
         self._attr_device_info = DeviceInfo(**device_info)
         self._attr_hvac_mode = HVACMode.HEAT
 
-        # Restored from the entity's state as of before an HA restart -
-        # see restore.py. Only used as a fallback when the coordinator
-        # doesn't currently have live data for this entity.
         self._restored_current_temperature = None
         self._restored_target_temperature = None
         self._restored_last_fetch = None
 
     async def async_added_to_hass(self) -> None:
-        """Restore the last-known temperatures across an HA restart (issue #54)."""
+        """Restore the last-known temperatures across an HA restart."""
         await super().async_added_to_hass()
 
         last_state = await self.async_get_last_state()
@@ -217,7 +214,7 @@ class LKThermostat(CoordinatorEntity, RestoreEntity, ClimateEntity):
     @property
     def current_temperature(self) -> Optional[float]:
         """Return the current temperature, falling back to the
-        last-restored value (issue #54) if there's no live one."""
+        last-restored value if there's no live one."""
         value = self._live_current_temperature()
         if value is not None:
             return value
@@ -255,7 +252,7 @@ class LKThermostat(CoordinatorEntity, RestoreEntity, ClimateEntity):
     @property
     def target_temperature(self) -> Optional[float]:
         """Return the target temperature, falling back to the
-        last-restored value (issue #54) if there's no live one."""
+        last-restored value if there's no live one."""
         value = self._live_target_temperature()
         if value is not None:
             return value
@@ -308,8 +305,7 @@ class LKThermostat(CoordinatorEntity, RestoreEntity, ClimateEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Expose the last-successful-fetch timestamp for freshness
-        (issue #54) - see restore.py."""
+        """Expose the last-successful-fetch timestamp."""
         if self.coordinator.last_successful_fetch is None:
             return {}
         return {

--- a/custom_components/lksystems/const.py
+++ b/custom_components/lksystems/const.py
@@ -111,7 +111,6 @@ LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement=None,
         state_class=None,
         translation_key="last_status_sensor",
-        entity_registry_enabled_default=False,
     ),
     "cacheUpdated": SensorEntityDescription(
         key="cacheUpdated",

--- a/custom_components/lksystems/const.py
+++ b/custom_components/lksystems/const.py
@@ -7,6 +7,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
+from homeassistant.const import EntityCategory
 
 DOMAIN = "lksystems"
 INTEGRATION_NAME = "LK Systems"
@@ -68,6 +69,7 @@ LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement="°C",
         state_class=SensorStateClass.MEASUREMENT,
         translation_key="temp_water_min_sensor",
+        entity_registry_enabled_default=False,
     ),
     "tempWaterMax": SensorEntityDescription(
         key="tempWaterMax",
@@ -78,6 +80,7 @@ LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement="°C",
         state_class=SensorStateClass.MEASUREMENT,
         translation_key="temp_water_max_sensor",
+        entity_registry_enabled_default=False,
     ),
     "waterPressure": SensorEntityDescription(
         key="waterPressure",
@@ -108,6 +111,7 @@ LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement=None,
         state_class=None,
         translation_key="last_status_sensor",
+        entity_registry_enabled_default=False,
     ),
     "cacheUpdated": SensorEntityDescription(
         key="cacheUpdated",
@@ -118,6 +122,7 @@ LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement=None,
         state_class=None,
         translation_key="cache_updated_sensor",
+        entity_registry_enabled_default=False,
     ),
     "leak.leakState": SensorEntityDescription(
         key="leak.leakState",
@@ -138,6 +143,7 @@ LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement="L/h",
         state_class=SensorStateClass.MEASUREMENT,
         translation_key="leak_mean_flow_sensor",
+        entity_registry_enabled_default=False,
     ),
     "leak.dateStartedAt": SensorEntityDescription(
         key="leak.dateStartedAt",
@@ -148,6 +154,7 @@ LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement=None,
         state_class=None,
         translation_key="leak_date_started_at_sensor",
+        entity_registry_enabled_default=False,
     ),
     "leak.dateUpdatedAt": SensorEntityDescription(
         key="leak.dateUpdatedAt",
@@ -158,6 +165,7 @@ LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement=None,
         state_class=None,
         translation_key="leak_date_updated_at_sensor",
+        entity_registry_enabled_default=False,
     ),
     "leak.acknowledged": SensorEntityDescription(
         key="leak.acknowledged",
@@ -168,6 +176,7 @@ LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement=None,
         state_class=None,
         translation_key="leak_acknowledged_sensor",
+        entity_registry_enabled_default=False,
     ),
 }
 LK_CUBICSECURE_CONFIG_SENSORS: dict[str, SensorEntityDescription] = {
@@ -190,6 +199,7 @@ LK_CUBICSECURE_CONFIG_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement=None,
         state_class=None,
         translation_key="firmware_version_sensor",
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "hardwareVersion": SensorEntityDescription(
         key="hardwareVersion",
@@ -200,5 +210,6 @@ LK_CUBICSECURE_CONFIG_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement=None,
         state_class=None,
         translation_key="hardware_version_sensor",
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
 }

--- a/custom_components/lksystems/const.py
+++ b/custom_components/lksystems/const.py
@@ -13,8 +13,8 @@ INTEGRATION_NAME = "LK Systems"
 ATTRIBUTION = "Data provided by LK Systems API"
 MANUFACTURER = "LK Systems"
 
-C_NEXT_UPDATE_TIME = "next_update"
-C_UPDATE_TIME = "last_update"
+C_NEXT_UPDATE_TIME = "next_cloud_fetch_attempt"
+C_UPDATE_TIME = "last_cloud_fetch_attempt"
 
 CUBIC_SECURE_MODEL = "Cubic Secure"
 

--- a/custom_components/lksystems/restore.py
+++ b/custom_components/lksystems/restore.py
@@ -1,0 +1,41 @@
+"""Restore-last-known-state helpers shared by every entity (issue #54).
+
+Every entity restores its last value uniformly across a Home Assistant
+restart. The coordinator's own in-memory fallback (see __init__.py's
+per-cubic-device fetch/fallback) only survives within a running process -
+coordinator.data starts as None on a fresh start, so the very first poll
+after a restart has nothing to fall back to on its own, and every affected
+entity shows unknown even though HA knew a perfectly good value seconds
+before the restart.
+
+A restored value is only shown while "fresh enough" - see
+is_restored_value_fresh(). During normal steady-state polling a value can
+already be up to one update_interval stale before the next poll catches
+up, and it's shown with full confidence the whole time; a typical restart
+produces a younger value than that (DataUpdateCoordinator's first refresh
+fires immediately on setup). The real risk is the tail: a value restored
+from disk has no ceiling on its age the way live polling does, so a real
+outage (HA/the network down for an hour, a day) must not be presented
+looking exactly as fresh as one from moments ago. STALE_THRESHOLD_MULTIPLIER
+draws that line at a small multiple of update_interval - beyond it, the
+restored value is discarded rather than shown.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+
+from homeassistant.util import dt as dt_util
+
+ATTR_LAST_SUCCESSFUL_FETCH = "last_successful_fetch"
+
+STALE_THRESHOLD_MULTIPLIER = 3
+
+
+def is_restored_value_fresh(
+    restored_last_fetch: datetime | None, update_interval: timedelta | None
+) -> bool:
+    """Return whether a value restored from disk is still fresh enough to show."""
+    if restored_last_fetch is None or update_interval is None:
+        return False
+    return dt_util.utcnow() - restored_last_fetch <= update_interval * STALE_THRESHOLD_MULTIPLIER

--- a/custom_components/lksystems/restore.py
+++ b/custom_components/lksystems/restore.py
@@ -28,35 +28,45 @@ from typing import Any
 
 from homeassistant.util import dt as dt_util
 
-ATTR_LAST_SUCCESSFUL_FETCH = "last_successful_fetch"
+# "Cloud" distinguishes this from lastStatus/"Last Data Sent" (when the
+# *device* last sent LK's cloud data - a value we only relay) and from the
+# coordinator's own last_update_attempt_time (every poll attempt, whether
+# or not it succeeded) - this is specifically when *our own* last
+# successful fetch from LK's cloud API happened.
+ATTR_LAST_SUCCESSFUL_CLOUD_FETCH = "last_successful_cloud_fetch"
 
 STALE_THRESHOLD_MULTIPLIER = 3
 
 
 def is_restored_value_fresh(
-    restored_last_fetch: datetime | None, update_interval: timedelta | None
+    restored_last_cloud_fetch: datetime | None, update_interval: timedelta | None
 ) -> bool:
     """Return whether a value restored from disk is still fresh enough to show."""
-    if restored_last_fetch is None or update_interval is None:
+    if restored_last_cloud_fetch is None or update_interval is None:
         return False
-    return dt_util.utcnow() - restored_last_fetch <= update_interval * STALE_THRESHOLD_MULTIPLIER
+    return (
+        dt_util.utcnow() - restored_last_cloud_fetch
+        <= update_interval * STALE_THRESHOLD_MULTIPLIER
+    )
 
 
-def parse_restored_last_fetch(last_state) -> datetime | None:
-    """Parse ATTR_LAST_SUCCESSFUL_FETCH from a restored state's attributes."""
-    last_fetch = last_state.attributes.get(ATTR_LAST_SUCCESSFUL_FETCH)
+def parse_restored_last_cloud_fetch(last_state) -> datetime | None:
+    """Parse ATTR_LAST_SUCCESSFUL_CLOUD_FETCH from a restored state's attributes."""
+    last_fetch = last_state.attributes.get(ATTR_LAST_SUCCESSFUL_CLOUD_FETCH)
     if not last_fetch:
         return None
     return dt_util.parse_datetime(last_fetch)
 
 
-def last_successful_fetch_attributes(
-    last_successful_fetch: datetime | None,
+def last_successful_cloud_fetch_attributes(
+    last_successful_cloud_fetch: datetime | None,
 ) -> dict[str, str]:
-    """Return the extra_state_attributes payload exposing last_successful_fetch."""
-    if last_successful_fetch is None:
+    """Return the extra_state_attributes payload exposing last_successful_cloud_fetch."""
+    if last_successful_cloud_fetch is None:
         return {}
-    return {ATTR_LAST_SUCCESSFUL_FETCH: last_successful_fetch.isoformat()}
+    return {
+        ATTR_LAST_SUCCESSFUL_CLOUD_FETCH: last_successful_cloud_fetch.isoformat()
+    }
 
 
 class RestoredNativeValueMixin:
@@ -70,7 +80,7 @@ class RestoredNativeValueMixin:
     """
 
     _restored_native_value: Any = None
-    _restored_last_fetch: datetime | None = None
+    _restored_last_cloud_fetch: datetime | None = None
 
     async def async_added_to_hass(self) -> None:
         """Restore the last-known value across an HA restart."""
@@ -82,7 +92,9 @@ class RestoredNativeValueMixin:
 
         last_state = await self.async_get_last_state()
         if last_state is not None:
-            self._restored_last_fetch = parse_restored_last_fetch(last_state)
+            self._restored_last_cloud_fetch = parse_restored_last_cloud_fetch(
+                last_state
+            )
 
     @property
     def native_value(self) -> Any:
@@ -92,7 +104,7 @@ class RestoredNativeValueMixin:
         if value is not None:
             return value
         if is_restored_value_fresh(
-            self._restored_last_fetch, self.coordinator.update_interval
+            self._restored_last_cloud_fetch, self.coordinator.update_interval
         ):
             return self._restored_native_value
         return None

--- a/custom_components/lksystems/restore.py
+++ b/custom_components/lksystems/restore.py
@@ -1,4 +1,4 @@
-"""Restore-last-known-state helpers shared by every entity (issue #54).
+"""Restore-last-known-state helpers shared by every entity.
 
 Every entity restores its last value uniformly across a Home Assistant
 restart. The coordinator's own in-memory fallback (see __init__.py's

--- a/custom_components/lksystems/restore.py
+++ b/custom_components/lksystems/restore.py
@@ -24,6 +24,7 @@ restored value is discarded rather than shown.
 from __future__ import annotations
 
 from datetime import datetime, timedelta
+from typing import Any
 
 from homeassistant.util import dt as dt_util
 
@@ -39,3 +40,59 @@ def is_restored_value_fresh(
     if restored_last_fetch is None or update_interval is None:
         return False
     return dt_util.utcnow() - restored_last_fetch <= update_interval * STALE_THRESHOLD_MULTIPLIER
+
+
+def parse_restored_last_fetch(last_state) -> datetime | None:
+    """Parse ATTR_LAST_SUCCESSFUL_FETCH from a restored state's attributes."""
+    last_fetch = last_state.attributes.get(ATTR_LAST_SUCCESSFUL_FETCH)
+    if not last_fetch:
+        return None
+    return dt_util.parse_datetime(last_fetch)
+
+
+def last_successful_fetch_attributes(
+    last_successful_fetch: datetime | None,
+) -> dict[str, str]:
+    """Return the extra_state_attributes payload exposing last_successful_fetch."""
+    if last_successful_fetch is None:
+        return {}
+    return {ATTR_LAST_SUCCESSFUL_FETCH: last_successful_fetch.isoformat()}
+
+
+class RestoredNativeValueMixin:
+    """Restore a sensor's last-known native value uniformly across an HA restart.
+
+    Mixed in ahead of CoordinatorEntity and RestoreSensor, whose
+    self.coordinator and async_get_last_sensor_data()/async_get_last_state()
+    this relies on. Subclasses supply the live lookup via _live_native_value();
+    this then owns the fallback to the restored value once that comes back
+    empty.
+    """
+
+    _restored_native_value: Any = None
+    _restored_last_fetch: datetime | None = None
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last-known value across an HA restart."""
+        await super().async_added_to_hass()
+
+        last_sensor_data = await self.async_get_last_sensor_data()
+        if last_sensor_data is not None:
+            self._restored_native_value = last_sensor_data.native_value
+
+        last_state = await self.async_get_last_state()
+        if last_state is not None:
+            self._restored_last_fetch = parse_restored_last_fetch(last_state)
+
+    @property
+    def native_value(self) -> Any:
+        """Return the live value, falling back to the last-restored value
+        if the coordinator doesn't currently have one."""
+        value = self._live_native_value()
+        if value is not None:
+            return value
+        if is_restored_value_fresh(
+            self._restored_last_fetch, self.coordinator.update_interval
+        ):
+            return self._restored_native_value
+        return None

--- a/custom_components/lksystems/sensor.py
+++ b/custom_components/lksystems/sensor.py
@@ -6,6 +6,7 @@ import logging
 from typing import Any, Dict, Optional
 
 from homeassistant.components.sensor import (
+    RestoreSensor,
     SensorDeviceClass,
     SensorEntity,
     SensorEntityDescription,
@@ -38,6 +39,7 @@ from .const import (
     LK_CUBICSECURE_CONFIG_SENSORS,
     MANUFACTURER,
 )
+from .restore import ATTR_LAST_SUCCESSFUL_FETCH, is_restored_value_fresh
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -386,7 +388,7 @@ async def async_setup_entry(
         _LOGGER.debug("Added %d sensor entities", len(sensor_entities))
 
 
-class LKArcSensorEntity(CoordinatorEntity, SensorEntity):
+class LKArcSensorEntity(CoordinatorEntity, RestoreSensor):
     """Representation of an LK Systems sensor entity."""
 
     def __init__(
@@ -471,6 +473,34 @@ class LKArcSensorEntity(CoordinatorEntity, SensorEntity):
 
         self._attr_device_info = DeviceInfo(**device_info)
 
+        # Restored from the entity's state as of before an HA restart -
+        # see restore.py. Only used as a fallback when the coordinator
+        # doesn't currently have a live value for this entity.
+        self._restored_native_value = None
+        self._restored_last_fetch = None
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last-known value across an HA restart (issue #54)."""
+        await super().async_added_to_hass()
+
+        last_sensor_data = await self.async_get_last_sensor_data()
+        if last_sensor_data is not None:
+            self._restored_native_value = last_sensor_data.native_value
+
+        last_state = await self.async_get_last_state()
+        if last_state is not None:
+            last_fetch = last_state.attributes.get(ATTR_LAST_SUCCESSFUL_FETCH)
+            if last_fetch:
+                self._restored_last_fetch = dt_util.parse_datetime(last_fetch)
+
+    def _restored_value_if_fresh(self):
+        """Return the restored value, or None if there isn't one or it's stale."""
+        if is_restored_value_fresh(
+            self._restored_last_fetch, self.coordinator.update_interval
+        ):
+            return self._restored_native_value
+        return None
+
     @property
     def available(self) -> bool:
         """Return if entity is available."""
@@ -512,7 +542,15 @@ class LKArcSensorEntity(CoordinatorEntity, SensorEntity):
 
     @property
     def native_value(self) -> Any:
-        """Return the value of the sensor."""
+        """Return the value of the sensor, falling back to the last-restored
+        value (issue #54) if the coordinator doesn't currently have one."""
+        value = self._live_native_value()
+        if value is not None:
+            return value
+        return self._restored_value_if_fresh()
+
+    def _live_native_value(self) -> Any:
+        """Return the value of the sensor from the coordinator's live data."""
         # First check device_details for the most up-to-date information
         if "device_details" in self.coordinator.data:
             device_details = self.coordinator.data["device_details"].get(
@@ -710,10 +748,17 @@ class LKArcSensorEntity(CoordinatorEntity, SensorEntity):
         # Add refresh button attribute with a timestamp to force UI refresh
         attrs["refresh_timestamp"] = dt_util.now().timestamp()
 
+        # So a value shown after an HA restart can judge its own freshness
+        # (issue #54) - see restore.py.
+        if self.coordinator.last_successful_fetch is not None:
+            attrs[ATTR_LAST_SUCCESSFUL_FETCH] = (
+                self.coordinator.last_successful_fetch.isoformat()
+            )
+
         return attrs
 
 
-class LKArcHubEntity(CoordinatorEntity, SensorEntity):
+class LKArcHubEntity(CoordinatorEntity, RestoreSensor):
     """Representation of an LK Systems ARC Hub entity."""
 
     def __init__(
@@ -778,6 +823,34 @@ class LKArcHubEntity(CoordinatorEntity, SensorEntity):
 
         self._attr_device_info = DeviceInfo(**device_info)
 
+        # Restored from the entity's state as of before an HA restart -
+        # see restore.py. Only used as a fallback when the coordinator
+        # doesn't currently have a live value for this entity.
+        self._restored_native_value = None
+        self._restored_last_fetch = None
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last-known value across an HA restart (issue #54)."""
+        await super().async_added_to_hass()
+
+        last_sensor_data = await self.async_get_last_sensor_data()
+        if last_sensor_data is not None:
+            self._restored_native_value = last_sensor_data.native_value
+
+        last_state = await self.async_get_last_state()
+        if last_state is not None:
+            last_fetch = last_state.attributes.get(ATTR_LAST_SUCCESSFUL_FETCH)
+            if last_fetch:
+                self._restored_last_fetch = dt_util.parse_datetime(last_fetch)
+
+    def _restored_value_if_fresh(self):
+        """Return the restored value, or None if there isn't one or it's stale."""
+        if is_restored_value_fresh(
+            self._restored_last_fetch, self.coordinator.update_interval
+        ):
+            return self._restored_native_value
+        return None
+
     @property
     def device_class(self) -> Optional[str]:
         """Return the device class."""
@@ -785,7 +858,15 @@ class LKArcHubEntity(CoordinatorEntity, SensorEntity):
 
     @property
     def native_value(self) -> Any:
-        """Return the value of the sensor."""
+        """Return the value of the sensor, falling back to the last-restored
+        value (issue #54) if the coordinator doesn't currently have one."""
+        value = self._live_native_value()
+        if value is not None:
+            return value
+        return self._restored_value_if_fresh()
+
+    def _live_native_value(self) -> Any:
+        """Return the value of the sensor from the coordinator's live data."""
         # First check the device_details dictionary which has the most up-to-date information
         if "device_details" in self.coordinator.data:
             device_details = self.coordinator.data["device_details"].get(
@@ -844,8 +925,18 @@ class LKArcHubEntity(CoordinatorEntity, SensorEntity):
         """Handle updated data from the coordinator."""
         self.async_write_ha_state()
 
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose the last-successful-fetch timestamp for freshness
+        (issue #54) - see restore.py."""
+        if self.coordinator.last_successful_fetch is None:
+            return {}
+        return {
+            ATTR_LAST_SUCCESSFUL_FETCH: self.coordinator.last_successful_fetch.isoformat()
+        }
 
-class AbstractLkCubicSensor(CoordinatorEntity[LKSystemCoordinator], SensorEntity):
+
+class AbstractLkCubicSensor(CoordinatorEntity[LKSystemCoordinator], RestoreSensor):
     """Abstract class for an LK Cubic secure sensor."""
 
     _attr_attribution = ATTRIBUTION
@@ -869,6 +960,33 @@ class AbstractLkCubicSensor(CoordinatorEntity[LKSystemCoordinator], SensorEntity
         self.native_unit_of_measurement = description.native_unit_of_measurement
         self._attr_unique_id = f"LkUid_{description.key}_{coordinator.data['cubic_machine_info']['identity']}"
         self._attr_extra_state_attributes = {}
+        # Restored from the entity's state as of before an HA restart -
+        # see restore.py. Only used as a fallback when the coordinator
+        # doesn't currently have a live value for this entity.
+        self._restored_native_value = None
+        self._restored_last_fetch = None
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last-known value across an HA restart (issue #54)."""
+        await super().async_added_to_hass()
+
+        last_sensor_data = await self.async_get_last_sensor_data()
+        if last_sensor_data is not None:
+            self._restored_native_value = last_sensor_data.native_value
+
+        last_state = await self.async_get_last_state()
+        if last_state is not None:
+            last_fetch = last_state.attributes.get(ATTR_LAST_SUCCESSFUL_FETCH)
+            if last_fetch:
+                self._restored_last_fetch = dt_util.parse_datetime(last_fetch)
+
+    def _restored_value_if_fresh(self):
+        """Return the restored value, or None if there isn't one or it's stale."""
+        if is_restored_value_fresh(
+            self._restored_last_fetch, self.coordinator.update_interval
+        ):
+            return self._restored_native_value
+        return None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -908,6 +1026,7 @@ class LKCubicSensor(AbstractLkCubicSensor):
             self._attr_extra_state_attributes.update(
                 {C_NEXT_UPDATE_TIME: self._coordinator.data["next_update_time"]}
             )
+        self._update_last_successful_fetch_attribute()
         self._attr_available = False
 
     async def async_update(self) -> None:
@@ -925,11 +1044,26 @@ class LKCubicSensor(AbstractLkCubicSensor):
             self._attr_extra_state_attributes.update(
                 {C_NEXT_UPDATE_TIME: self._coordinator.data["next_update_time"]}
             )
+        self._update_last_successful_fetch_attribute()
         super()._handle_coordinator_update()
+
+    def _update_last_successful_fetch_attribute(self) -> None:
+        if self.coordinator.last_successful_fetch is not None:
+            self._attr_extra_state_attributes[ATTR_LAST_SUCCESSFUL_FETCH] = (
+                self.coordinator.last_successful_fetch.isoformat()
+            )
 
     @property
     def native_value(self) -> Any | None:
-        """Get the latest state value."""
+        """Get the latest state value, falling back to the last-restored
+        value (issue #54) if the coordinator doesn't currently have one."""
+        value = self._live_native_value()
+        if value is not None:
+            return value
+        return self._restored_value_if_fresh()
+
+    def _live_native_value(self) -> Any | None:
+        """Get the latest state value from the coordinator's live data."""
         value = None
 
         if self._data_source == "configuration":

--- a/custom_components/lksystems/sensor.py
+++ b/custom_components/lksystems/sensor.py
@@ -39,7 +39,7 @@ from .const import (
     LK_CUBICSECURE_CONFIG_SENSORS,
     MANUFACTURER,
 )
-from .restore import ATTR_LAST_SUCCESSFUL_FETCH, is_restored_value_fresh
+from .restore import RestoredNativeValueMixin, last_successful_fetch_attributes
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -388,7 +388,7 @@ async def async_setup_entry(
         _LOGGER.debug("Added %d sensor entities", len(sensor_entities))
 
 
-class LKArcSensorEntity(CoordinatorEntity, RestoreSensor):
+class LKArcSensorEntity(RestoredNativeValueMixin, CoordinatorEntity, RestoreSensor):
     """Representation of an LK Systems sensor entity."""
 
     def __init__(
@@ -473,31 +473,6 @@ class LKArcSensorEntity(CoordinatorEntity, RestoreSensor):
 
         self._attr_device_info = DeviceInfo(**device_info)
 
-        self._restored_native_value = None
-        self._restored_last_fetch = None
-
-    async def async_added_to_hass(self) -> None:
-        """Restore the last-known value across an HA restart."""
-        await super().async_added_to_hass()
-
-        last_sensor_data = await self.async_get_last_sensor_data()
-        if last_sensor_data is not None:
-            self._restored_native_value = last_sensor_data.native_value
-
-        last_state = await self.async_get_last_state()
-        if last_state is not None:
-            last_fetch = last_state.attributes.get(ATTR_LAST_SUCCESSFUL_FETCH)
-            if last_fetch:
-                self._restored_last_fetch = dt_util.parse_datetime(last_fetch)
-
-    def _restored_value_if_fresh(self):
-        """Return the restored value, or None if there isn't one or it's stale."""
-        if is_restored_value_fresh(
-            self._restored_last_fetch, self.coordinator.update_interval
-        ):
-            return self._restored_native_value
-        return None
-
     @property
     def available(self) -> bool:
         """Return if entity is available."""
@@ -536,15 +511,6 @@ class LKArcSensorEntity(CoordinatorEntity, RestoreSensor):
     def native_unit_of_measurement(self) -> Optional[str]:
         """Return the unit of measurement."""
         return self._attr_unit_of_measurement
-
-    @property
-    def native_value(self) -> Any:
-        """Return the value of the sensor, falling back to the last-restored
-        value if the coordinator doesn't currently have one."""
-        value = self._live_native_value()
-        if value is not None:
-            return value
-        return self._restored_value_if_fresh()
 
     def _live_native_value(self) -> Any:
         """Return the value of the sensor from the coordinator's live data."""
@@ -745,15 +711,12 @@ class LKArcSensorEntity(CoordinatorEntity, RestoreSensor):
         # Add refresh button attribute with a timestamp to force UI refresh
         attrs["refresh_timestamp"] = dt_util.now().timestamp()
 
-        if self.coordinator.last_successful_fetch is not None:
-            attrs[ATTR_LAST_SUCCESSFUL_FETCH] = (
-                self.coordinator.last_successful_fetch.isoformat()
-            )
+        attrs.update(last_successful_fetch_attributes(self.coordinator.last_successful_fetch))
 
         return attrs
 
 
-class LKArcHubEntity(CoordinatorEntity, RestoreSensor):
+class LKArcHubEntity(RestoredNativeValueMixin, CoordinatorEntity, RestoreSensor):
     """Representation of an LK Systems ARC Hub entity."""
 
     def __init__(
@@ -818,44 +781,10 @@ class LKArcHubEntity(CoordinatorEntity, RestoreSensor):
 
         self._attr_device_info = DeviceInfo(**device_info)
 
-        self._restored_native_value = None
-        self._restored_last_fetch = None
-
-    async def async_added_to_hass(self) -> None:
-        """Restore the last-known value across an HA restart."""
-        await super().async_added_to_hass()
-
-        last_sensor_data = await self.async_get_last_sensor_data()
-        if last_sensor_data is not None:
-            self._restored_native_value = last_sensor_data.native_value
-
-        last_state = await self.async_get_last_state()
-        if last_state is not None:
-            last_fetch = last_state.attributes.get(ATTR_LAST_SUCCESSFUL_FETCH)
-            if last_fetch:
-                self._restored_last_fetch = dt_util.parse_datetime(last_fetch)
-
-    def _restored_value_if_fresh(self):
-        """Return the restored value, or None if there isn't one or it's stale."""
-        if is_restored_value_fresh(
-            self._restored_last_fetch, self.coordinator.update_interval
-        ):
-            return self._restored_native_value
-        return None
-
     @property
     def device_class(self) -> Optional[str]:
         """Return the device class."""
         return self._device_class
-
-    @property
-    def native_value(self) -> Any:
-        """Return the value of the sensor, falling back to the last-restored
-        value if the coordinator doesn't currently have one."""
-        value = self._live_native_value()
-        if value is not None:
-            return value
-        return self._restored_value_if_fresh()
 
     def _live_native_value(self) -> Any:
         """Return the value of the sensor from the coordinator's live data."""
@@ -920,14 +849,12 @@ class LKArcHubEntity(CoordinatorEntity, RestoreSensor):
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Expose the last-successful-fetch timestamp."""
-        if self.coordinator.last_successful_fetch is None:
-            return {}
-        return {
-            ATTR_LAST_SUCCESSFUL_FETCH: self.coordinator.last_successful_fetch.isoformat()
-        }
+        return last_successful_fetch_attributes(self.coordinator.last_successful_fetch)
 
 
-class AbstractLkCubicSensor(CoordinatorEntity[LKSystemCoordinator], RestoreSensor):
+class AbstractLkCubicSensor(
+    RestoredNativeValueMixin, CoordinatorEntity[LKSystemCoordinator], RestoreSensor
+):
     """Abstract class for an LK Cubic secure sensor."""
 
     _attr_attribution = ATTRIBUTION
@@ -951,30 +878,6 @@ class AbstractLkCubicSensor(CoordinatorEntity[LKSystemCoordinator], RestoreSenso
         self.native_unit_of_measurement = description.native_unit_of_measurement
         self._attr_unique_id = f"LkUid_{description.key}_{coordinator.data['cubic_machine_info']['identity']}"
         self._attr_extra_state_attributes = {}
-        self._restored_native_value = None
-        self._restored_last_fetch = None
-
-    async def async_added_to_hass(self) -> None:
-        """Restore the last-known value across an HA restart."""
-        await super().async_added_to_hass()
-
-        last_sensor_data = await self.async_get_last_sensor_data()
-        if last_sensor_data is not None:
-            self._restored_native_value = last_sensor_data.native_value
-
-        last_state = await self.async_get_last_state()
-        if last_state is not None:
-            last_fetch = last_state.attributes.get(ATTR_LAST_SUCCESSFUL_FETCH)
-            if last_fetch:
-                self._restored_last_fetch = dt_util.parse_datetime(last_fetch)
-
-    def _restored_value_if_fresh(self):
-        """Return the restored value, or None if there isn't one or it's stale."""
-        if is_restored_value_fresh(
-            self._restored_last_fetch, self.coordinator.update_interval
-        ):
-            return self._restored_native_value
-        return None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -1036,19 +939,9 @@ class LKCubicSensor(AbstractLkCubicSensor):
         super()._handle_coordinator_update()
 
     def _update_last_successful_fetch_attribute(self) -> None:
-        if self.coordinator.last_successful_fetch is not None:
-            self._attr_extra_state_attributes[ATTR_LAST_SUCCESSFUL_FETCH] = (
-                self.coordinator.last_successful_fetch.isoformat()
-            )
-
-    @property
-    def native_value(self) -> Any | None:
-        """Get the latest state value, falling back to the last-restored
-        value if the coordinator doesn't currently have one."""
-        value = self._live_native_value()
-        if value is not None:
-            return value
-        return self._restored_value_if_fresh()
+        self._attr_extra_state_attributes.update(
+            last_successful_fetch_attributes(self.coordinator.last_successful_fetch)
+        )
 
     def _live_native_value(self) -> Any | None:
         """Get the latest state value from the coordinator's live data."""

--- a/custom_components/lksystems/sensor.py
+++ b/custom_components/lksystems/sensor.py
@@ -379,7 +379,7 @@ async def async_setup_entry(
                                 SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
                                 # Signal-strength diagnostics, not a reading
                                 # most users watch day-to-day - the textbook
-                                # HA case for opt-in-only (issue #57).
+                                # HA case for opt-in-only.
                                 entity_registry_enabled_default=False,
                             )
                         )

--- a/custom_components/lksystems/sensor.py
+++ b/custom_components/lksystems/sensor.py
@@ -473,14 +473,11 @@ class LKArcSensorEntity(CoordinatorEntity, RestoreSensor):
 
         self._attr_device_info = DeviceInfo(**device_info)
 
-        # Restored from the entity's state as of before an HA restart -
-        # see restore.py. Only used as a fallback when the coordinator
-        # doesn't currently have a live value for this entity.
         self._restored_native_value = None
         self._restored_last_fetch = None
 
     async def async_added_to_hass(self) -> None:
-        """Restore the last-known value across an HA restart (issue #54)."""
+        """Restore the last-known value across an HA restart."""
         await super().async_added_to_hass()
 
         last_sensor_data = await self.async_get_last_sensor_data()
@@ -543,7 +540,7 @@ class LKArcSensorEntity(CoordinatorEntity, RestoreSensor):
     @property
     def native_value(self) -> Any:
         """Return the value of the sensor, falling back to the last-restored
-        value (issue #54) if the coordinator doesn't currently have one."""
+        value if the coordinator doesn't currently have one."""
         value = self._live_native_value()
         if value is not None:
             return value
@@ -748,8 +745,6 @@ class LKArcSensorEntity(CoordinatorEntity, RestoreSensor):
         # Add refresh button attribute with a timestamp to force UI refresh
         attrs["refresh_timestamp"] = dt_util.now().timestamp()
 
-        # So a value shown after an HA restart can judge its own freshness
-        # (issue #54) - see restore.py.
         if self.coordinator.last_successful_fetch is not None:
             attrs[ATTR_LAST_SUCCESSFUL_FETCH] = (
                 self.coordinator.last_successful_fetch.isoformat()
@@ -823,14 +818,11 @@ class LKArcHubEntity(CoordinatorEntity, RestoreSensor):
 
         self._attr_device_info = DeviceInfo(**device_info)
 
-        # Restored from the entity's state as of before an HA restart -
-        # see restore.py. Only used as a fallback when the coordinator
-        # doesn't currently have a live value for this entity.
         self._restored_native_value = None
         self._restored_last_fetch = None
 
     async def async_added_to_hass(self) -> None:
-        """Restore the last-known value across an HA restart (issue #54)."""
+        """Restore the last-known value across an HA restart."""
         await super().async_added_to_hass()
 
         last_sensor_data = await self.async_get_last_sensor_data()
@@ -859,7 +851,7 @@ class LKArcHubEntity(CoordinatorEntity, RestoreSensor):
     @property
     def native_value(self) -> Any:
         """Return the value of the sensor, falling back to the last-restored
-        value (issue #54) if the coordinator doesn't currently have one."""
+        value if the coordinator doesn't currently have one."""
         value = self._live_native_value()
         if value is not None:
             return value
@@ -927,8 +919,7 @@ class LKArcHubEntity(CoordinatorEntity, RestoreSensor):
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Expose the last-successful-fetch timestamp for freshness
-        (issue #54) - see restore.py."""
+        """Expose the last-successful-fetch timestamp."""
         if self.coordinator.last_successful_fetch is None:
             return {}
         return {
@@ -960,14 +951,11 @@ class AbstractLkCubicSensor(CoordinatorEntity[LKSystemCoordinator], RestoreSenso
         self.native_unit_of_measurement = description.native_unit_of_measurement
         self._attr_unique_id = f"LkUid_{description.key}_{coordinator.data['cubic_machine_info']['identity']}"
         self._attr_extra_state_attributes = {}
-        # Restored from the entity's state as of before an HA restart -
-        # see restore.py. Only used as a fallback when the coordinator
-        # doesn't currently have a live value for this entity.
         self._restored_native_value = None
         self._restored_last_fetch = None
 
     async def async_added_to_hass(self) -> None:
-        """Restore the last-known value across an HA restart (issue #54)."""
+        """Restore the last-known value across an HA restart."""
         await super().async_added_to_hass()
 
         last_sensor_data = await self.async_get_last_sensor_data()
@@ -1056,7 +1044,7 @@ class LKCubicSensor(AbstractLkCubicSensor):
     @property
     def native_value(self) -> Any | None:
         """Get the latest state value, falling back to the last-restored
-        value (issue #54) if the coordinator doesn't currently have one."""
+        value if the coordinator doesn't currently have one."""
         value = self._live_native_value()
         if value is not None:
             return value

--- a/custom_components/lksystems/sensor.py
+++ b/custom_components/lksystems/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    EntityCategory,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     UnitOfTemperature,
@@ -376,6 +377,10 @@ async def async_setup_entry(
                                 SensorDeviceClass.SIGNAL_STRENGTH,
                                 SensorStateClass.MEASUREMENT,
                                 SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+                                # Signal-strength diagnostics, not a reading
+                                # most users watch day-to-day - the textbook
+                                # HA case for opt-in-only (issue #57).
+                                entity_registry_enabled_default=False,
                             )
                         )
                         created_entity_ids.add(entity_id)
@@ -399,6 +404,7 @@ class LKArcSensorEntity(CoordinatorEntity, SensorEntity):
         device_class: Optional[str] = None,
         state_class: Optional[str] = None,
         unit_of_measurement: Optional[str] = None,
+        entity_registry_enabled_default: bool = True,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
@@ -409,6 +415,7 @@ class LKArcSensorEntity(CoordinatorEntity, SensorEntity):
         self._attr_icon = icon
         self._attr_state_class = state_class
         self._attr_unit_of_measurement = unit_of_measurement
+        self._attr_entity_registry_enabled_default = entity_registry_enabled_default
 
         # Get device info
         device_title = device.get("deviceTitle", {})
@@ -715,6 +722,8 @@ class LKArcSensorEntity(CoordinatorEntity, SensorEntity):
 
 class LKArcHubEntity(CoordinatorEntity, SensorEntity):
     """Representation of an LK Systems ARC Hub entity."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
         self,

--- a/custom_components/lksystems/sensor.py
+++ b/custom_components/lksystems/sensor.py
@@ -39,7 +39,7 @@ from .const import (
     LK_CUBICSECURE_CONFIG_SENSORS,
     MANUFACTURER,
 )
-from .restore import RestoredNativeValueMixin, last_successful_fetch_attributes
+from .restore import RestoredNativeValueMixin, last_successful_cloud_fetch_attributes
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -694,24 +694,31 @@ class LKArcSensorEntity(RestoredNativeValueMixin, CoordinatorEntity, RestoreSens
             )
 
         # Add last update time
-        if self.coordinator and hasattr(self.coordinator, "_last_update_time"):
-            attrs["last_updated"] = self.coordinator._last_update_time.isoformat()
+        if self.coordinator and hasattr(self.coordinator, "_last_cloud_fetch_attempt"):
+            attrs["last_cloud_fetch_attempt"] = (
+                self.coordinator._last_cloud_fetch_attempt.isoformat()
+            )
 
         # Add next scheduled update time
         if (
             self.coordinator
             and hasattr(self.coordinator, "update_interval")
-            and hasattr(self.coordinator, "_last_update_time")
+            and hasattr(self.coordinator, "_last_cloud_fetch_attempt")
         ):
-            next_update = (
-                self.coordinator._last_update_time + self.coordinator.update_interval
+            next_cloud_fetch_attempt = (
+                self.coordinator._last_cloud_fetch_attempt
+                + self.coordinator.update_interval
             )
-            attrs["next_update"] = next_update.isoformat()
+            attrs["next_cloud_fetch_attempt"] = next_cloud_fetch_attempt.isoformat()
 
         # Add refresh button attribute with a timestamp to force UI refresh
         attrs["refresh_timestamp"] = dt_util.now().timestamp()
 
-        attrs.update(last_successful_fetch_attributes(self.coordinator.last_successful_fetch))
+        attrs.update(
+            last_successful_cloud_fetch_attributes(
+                self.coordinator.last_successful_cloud_fetch
+            )
+        )
 
         return attrs
 
@@ -848,8 +855,10 @@ class LKArcHubEntity(RestoredNativeValueMixin, CoordinatorEntity, RestoreSensor)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Expose the last-successful-fetch timestamp."""
-        return last_successful_fetch_attributes(self.coordinator.last_successful_fetch)
+        """Expose the last-successful-cloud-fetch timestamp."""
+        return last_successful_cloud_fetch_attributes(
+            self.coordinator.last_successful_cloud_fetch
+        )
 
 
 class AbstractLkCubicSensor(
@@ -917,7 +926,7 @@ class LKCubicSensor(AbstractLkCubicSensor):
             self._attr_extra_state_attributes.update(
                 {C_NEXT_UPDATE_TIME: self._coordinator.data["next_update_time"]}
             )
-        self._update_last_successful_fetch_attribute()
+        self._update_last_successful_cloud_fetch_attribute()
         self._attr_available = False
 
     async def async_update(self) -> None:
@@ -935,12 +944,14 @@ class LKCubicSensor(AbstractLkCubicSensor):
             self._attr_extra_state_attributes.update(
                 {C_NEXT_UPDATE_TIME: self._coordinator.data["next_update_time"]}
             )
-        self._update_last_successful_fetch_attribute()
+        self._update_last_successful_cloud_fetch_attribute()
         super()._handle_coordinator_update()
 
-    def _update_last_successful_fetch_attribute(self) -> None:
+    def _update_last_successful_cloud_fetch_attribute(self) -> None:
         self._attr_extra_state_attributes.update(
-            last_successful_fetch_attributes(self.coordinator.last_successful_fetch)
+            last_successful_cloud_fetch_attributes(
+                self.coordinator.last_successful_cloud_fetch
+            )
         )
 
     def _live_native_value(self) -> Any | None:

--- a/tests_ha/conftest.py
+++ b/tests_ha/conftest.py
@@ -17,8 +17,14 @@ from __future__ import annotations
 
 import asyncio
 import time
+from unittest.mock import patch
 
 import pytest
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.lksystems.const import DOMAIN
 
 pytest_plugins = "pytest_homeassistant_custom_component"
 
@@ -345,3 +351,32 @@ def fake_manager() -> FakeLKSystemsManager:
     manager = FakeLKSystemsManager()
     configure_fake_manager_with_sample_data(manager)
     return manager
+
+
+async def setup_entry(hass, manager: FakeLKSystemsManager) -> MockConfigEntry:
+    """Drive a real config-entry setup against a FakeLKSystemsManager.
+
+    Runs the coordinator's first refresh and both the sensor.py and
+    climate.py platforms' async_setup_entry() for real, so tests can inspect
+    the entities/entity registry they actually produce.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
+    )
+    entry.add_to_hass(hass)
+    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def entity_id(hass, platform: str, unique_id: str) -> str:
+    """Look up an entity_id by platform/unique_id via the entity registry.
+
+    Entities are looked up this way, rather than by guessing slugified
+    entity_ids, so tests don't depend on HA's naming/slugify rules.
+    """
+    found = er.async_get(hass).async_get_entity_id(platform, DOMAIN, unique_id)
+    assert found is not None, f"no {platform} entity registered for {unique_id!r}"
+    return found

--- a/tests_ha/test_climate.py
+++ b/tests_ha/test_climate.py
@@ -1,0 +1,129 @@
+"""Tests for climate.py's restore-last-known-state behavior (issue #54).
+
+See test_sensor.py's module docstring for the general testing pattern -
+climate has no RestoreSensor equivalent, so LKThermostat uses plain
+RestoreEntity and reads current_temperature/target_temperature back from
+the restored State's attributes instead of a typed native_value.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from homeassistant.components.climate import ATTR_CURRENT_TEMPERATURE
+from homeassistant.const import ATTR_TEMPERATURE, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import State
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    mock_restore_cache,
+)
+
+from custom_components.lksystems.climate import LKThermostat
+from custom_components.lksystems.const import DOMAIN
+from custom_components.lksystems.restore import ATTR_LAST_SUCCESSFUL_FETCH
+
+from .conftest import THERMOSTAT_MAC
+
+
+async def _setup_entry(hass, manager) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
+    )
+    entry.add_to_hass(hass)
+    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def _seed_restore_cache(
+    hass, entity_id: str, current_temperature: float, target_temperature: float, fetched_at
+) -> None:
+    mock_restore_cache(
+        hass,
+        [
+            State(
+                entity_id,
+                "heat",
+                {
+                    ATTR_CURRENT_TEMPERATURE: current_temperature,
+                    ATTR_TEMPERATURE: target_temperature,
+                    ATTR_LAST_SUCCESSFUL_FETCH: fetched_at.isoformat(),
+                },
+            )
+        ],
+    )
+
+
+def _thermostat_device(coordinator) -> dict:
+    return next(
+        d for d in coordinator.data["devices"] if d.get("mac") == THERMOSTAT_MAC
+    )
+
+
+def _clear_thermostat_live_measurement(coordinator) -> dict:
+    """See test_sensor.py's identically-named helper - native_value/here
+    current_temperature checks the devices list and hub_data; clearing the
+    devices-list entry's measurement is enough for the thermostat since,
+    unlike LKArcSensorEntity, it doesn't also consult device_details."""
+    device = _thermostat_device(coordinator)
+    device["measurement"] = {}
+    return device
+
+
+class TestThermostatRestore:
+    async def test_restores_temperatures_when_live_fetch_failed_and_fresh(
+        self, hass, fake_manager
+    ):
+        entity_id = "climate.test_restore_thermostat"
+        _seed_restore_cache(hass, entity_id, 19.5, 21.0, dt_util.utcnow())
+
+        entry = await _setup_entry(hass, fake_manager)
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+
+        device = _clear_thermostat_live_measurement(coordinator)
+        entity = LKThermostat(coordinator=coordinator, device=device)
+        entity.hass = hass
+        entity.entity_id = entity_id
+        await entity.async_added_to_hass()
+
+        assert entity.current_temperature == 19.5
+        assert entity.target_temperature == 21.0
+
+    async def test_ignores_a_stale_restored_value(self, hass, fake_manager):
+        entity_id = "climate.test_restore_thermostat"
+        stale = dt_util.utcnow() - timedelta(hours=1)
+        _seed_restore_cache(hass, entity_id, 19.5, 21.0, stale)
+
+        entry = await _setup_entry(hass, fake_manager)
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+
+        device = _clear_thermostat_live_measurement(coordinator)
+        entity = LKThermostat(coordinator=coordinator, device=device)
+        entity.hass = hass
+        entity.entity_id = entity_id
+        await entity.async_added_to_hass()
+
+        assert entity.current_temperature is None
+        assert entity.target_temperature is None
+
+    async def test_live_value_takes_priority_over_a_restored_one(
+        self, hass, fake_manager
+    ):
+        entity_id = "climate.test_restore_thermostat"
+        _seed_restore_cache(hass, entity_id, 1.1, 2.2, dt_util.utcnow())
+
+        entry = await _setup_entry(hass, fake_manager)
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+
+        # Live data is present this time - unlike the tests above.
+        entity = LKThermostat(coordinator=coordinator, device=_thermostat_device(coordinator))
+        entity.hass = hass
+        entity.entity_id = entity_id
+        await entity.async_added_to_hass()
+
+        assert entity.current_temperature == 20.5  # conftest's live value
+        assert entity.target_temperature == 21.5

--- a/tests_ha/test_climate.py
+++ b/tests_ha/test_climate.py
@@ -1,4 +1,4 @@
-"""Tests for climate.py's restore-last-known-state behavior (issue #54).
+"""Tests for climate.py's restore-last-known-state behavior.
 
 See test_sensor.py's module docstring for the general testing pattern -
 climate has no RestoreSensor equivalent, so LKThermostat uses plain

--- a/tests_ha/test_climate.py
+++ b/tests_ha/test_climate.py
@@ -9,34 +9,18 @@ the restored State's attributes instead of a typed native_value.
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import patch
 
 from homeassistant.components.climate import ATTR_CURRENT_TEMPERATURE
-from homeassistant.const import ATTR_TEMPERATURE, CONF_PASSWORD, CONF_USERNAME
+from homeassistant.const import ATTR_TEMPERATURE
 from homeassistant.core import State
 from homeassistant.util import dt as dt_util
-from pytest_homeassistant_custom_component.common import (
-    MockConfigEntry,
-    mock_restore_cache,
-)
+from pytest_homeassistant_custom_component.common import mock_restore_cache
 
 from custom_components.lksystems.climate import LKThermostat
 from custom_components.lksystems.const import DOMAIN
 from custom_components.lksystems.restore import ATTR_LAST_SUCCESSFUL_FETCH
 
-from .conftest import THERMOSTAT_MAC
-
-
-async def _setup_entry(hass, manager) -> MockConfigEntry:
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
-    )
-    entry.add_to_hass(hass)
-    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-    return entry
+from .conftest import THERMOSTAT_MAC, setup_entry as _setup_entry
 
 
 def _seed_restore_cache(

--- a/tests_ha/test_climate.py
+++ b/tests_ha/test_climate.py
@@ -18,7 +18,7 @@ from pytest_homeassistant_custom_component.common import mock_restore_cache
 
 from custom_components.lksystems.climate import LKThermostat
 from custom_components.lksystems.const import DOMAIN
-from custom_components.lksystems.restore import ATTR_LAST_SUCCESSFUL_FETCH
+from custom_components.lksystems.restore import ATTR_LAST_SUCCESSFUL_CLOUD_FETCH
 
 from .conftest import THERMOSTAT_MAC, setup_entry as _setup_entry
 
@@ -35,7 +35,7 @@ def _seed_restore_cache(
                 {
                     ATTR_CURRENT_TEMPERATURE: current_temperature,
                     ATTR_TEMPERATURE: target_temperature,
-                    ATTR_LAST_SUCCESSFUL_FETCH: fetched_at.isoformat(),
+                    ATTR_LAST_SUCCESSFUL_CLOUD_FETCH: fetched_at.isoformat(),
                 },
             )
         ],

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -106,13 +106,13 @@ class TestCoordinatorConstruction:
             minutes=DEFAULT_UPDATE_INTERVAL
         )
 
-    async def test_last_successful_fetch_starts_none(self, hass):
+    async def test_last_successful_cloud_fetch_starts_none(self, hass):
         entry = _make_entry(hass)
         coordinator = LKSystemCoordinator(hass, entry)
-        assert coordinator.last_successful_fetch is None
+        assert coordinator.last_successful_cloud_fetch is None
 
 
-class TestLastSuccessfulFetch:
+class TestLastSuccessfulCloudFetch:
     """Restoring entity state across a restart needs a per-update
     timestamp to judge whether a restored value is still fresh enough to
     show."""
@@ -126,8 +126,8 @@ class TestLastSuccessfulFetch:
             await coordinator._async_update_data()
         after = dt_util.utcnow()
 
-        assert coordinator.last_successful_fetch is not None
-        assert before <= coordinator.last_successful_fetch <= after
+        assert coordinator.last_successful_cloud_fetch is not None
+        assert before <= coordinator.last_successful_cloud_fetch <= after
 
     async def test_failed_update_does_not_clear_a_prior_timestamp(
         self, hass, fake_manager
@@ -136,14 +136,14 @@ class TestLastSuccessfulFetch:
         coordinator = LKSystemCoordinator(hass, entry)
         with _patch_manager(fake_manager):
             await coordinator._async_update_data()
-        first_fetch_time = coordinator.last_successful_fetch
+        first_fetch_time = coordinator.last_successful_cloud_fetch
 
         fake_manager.get_user_structure_result = False
         with _patch_manager(fake_manager):
             with pytest.raises(UpdateFailed):
                 await coordinator._async_update_data()
 
-        assert coordinator.last_successful_fetch == first_fetch_time
+        assert coordinator.last_successful_cloud_fetch == first_fetch_time
 
 
 class TestAsyncUpdateData:

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -113,9 +113,9 @@ class TestCoordinatorConstruction:
 
 
 class TestLastSuccessfulFetch:
-    """Restoring entity state across a restart (issue #54) needs a
-    per-update timestamp to judge whether a restored value is still fresh
-    enough to show - see restore.py."""
+    """Restoring entity state across a restart needs a per-update
+    timestamp to judge whether a restored value is still fresh enough to
+    show."""
 
     async def test_successful_update_sets_the_timestamp(self, hass, fake_manager):
         entry = _make_entry(hass)

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -106,6 +106,45 @@ class TestCoordinatorConstruction:
             minutes=DEFAULT_UPDATE_INTERVAL
         )
 
+    async def test_last_successful_fetch_starts_none(self, hass):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+        assert coordinator.last_successful_fetch is None
+
+
+class TestLastSuccessfulFetch:
+    """Restoring entity state across a restart (issue #54) needs a
+    per-update timestamp to judge whether a restored value is still fresh
+    enough to show - see restore.py."""
+
+    async def test_successful_update_sets_the_timestamp(self, hass, fake_manager):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        before = dt_util.utcnow()
+        with _patch_manager(fake_manager):
+            await coordinator._async_update_data()
+        after = dt_util.utcnow()
+
+        assert coordinator.last_successful_fetch is not None
+        assert before <= coordinator.last_successful_fetch <= after
+
+    async def test_failed_update_does_not_clear_a_prior_timestamp(
+        self, hass, fake_manager
+    ):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+        with _patch_manager(fake_manager):
+            await coordinator._async_update_data()
+        first_fetch_time = coordinator.last_successful_fetch
+
+        fake_manager.get_user_structure_result = False
+        with _patch_manager(fake_manager):
+            with pytest.raises(UpdateFailed):
+                await coordinator._async_update_data()
+
+        assert coordinator.last_successful_fetch == first_fetch_time
+
 
 class TestAsyncUpdateData:
     async def test_missing_credentials_raises_auth_failed(self, hass):

--- a/tests_ha/test_integration_setup.py
+++ b/tests_ha/test_integration_setup.py
@@ -12,10 +12,6 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.helpers import entity_registry as er
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
 from custom_components.lksystems.const import DOMAIN
 
 from .conftest import (
@@ -24,25 +20,9 @@ from .conftest import (
     HUB_IDENTITY,
     SENSOR_MAC,
     THERMOSTAT_MAC,
+    entity_id as _entity_id,
+    setup_entry as _setup_entry,
 )
-
-
-async def _setup_entry(hass, manager) -> MockConfigEntry:
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
-    )
-    entry.add_to_hass(hass)
-    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-    return entry
-
-
-def _entity_id(hass, platform: str, unique_id: str) -> str:
-    entity_id = er.async_get(hass).async_get_entity_id(platform, DOMAIN, unique_id)
-    assert entity_id is not None, f"no {platform} entity registered for {unique_id!r}"
-    return entity_id
 
 
 async def test_thermostat_entity_reflects_client_data(hass, fake_manager):

--- a/tests_ha/test_integration_setup.py
+++ b/tests_ha/test_integration_setup.py
@@ -12,10 +12,6 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.helpers import entity_registry as er
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
 from custom_components.lksystems.const import DOMAIN
 
 from .conftest import (
@@ -24,25 +20,9 @@ from .conftest import (
     HUB_IDENTITY,
     SENSOR_MAC,
     THERMOSTAT_MAC,
+    entity_id as _entity_id,
+    setup_entry as _setup_entry,
 )
-
-
-async def _setup_entry(hass, manager) -> MockConfigEntry:
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
-    )
-    entry.add_to_hass(hass)
-    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-    return entry
-
-
-def _entity_id(hass, platform: str, unique_id: str) -> str:
-    entity_id = er.async_get(hass).async_get_entity_id(platform, DOMAIN, unique_id)
-    assert entity_id is not None, f"no {platform} entity registered for {unique_id!r}"
-    return entity_id
 
 
 async def test_thermostat_entity_reflects_client_data(hass, fake_manager):
@@ -58,6 +38,8 @@ async def test_thermostat_entity_reflects_client_data(hass, fake_manager):
 
 
 async def test_standalone_sensor_entities_reflect_client_data(hass, fake_manager):
+    """RSSI is excluded here - it's disabled by default (issue #57), so it
+    has no live state to assert on; see test_sensor.py for that."""
     await _setup_entry(hass, fake_manager)
 
     temperature_id = _entity_id(
@@ -65,12 +47,10 @@ async def test_standalone_sensor_entities_reflect_client_data(hass, fake_manager
     )
     humidity_id = _entity_id(hass, "sensor", f"{DOMAIN}_{SENSOR_MAC}_humidity")
     battery_id = _entity_id(hass, "sensor", f"{DOMAIN}_{SENSOR_MAC}_battery")
-    rssi_id = _entity_id(hass, "sensor", f"{DOMAIN}_{SENSOR_MAC}_rssi")
 
     assert hass.states.get(temperature_id).state == "19.0"
     assert hass.states.get(humidity_id).state == "40.0"
     assert hass.states.get(battery_id).state == "75"
-    assert hass.states.get(rssi_id).state == "-60"
 
 
 async def test_hub_and_hub_child_entities_are_created(hass, fake_manager):

--- a/tests_ha/test_integration_setup.py
+++ b/tests_ha/test_integration_setup.py
@@ -38,8 +38,8 @@ async def test_thermostat_entity_reflects_client_data(hass, fake_manager):
 
 
 async def test_standalone_sensor_entities_reflect_client_data(hass, fake_manager):
-    """RSSI is excluded here - it's disabled by default (issue #57), so it
-    has no live state to assert on; see test_sensor.py for that."""
+    """RSSI is excluded here - it's disabled by default, so it has no live
+    state to assert on; see test_sensor.py for that."""
     await _setup_entry(hass, fake_manager)
 
     temperature_id = _entity_id(

--- a/tests_ha/test_restore.py
+++ b/tests_ha/test_restore.py
@@ -1,0 +1,42 @@
+"""Tests for restore.py's freshness-check helper.
+
+Entity-level restore behavior (an entity actually showing a restored value,
+or not) is covered separately in test_sensor.py/test_climate.py - this is
+only concerned with is_restored_value_fresh()'s own age-vs-threshold logic.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+from homeassistant.util import dt as dt_util
+
+from custom_components.lksystems.restore import (
+    STALE_THRESHOLD_MULTIPLIER,
+    is_restored_value_fresh,
+)
+
+
+class TestIsRestoredValueFresh:
+    def test_none_last_fetch_is_not_fresh(self):
+        assert is_restored_value_fresh(None, timedelta(minutes=5)) is False
+
+    def test_none_update_interval_is_not_fresh(self):
+        assert is_restored_value_fresh(dt_util.utcnow(), None) is False
+
+    def test_just_fetched_is_fresh(self):
+        assert is_restored_value_fresh(dt_util.utcnow(), timedelta(minutes=5)) is True
+
+    def test_within_threshold_is_fresh(self):
+        update_interval = timedelta(minutes=5)
+        age = update_interval * STALE_THRESHOLD_MULTIPLIER - timedelta(seconds=1)
+        last_fetch = dt_util.utcnow() - age
+
+        assert is_restored_value_fresh(last_fetch, update_interval) is True
+
+    def test_beyond_threshold_is_not_fresh(self):
+        update_interval = timedelta(minutes=5)
+        age = update_interval * STALE_THRESHOLD_MULTIPLIER + timedelta(seconds=1)
+        last_fetch = dt_util.utcnow() - age
+
+        assert is_restored_value_fresh(last_fetch, update_interval) is False

--- a/tests_ha/test_sensor.py
+++ b/tests_ha/test_sensor.py
@@ -40,7 +40,6 @@ async def test_low_value_sensors_are_disabled_by_default(hass, fake_manager):
         "tempWaterMin",
         "tempWaterMax",
         "cacheUpdated",
-        "lastStatus",
         "leak.meanFlow",
         "leak.dateStartedAt",
         "leak.dateUpdatedAt",
@@ -53,6 +52,12 @@ async def test_low_value_sensors_are_disabled_by_default(hass, fake_manager):
 async def test_safety_and_primary_sensors_stay_enabled_by_default(
     hass, fake_manager
 ):
+    """lastStatus ("Last Data Sent") is device-freshness information, not
+    low-value: it's the only signal that the device itself has gone quiet,
+    as distinct from last_successful_cloud_fetch (an attribute on every
+    cubic sensor), which only says the integration's own poll of LK's cloud
+    API succeeded - LK's cloud can keep serving a stale cached reading
+    successfully long after the device itself stopped reporting to it."""
     await setup_entry(hass, fake_manager)
 
     temperature_entry = _registry_entry(
@@ -60,7 +65,13 @@ async def test_safety_and_primary_sensors_stay_enabled_by_default(
     )
     assert temperature_entry.disabled_by is None
 
-    for key in ("volumeTotal", "tempWaterAverage", "waterPressure", "leak.leakState"):
+    for key in (
+        "volumeTotal",
+        "tempWaterAverage",
+        "waterPressure",
+        "leak.leakState",
+        "lastStatus",
+    ):
         entry = _registry_entry(hass, "sensor", f"LkUid_{key}_{CUBIC_IDENTITY}")
         assert entry.disabled_by is None, key
 

--- a/tests_ha/test_sensor.py
+++ b/tests_ha/test_sensor.py
@@ -1,0 +1,265 @@
+"""Tests for sensor.py's restore-last-known-state behavior (issue #54).
+
+Entities are exercised somewhat directly rather than through a full
+config-entry setup + simulated process restart: a real coordinator is set
+up once via _setup_entry() (so entity construction has real coordinator
+data to work from), then the entity under test is instantiated on its own,
+given a pre-seeded restore cache via mock_restore_cache_with_extra_data(),
+and added to hass directly - the standard Home Assistant pattern for
+testing a RestoreEntity/RestoreSensor mixin without simulating an actual
+process restart.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from unittest.mock import patch
+
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.core import State
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    mock_restore_cache_with_extra_data,
+)
+
+from custom_components.lksystems.const import (
+    DOMAIN,
+    LK_CUBICSECURE_CONFIG_SENSORS,
+)
+from custom_components.lksystems.restore import ATTR_LAST_SUCCESSFUL_FETCH
+from custom_components.lksystems.sensor import (
+    LKArcHubEntity,
+    LKArcSensorEntity,
+    LKCubicSensor,
+)
+
+from .conftest import HUB_IDENTITY, THERMOSTAT_MAC
+
+
+async def _setup_entry(hass, manager) -> MockConfigEntry:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
+    )
+    entry.add_to_hass(hass)
+    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def _seed_restore_cache(hass, entity_id: str, native_value, fetched_at) -> None:
+    """Seed a restore cache entry with a properly-typed native_value.
+
+    RestoreSensor stores/restores native_value with its original type
+    (float, datetime, ...) via extra_data, separate from the state
+    machine's own string state - the State.state string is what an entity
+    without RestoreSensor (e.g. climate) would fall back to instead.
+    """
+    mock_restore_cache_with_extra_data(
+        hass,
+        [
+            (
+                State(
+                    entity_id,
+                    str(native_value),
+                    {ATTR_LAST_SUCCESSFUL_FETCH: fetched_at.isoformat()},
+                ),
+                {"native_value": native_value, "native_unit_of_measurement": None},
+            )
+        ],
+    )
+
+
+async def _restored_firmware_version_entity(hass, fake_manager, fetched_at):
+    """A firmwareVersion sensor added fresh, as if right after an HA
+    restart, with a restore cache seeded from before that restart and the
+    live cubic_configuration payload missing (a fetch failure on the very
+    first poll - the scenario issue #54 is about)."""
+    entity_id = "sensor.test_restore_firmware_version"
+    # Deliberately distinct from conftest's live firmwareVersion ("1.2.3")
+    # so a pass unambiguously means the restored path, not a coincidence.
+    # Seeded before setup, per mock_restore_cache_with_extra_data's own
+    # convention - it replaces hass's RestoreStateData wholesale, which
+    # would otherwise orphan the bookkeeping of any entity already added
+    # by an earlier _setup_entry() call.
+    _seed_restore_cache(hass, entity_id, "9.9.9-restored", fetched_at)
+
+    entry = await _setup_entry(hass, fake_manager)
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    coordinator.data["cubic_configuration"] = None
+    entity = LKCubicSensor(
+        coordinator,
+        LK_CUBICSECURE_CONFIG_SENSORS["firmwareVersion"],
+        data_source="configuration",
+    )
+    entity.hass = hass
+    entity.entity_id = entity_id
+    await entity.async_added_to_hass()
+    return entity
+
+
+class TestCubicSensorRestore:
+    async def test_restores_value_when_live_fetch_failed_and_restore_is_fresh(
+        self, hass, fake_manager
+    ):
+        entity = await _restored_firmware_version_entity(
+            hass, fake_manager, fetched_at=dt_util.utcnow()
+        )
+
+        assert entity.native_value == "9.9.9-restored"
+
+    async def test_ignores_a_stale_restored_value(self, hass, fake_manager):
+        stale = dt_util.utcnow() - timedelta(hours=1)
+        entity = await _restored_firmware_version_entity(
+            hass, fake_manager, fetched_at=stale
+        )
+
+        assert entity.native_value is None
+
+    async def test_live_value_takes_priority_over_a_restored_one(
+        self, hass, fake_manager
+    ):
+        entity_id = "sensor.test_restore_firmware_version"
+        _seed_restore_cache(hass, entity_id, "old-version", dt_util.utcnow())
+
+        entry = await _setup_entry(hass, fake_manager)
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+
+        # Live data is present this time - unlike _restored_firmware_version_entity().
+        entity = LKCubicSensor(
+            coordinator,
+            LK_CUBICSECURE_CONFIG_SENSORS["firmwareVersion"],
+            data_source="configuration",
+        )
+        entity.hass = hass
+        entity.entity_id = entity_id
+        await entity.async_added_to_hass()
+
+        assert entity.native_value == coordinator.data["cubic_configuration"][
+            "firmwareVersion"
+        ]
+        assert entity.native_value != "old-version"
+
+
+def _thermostat_device(coordinator) -> dict:
+    return next(
+        d for d in coordinator.data["devices"] if d.get("mac") == THERMOSTAT_MAC
+    )
+
+
+def _clear_thermostat_live_measurement(coordinator) -> dict:
+    """Simulate a live fetch failure for the thermostat device: native_value
+    checks device_details before the devices list (see LKArcSensorEntity's
+    docstring-free comment "First check device_details..."), so both need
+    clearing to make the live lookup actually return None."""
+    device = _thermostat_device(coordinator)
+    device["measurement"] = {}
+    device_details = coordinator.data.get("device_details", {}).get(THERMOSTAT_MAC)
+    if device_details:
+        device_details["measurement"] = {}
+    return device
+
+
+class TestArcSensorRestore:
+    async def test_restores_value_when_live_fetch_failed_and_restore_is_fresh(
+        self, hass, fake_manager
+    ):
+        entity_id = "sensor.test_restore_temperature"
+        _seed_restore_cache(hass, entity_id, 42.0, dt_util.utcnow())
+
+        entry = await _setup_entry(hass, fake_manager)
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+
+        device = _clear_thermostat_live_measurement(coordinator)
+        entity = LKArcSensorEntity(
+            coordinator,
+            device,
+            "temperature",
+            "Temperature",
+            "mdi:thermometer",
+        )
+        entity.hass = hass
+        entity.entity_id = entity_id
+        await entity.async_added_to_hass()
+
+        assert entity.native_value == 42.0
+
+    async def test_ignores_a_stale_restored_value(self, hass, fake_manager):
+        entity_id = "sensor.test_restore_temperature"
+        stale = dt_util.utcnow() - timedelta(hours=1)
+        _seed_restore_cache(hass, entity_id, 42.0, stale)
+
+        entry = await _setup_entry(hass, fake_manager)
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+
+        device = _clear_thermostat_live_measurement(coordinator)
+        entity = LKArcSensorEntity(
+            coordinator,
+            device,
+            "temperature",
+            "Temperature",
+            "mdi:thermometer",
+        )
+        entity.hass = hass
+        entity.entity_id = entity_id
+        await entity.async_added_to_hass()
+
+        assert entity.native_value is None
+
+
+def _hub_device(coordinator) -> dict:
+    return next(
+        d for d in coordinator.data["devices"] if d.get("mac") == HUB_IDENTITY
+    )
+
+
+class TestArcHubRestore:
+    """The hub's own "Status" sensor never actually gets live data (issue
+    #46 - the coordinator never stores a measurement/connectionState for
+    the arc-hub device itself, only its children), so unlike the other
+    restore tests there's no live data to clear first - native_value is
+    already unconditionally None going in."""
+
+    async def test_restores_value_when_fresh(self, hass, fake_manager):
+        entity_id = "sensor.test_restore_hub_status"
+        _seed_restore_cache(hass, entity_id, "Connected", dt_util.utcnow())
+
+        entry = await _setup_entry(hass, fake_manager)
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+
+        entity = LKArcHubEntity(
+            coordinator,
+            _hub_device(coordinator),
+            "status",
+            "Status",
+            "mdi:router-wireless",
+        )
+        entity.hass = hass
+        entity.entity_id = entity_id
+        await entity.async_added_to_hass()
+
+        assert entity.native_value == "Connected"
+
+    async def test_ignores_a_stale_restored_value(self, hass, fake_manager):
+        entity_id = "sensor.test_restore_hub_status"
+        stale = dt_util.utcnow() - timedelta(hours=1)
+        _seed_restore_cache(hass, entity_id, "Connected", stale)
+
+        entry = await _setup_entry(hass, fake_manager)
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+
+        entity = LKArcHubEntity(
+            coordinator,
+            _hub_device(coordinator),
+            "status",
+            "Status",
+            "mdi:router-wireless",
+        )
+        entity.hass = hass
+        entity.entity_id = entity_id
+        await entity.async_added_to_hass()
+
+        assert entity.native_value is None

--- a/tests_ha/test_sensor.py
+++ b/tests_ha/test_sensor.py
@@ -13,13 +13,10 @@ process restart.
 from __future__ import annotations
 
 from datetime import timedelta
-from unittest.mock import patch
 
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
 from homeassistant.core import State
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import (
-    MockConfigEntry,
     mock_restore_cache_with_extra_data,
 )
 
@@ -34,19 +31,7 @@ from custom_components.lksystems.sensor import (
     LKCubicSensor,
 )
 
-from .conftest import HUB_IDENTITY, THERMOSTAT_MAC
-
-
-async def _setup_entry(hass, manager) -> MockConfigEntry:
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
-    )
-    entry.add_to_hass(hass)
-    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-    return entry
+from .conftest import HUB_IDENTITY, THERMOSTAT_MAC, setup_entry as _setup_entry
 
 
 def _seed_restore_cache(hass, entity_id: str, native_value, fetched_at) -> None:

--- a/tests_ha/test_sensor.py
+++ b/tests_ha/test_sensor.py
@@ -24,7 +24,7 @@ from custom_components.lksystems.const import (
     DOMAIN,
     LK_CUBICSECURE_CONFIG_SENSORS,
 )
-from custom_components.lksystems.restore import ATTR_LAST_SUCCESSFUL_FETCH
+from custom_components.lksystems.restore import ATTR_LAST_SUCCESSFUL_CLOUD_FETCH
 from custom_components.lksystems.sensor import (
     LKArcHubEntity,
     LKArcSensorEntity,
@@ -49,7 +49,7 @@ def _seed_restore_cache(hass, entity_id: str, native_value, fetched_at) -> None:
                 State(
                     entity_id,
                     str(native_value),
-                    {ATTR_LAST_SUCCESSFUL_FETCH: fetched_at.isoformat()},
+                    {ATTR_LAST_SUCCESSFUL_CLOUD_FETCH: fetched_at.isoformat()},
                 ),
                 {"native_value": native_value, "native_unit_of_measurement": None},
             )

--- a/tests_ha/test_sensor.py
+++ b/tests_ha/test_sensor.py
@@ -1,4 +1,4 @@
-"""Tests for sensor.py's entity-registry defaults (issue #57).
+"""Tests for sensor.py's entity-registry defaults.
 
 Several sensors are diagnostic/low-value enough that they shouldn't clutter
 the main device card by default - drives a real config-entry setup (like

--- a/tests_ha/test_sensor.py
+++ b/tests_ha/test_sensor.py
@@ -1,4 +1,4 @@
-"""Tests for sensor.py's restore-last-known-state behavior (issue #54).
+"""Tests for sensor.py's restore-last-known-state behavior.
 
 Entities are exercised somewhat directly rather than through a full
 config-entry setup + simulated process restart: a real coordinator is set
@@ -61,7 +61,7 @@ async def _restored_firmware_version_entity(hass, fake_manager, fetched_at):
     """A firmwareVersion sensor added fresh, as if right after an HA
     restart, with a restore cache seeded from before that restart and the
     live cubic_configuration payload missing (a fetch failure on the very
-    first poll - the scenario issue #54 is about)."""
+    first poll)."""
     entity_id = "sensor.test_restore_firmware_version"
     # Deliberately distinct from conftest's live firmwareVersion ("1.2.3")
     # so a pass unambiguously means the restored path, not a coincidence.
@@ -202,11 +202,11 @@ def _hub_device(coordinator) -> dict:
 
 
 class TestArcHubRestore:
-    """The hub's own "Status" sensor never actually gets live data (issue
-    #46 - the coordinator never stores a measurement/connectionState for
-    the arc-hub device itself, only its children), so unlike the other
-    restore tests there's no live data to clear first - native_value is
-    already unconditionally None going in."""
+    """The hub's own "Status" sensor never actually gets live data - the
+    coordinator never stores a measurement/connectionState for the arc-hub
+    device itself, only its children - so unlike the other restore tests
+    there's no live data to clear first - native_value is already
+    unconditionally None going in."""
 
     async def test_restores_value_when_fresh(self, hass, fake_manager):
         entity_id = "sensor.test_restore_hub_status"

--- a/tests_ha/test_sensor.py
+++ b/tests_ha/test_sensor.py
@@ -1,0 +1,76 @@
+"""Tests for sensor.py's entity-registry defaults (issue #57).
+
+Several sensors are diagnostic/low-value enough that they shouldn't clutter
+the main device card by default - drives a real config-entry setup (like
+test_integration_setup.py) and inspects the entities the entity registry
+actually ended up with, rather than the SensorEntityDescription objects in
+const.py directly, so a bug in how sensor.py applies them would still show up.
+"""
+
+from __future__ import annotations
+
+from homeassistant.const import EntityCategory
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_registry import RegistryEntryDisabler
+
+from custom_components.lksystems.const import DOMAIN
+
+from .conftest import (
+    CUBIC_IDENTITY,
+    HUB_IDENTITY,
+    SENSOR_MAC,
+    entity_id,
+    setup_entry,
+)
+
+
+def _registry_entry(hass, platform: str, unique_id: str) -> er.RegistryEntry:
+    entry = er.async_get(hass).async_get(entity_id(hass, platform, unique_id))
+    assert entry is not None
+    return entry
+
+
+async def test_low_value_sensors_are_disabled_by_default(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+
+    rssi_entry = _registry_entry(hass, "sensor", f"{DOMAIN}_{SENSOR_MAC}_rssi")
+    assert rssi_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
+
+    for key in (
+        "tempWaterMin",
+        "tempWaterMax",
+        "cacheUpdated",
+        "lastStatus",
+        "leak.meanFlow",
+        "leak.dateStartedAt",
+        "leak.dateUpdatedAt",
+        "leak.acknowledged",
+    ):
+        entry = _registry_entry(hass, "sensor", f"LkUid_{key}_{CUBIC_IDENTITY}")
+        assert entry.disabled_by == RegistryEntryDisabler.INTEGRATION, key
+
+
+async def test_safety_and_primary_sensors_stay_enabled_by_default(
+    hass, fake_manager
+):
+    await setup_entry(hass, fake_manager)
+
+    temperature_entry = _registry_entry(
+        hass, "sensor", f"{DOMAIN}_{SENSOR_MAC}_temperature"
+    )
+    assert temperature_entry.disabled_by is None
+
+    for key in ("volumeTotal", "tempWaterAverage", "waterPressure", "leak.leakState"):
+        entry = _registry_entry(hass, "sensor", f"LkUid_{key}_{CUBIC_IDENTITY}")
+        assert entry.disabled_by is None, key
+
+
+async def test_diagnostic_sensors_are_categorized_as_diagnostic(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+
+    hub_status_entry = _registry_entry(hass, "sensor", f"{DOMAIN}_{HUB_IDENTITY}_status")
+    assert hub_status_entry.entity_category == EntityCategory.DIAGNOSTIC
+
+    for key in ("firmwareVersion", "hardwareVersion"):
+        entry = _registry_entry(hass, "sensor", f"LkUid_{key}_{CUBIC_IDENTITY}")
+        assert entry.entity_category == EntityCategory.DIAGNOSTIC, key


### PR DESCRIPTION
Closes #54.

**Depends on #65 - draft until that merges.** #60 and #63 (the test-file-overlap PRs this was originally held for) have both merged. #65 hasn't, and independently touches the same `sensor.py`/`tests_ha/test_sensor.py`/`tests_ha/test_coordinator.py` this PR does - so this branch now has #65's branch merged directly into it (not just rebased on `main`), and stays conflict-free against `main` once #65 lands. Merging this before #65 would just reopen the same conflicts on #65's side. Ready for real review once #65 is in.

---

No entity used `RestoreEntity`/`RestoreSensor`, and the coordinator's own in-memory fallback (the per-cubic-device fetch/fallback in `__init__.py`) only survives within a running process - `coordinator.data` starts as `None` on a fresh start, so the very first poll after a restart has nothing to fall back to. A fetch failure on that first poll (e.g. a 429 that exhausted its #53 retries) left every affected entity showing `unknown`, even though HA knew a perfectly good value seconds before the restart.

**Design** (settled while testing the coordinator log-level fix - see the linked issue's own discussion): restore every entity uniformly, no special-casing by entity type, paired with a coordinator-level "last successfully fetched" timestamp and an age-vs-threshold check at restore time. A restored value is only shown while younger than `STALE_THRESHOLD_MULTIPLIER` (3) × `update_interval` - a routine restart produces a much younger value than that (the coordinator's first refresh fires immediately on setup), so this only screens out a real outage, not normal operation.

- `coordinator.py`: new `last_successful_fetch` timestamp, set on every successful update, left untouched on failure.
- New `restore.py`: `is_restored_value_fresh()` (the age-vs-threshold check, pure function) and the `ATTR_LAST_SUCCESSFUL_FETCH` attribute key shared by every entity class below.
- `sensor.py`: `AbstractLkCubicSensor`/`LKCubicSensor` (covers essentially every Cubic Secure sensor - `firmwareVersion`/`hardwareVersion`/`valveState`, the issue's own real-world example, included), `LKArcSensorEntity`, and `LKArcHubEntity` all gain `RestoreSensor`. Each `native_value` property is split into a live lookup (renamed, logic unchanged) plus a thin wrapper that falls back to the restored value when live data is missing.
- `climate.py`: `LKThermostat` gains `RestoreEntity` (no `RestoreSensor` equivalent for climate) and the same live/restored split for `current_temperature` and `target_temperature`.

TDD'd throughout: `tests_ha/test_restore.py` for the pure freshness check, new `TestLastSuccessfulFetch` tests in `test_coordinator.py`, and per-platform restore tests in new `test_sensor.py`/`test_climate.py` files (RED confirmed before each corresponding production change). Full suite passes: 110/110 in `tests_ha/`, 33/33 in `tests/` (counts include #65's tests, now merged in).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
