### PR TITLE
Disable low-value/diagnostic sensors by default

### DIFF
--- a/custom_components/lksystems/const.py
+++ b/custom_components/lksystems/const.py
@@ -111,7 +111,6 @@ LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement=None,
         state_class=None,
         translation_key="last_status_sensor",
-        entity_registry_enabled_default=False,
     ),
     "cacheUpdated": SensorEntityDescription(
         key="cacheUpdated",

--- a/custom_components/lksystems/const.py
+++ b/custom_components/lksystems/const.py
@@ -7,6 +7,7 @@ from homeassistant.components.sensor import (
     SensorEntityDescription,
     SensorStateClass,
 )
+from homeassistant.const import EntityCategory
 
 DOMAIN = "lksystems"
 INTEGRATION_NAME = "LK Systems"
@@ -68,6 +69,7 @@ LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement="°C",
         state_class=SensorStateClass.MEASUREMENT,
         translation_key="temp_water_min_sensor",
+        entity_registry_enabled_default=False,
     ),
     "tempWaterMax": SensorEntityDescription(
         key="tempWaterMax",
@@ -78,6 +80,7 @@ LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement="°C",
         state_class=SensorStateClass.MEASUREMENT,
         translation_key="temp_water_max_sensor",
+        entity_registry_enabled_default=False,
     ),
     "waterPressure": SensorEntityDescription(
         key="waterPressure",
@@ -108,6 +111,7 @@ LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement=None,
         state_class=None,
         translation_key="last_status_sensor",
+        entity_registry_enabled_default=False,
     ),
     "cacheUpdated": SensorEntityDescription(
         key="cacheUpdated",
@@ -118,6 +122,7 @@ LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement=None,
         state_class=None,
         translation_key="cache_updated_sensor",
+        entity_registry_enabled_default=False,
     ),
     "leak.leakState": SensorEntityDescription(
         key="leak.leakState",
@@ -138,6 +143,7 @@ LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement="L/h",
         state_class=SensorStateClass.MEASUREMENT,
         translation_key="leak_mean_flow_sensor",
+        entity_registry_enabled_default=False,
     ),
     "leak.dateStartedAt": SensorEntityDescription(
         key="leak.dateStartedAt",
@@ -148,6 +154,7 @@ LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement=None,
         state_class=None,
         translation_key="leak_date_started_at_sensor",
+        entity_registry_enabled_default=False,
     ),
     "leak.dateUpdatedAt": SensorEntityDescription(
         key="leak.dateUpdatedAt",
@@ -158,6 +165,7 @@ LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement=None,
         state_class=None,
         translation_key="leak_date_updated_at_sensor",
+        entity_registry_enabled_default=False,
     ),
     "leak.acknowledged": SensorEntityDescription(
         key="leak.acknowledged",
@@ -168,6 +176,7 @@ LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement=None,
         state_class=None,
         translation_key="leak_acknowledged_sensor",
+        entity_registry_enabled_default=False,
     ),
 }
 LK_CUBICSECURE_CONFIG_SENSORS: dict[str, SensorEntityDescription] = {
@@ -190,6 +199,7 @@ LK_CUBICSECURE_CONFIG_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement=None,
         state_class=None,
         translation_key="firmware_version_sensor",
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
     "hardwareVersion": SensorEntityDescription(
         key="hardwareVersion",
@@ -200,5 +210,6 @@ LK_CUBICSECURE_CONFIG_SENSORS: dict[str, SensorEntityDescription] = {
         native_unit_of_measurement=None,
         state_class=None,
         translation_key="hardware_version_sensor",
+        entity_category=EntityCategory.DIAGNOSTIC,
     ),
 }

--- a/custom_components/lksystems/sensor.py
+++ b/custom_components/lksystems/sensor.py
@@ -379,7 +379,7 @@ async def async_setup_entry(
                                 SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
                                 # Signal-strength diagnostics, not a reading
                                 # most users watch day-to-day - the textbook
-                                # HA case for opt-in-only (issue #57).
+                                # HA case for opt-in-only.
                                 entity_registry_enabled_default=False,
                             )
                         )

--- a/custom_components/lksystems/sensor.py
+++ b/custom_components/lksystems/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
+    EntityCategory,
     PERCENTAGE,
     SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
     UnitOfTemperature,
@@ -376,6 +377,10 @@ async def async_setup_entry(
                                 SensorDeviceClass.SIGNAL_STRENGTH,
                                 SensorStateClass.MEASUREMENT,
                                 SIGNAL_STRENGTH_DECIBELS_MILLIWATT,
+                                # Signal-strength diagnostics, not a reading
+                                # most users watch day-to-day - the textbook
+                                # HA case for opt-in-only (issue #57).
+                                entity_registry_enabled_default=False,
                             )
                         )
                         created_entity_ids.add(entity_id)
@@ -399,6 +404,7 @@ class LKArcSensorEntity(CoordinatorEntity, SensorEntity):
         device_class: Optional[str] = None,
         state_class: Optional[str] = None,
         unit_of_measurement: Optional[str] = None,
+        entity_registry_enabled_default: bool = True,
     ) -> None:
         """Initialize the sensor."""
         super().__init__(coordinator)
@@ -409,6 +415,7 @@ class LKArcSensorEntity(CoordinatorEntity, SensorEntity):
         self._attr_icon = icon
         self._attr_state_class = state_class
         self._attr_unit_of_measurement = unit_of_measurement
+        self._attr_entity_registry_enabled_default = entity_registry_enabled_default
 
         # Get device info
         device_title = device.get("deviceTitle", {})
@@ -715,6 +722,8 @@ class LKArcSensorEntity(CoordinatorEntity, SensorEntity):
 
 class LKArcHubEntity(CoordinatorEntity, SensorEntity):
     """Representation of an LK Systems ARC Hub entity."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(
         self,

--- a/tests_ha/conftest.py
+++ b/tests_ha/conftest.py
@@ -17,8 +17,14 @@ from __future__ import annotations
 
 import asyncio
 import time
+from unittest.mock import patch
 
 import pytest
+from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.lksystems.const import DOMAIN
 
 pytest_plugins = "pytest_homeassistant_custom_component"
 
@@ -345,3 +351,32 @@ def fake_manager() -> FakeLKSystemsManager:
     manager = FakeLKSystemsManager()
     configure_fake_manager_with_sample_data(manager)
     return manager
+
+
+async def setup_entry(hass, manager: FakeLKSystemsManager) -> MockConfigEntry:
+    """Drive a real config-entry setup against a FakeLKSystemsManager.
+
+    Runs the coordinator's first refresh and both the sensor.py and
+    climate.py platforms' async_setup_entry() for real, so tests can inspect
+    the entities/entity registry they actually produce.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
+    )
+    entry.add_to_hass(hass)
+    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+    return entry
+
+
+def entity_id(hass, platform: str, unique_id: str) -> str:
+    """Look up an entity_id by platform/unique_id via the entity registry.
+
+    Entities are looked up this way, rather than by guessing slugified
+    entity_ids, so tests don't depend on HA's naming/slugify rules.
+    """
+    found = er.async_get(hass).async_get_entity_id(platform, DOMAIN, unique_id)
+    assert found is not None, f"no {platform} entity registered for {unique_id!r}"
+    return found

--- a/tests_ha/test_integration_setup.py
+++ b/tests_ha/test_integration_setup.py
@@ -12,10 +12,6 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, patch
 
-from homeassistant.const import CONF_PASSWORD, CONF_USERNAME
-from homeassistant.helpers import entity_registry as er
-from pytest_homeassistant_custom_component.common import MockConfigEntry
-
 from custom_components.lksystems.const import DOMAIN
 
 from .conftest import (
@@ -24,25 +20,9 @@ from .conftest import (
     HUB_IDENTITY,
     SENSOR_MAC,
     THERMOSTAT_MAC,
+    entity_id as _entity_id,
+    setup_entry as _setup_entry,
 )
-
-
-async def _setup_entry(hass, manager) -> MockConfigEntry:
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
-    )
-    entry.add_to_hass(hass)
-    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
-        assert await hass.config_entries.async_setup(entry.entry_id)
-        await hass.async_block_till_done()
-    return entry
-
-
-def _entity_id(hass, platform: str, unique_id: str) -> str:
-    entity_id = er.async_get(hass).async_get_entity_id(platform, DOMAIN, unique_id)
-    assert entity_id is not None, f"no {platform} entity registered for {unique_id!r}"
-    return entity_id
 
 
 async def test_thermostat_entity_reflects_client_data(hass, fake_manager):
@@ -58,6 +38,8 @@ async def test_thermostat_entity_reflects_client_data(hass, fake_manager):
 
 
 async def test_standalone_sensor_entities_reflect_client_data(hass, fake_manager):
+    """RSSI is excluded here - it's disabled by default (issue #57), so it
+    has no live state to assert on; see test_sensor.py for that."""
     await _setup_entry(hass, fake_manager)
 
     temperature_id = _entity_id(
@@ -65,12 +47,10 @@ async def test_standalone_sensor_entities_reflect_client_data(hass, fake_manager
     )
     humidity_id = _entity_id(hass, "sensor", f"{DOMAIN}_{SENSOR_MAC}_humidity")
     battery_id = _entity_id(hass, "sensor", f"{DOMAIN}_{SENSOR_MAC}_battery")
-    rssi_id = _entity_id(hass, "sensor", f"{DOMAIN}_{SENSOR_MAC}_rssi")
 
     assert hass.states.get(temperature_id).state == "19.0"
     assert hass.states.get(humidity_id).state == "40.0"
     assert hass.states.get(battery_id).state == "75"
-    assert hass.states.get(rssi_id).state == "-60"
 
 
 async def test_hub_and_hub_child_entities_are_created(hass, fake_manager):

--- a/tests_ha/test_integration_setup.py
+++ b/tests_ha/test_integration_setup.py
@@ -38,8 +38,8 @@ async def test_thermostat_entity_reflects_client_data(hass, fake_manager):
 
 
 async def test_standalone_sensor_entities_reflect_client_data(hass, fake_manager):
-    """RSSI is excluded here - it's disabled by default (issue #57), so it
-    has no live state to assert on; see test_sensor.py for that."""
+    """RSSI is excluded here - it's disabled by default, so it has no live
+    state to assert on; see test_sensor.py for that."""
     await _setup_entry(hass, fake_manager)
 
     temperature_id = _entity_id(

--- a/tests_ha/test_sensor.py
+++ b/tests_ha/test_sensor.py
@@ -40,7 +40,6 @@ async def test_low_value_sensors_are_disabled_by_default(hass, fake_manager):
         "tempWaterMin",
         "tempWaterMax",
         "cacheUpdated",
-        "lastStatus",
         "leak.meanFlow",
         "leak.dateStartedAt",
         "leak.dateUpdatedAt",
@@ -53,6 +52,12 @@ async def test_low_value_sensors_are_disabled_by_default(hass, fake_manager):
 async def test_safety_and_primary_sensors_stay_enabled_by_default(
     hass, fake_manager
 ):
+    """lastStatus ("Last Data Sent") is device-freshness information, not
+    low-value: it's the only signal that the device itself has gone quiet,
+    as distinct from last_successful_cloud_fetch (an attribute on every
+    cubic sensor), which only says the integration's own poll of LK's cloud
+    API succeeded - LK's cloud can keep serving a stale cached reading
+    successfully long after the device itself stopped reporting to it."""
     await setup_entry(hass, fake_manager)
 
     temperature_entry = _registry_entry(
@@ -60,7 +65,13 @@ async def test_safety_and_primary_sensors_stay_enabled_by_default(
     )
     assert temperature_entry.disabled_by is None
 
-    for key in ("volumeTotal", "tempWaterAverage", "waterPressure", "leak.leakState"):
+    for key in (
+        "volumeTotal",
+        "tempWaterAverage",
+        "waterPressure",
+        "leak.leakState",
+        "lastStatus",
+    ):
         entry = _registry_entry(hass, "sensor", f"LkUid_{key}_{CUBIC_IDENTITY}")
         assert entry.disabled_by is None, key
 

--- a/tests_ha/test_sensor.py
+++ b/tests_ha/test_sensor.py
@@ -1,4 +1,4 @@
-"""Tests for sensor.py's entity-registry defaults (issue #57).
+"""Tests for sensor.py's entity-registry defaults.
 
 Several sensors are diagnostic/low-value enough that they shouldn't clutter
 the main device card by default - drives a real config-entry setup (like

--- a/tests_ha/test_sensor.py
+++ b/tests_ha/test_sensor.py
@@ -1,0 +1,76 @@
+"""Tests for sensor.py's entity-registry defaults (issue #57).
+
+Several sensors are diagnostic/low-value enough that they shouldn't clutter
+the main device card by default - drives a real config-entry setup (like
+test_integration_setup.py) and inspects the entities the entity registry
+actually ended up with, rather than the SensorEntityDescription objects in
+const.py directly, so a bug in how sensor.py applies them would still show up.
+"""
+
+from __future__ import annotations
+
+from homeassistant.const import EntityCategory
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.entity_registry import RegistryEntryDisabler
+
+from custom_components.lksystems.const import DOMAIN
+
+from .conftest import (
+    CUBIC_IDENTITY,
+    HUB_IDENTITY,
+    SENSOR_MAC,
+    entity_id,
+    setup_entry,
+)
+
+
+def _registry_entry(hass, platform: str, unique_id: str) -> er.RegistryEntry:
+    entry = er.async_get(hass).async_get(entity_id(hass, platform, unique_id))
+    assert entry is not None
+    return entry
+
+
+async def test_low_value_sensors_are_disabled_by_default(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+
+    rssi_entry = _registry_entry(hass, "sensor", f"{DOMAIN}_{SENSOR_MAC}_rssi")
+    assert rssi_entry.disabled_by == RegistryEntryDisabler.INTEGRATION
+
+    for key in (
+        "tempWaterMin",
+        "tempWaterMax",
+        "cacheUpdated",
+        "lastStatus",
+        "leak.meanFlow",
+        "leak.dateStartedAt",
+        "leak.dateUpdatedAt",
+        "leak.acknowledged",
+    ):
+        entry = _registry_entry(hass, "sensor", f"LkUid_{key}_{CUBIC_IDENTITY}")
+        assert entry.disabled_by == RegistryEntryDisabler.INTEGRATION, key
+
+
+async def test_safety_and_primary_sensors_stay_enabled_by_default(
+    hass, fake_manager
+):
+    await setup_entry(hass, fake_manager)
+
+    temperature_entry = _registry_entry(
+        hass, "sensor", f"{DOMAIN}_{SENSOR_MAC}_temperature"
+    )
+    assert temperature_entry.disabled_by is None
+
+    for key in ("volumeTotal", "tempWaterAverage", "waterPressure", "leak.leakState"):
+        entry = _registry_entry(hass, "sensor", f"LkUid_{key}_{CUBIC_IDENTITY}")
+        assert entry.disabled_by is None, key
+
+
+async def test_diagnostic_sensors_are_categorized_as_diagnostic(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+
+    hub_status_entry = _registry_entry(hass, "sensor", f"{DOMAIN}_{HUB_IDENTITY}_status")
+    assert hub_status_entry.entity_category == EntityCategory.DIAGNOSTIC
+
+    for key in ("firmwareVersion", "hardwareVersion"):
+        entry = _registry_entry(hass, "sensor", f"LkUid_{key}_{CUBIC_IDENTITY}")
+        assert entry.entity_category == EntityCategory.DIAGNOSTIC, key


### PR DESCRIPTION
Closes #57.

Every sensor this integration creates was enabled by default - this disables/categorizes the ones the issue calls out as diagnostic or secondary:

**`entity_registry_enabled_default=False`:**
- RSSI (`LKArcSensorEntity`, `rssi`) - the textbook HA case for opt-in-only signal-strength diagnostics.
- `tempWaterMin` / `tempWaterMax` (Cubic Secure) - secondary to `tempWaterAverage`.
- Leak forensics: `leak.meanFlow`, `leak.dateStartedAt`, `leak.dateUpdatedAt`, `leak.acknowledged` - only meaningful after a leak event. `leak.leakState` itself (the safety-relevant sensor) stays enabled.
- `cacheUpdated` - API-staleness bookkeeping.

`lastStatus` was originally in this list too, but stays enabled after review: it's the only signal that the device itself has stopped reporting to LK's cloud, distinct from `last_successful_cloud_fetch` (an attribute on every cubic sensor, added by the restore-state work), which only reflects the integration's own poll of that cloud API succeeding - LK's cloud can keep serving a stale cached reading successfully long after the device itself goes quiet.

**`entity_category=EntityCategory.DIAGNOSTIC`** (stays enabled, grouped out of the main card):
- `firmwareVersion` / `hardwareVersion`
- the ARC hub's own `status` sensor

Left as-is: `volumeTotal`, `volumeTotalDay`, `tempWaterAverage`, `waterPressure`, `ambientTemp`, `valveState`, `lastStatus`, and temperature/humidity/battery on Arc sensor devices - the readings the integration exists to surface.

For the Cubic/hub sensors this is just new fields on their existing `SensorEntityDescription`/a class attribute. `LKArcSensorEntity` (the RSSI case) had no description object to hang a flag on, so it gained an explicit `entity_registry_enabled_default` constructor parameter - passed at the RSSI call site, the same way `device_class`/`state_class`/`icon` already are for every other Arc sensor kind, rather than special-casing on `entity_key` inside `__init__`.

TDD'd via new `tests_ha/test_sensor.py` (confirmed RED before the `const.py`/`sensor.py` changes, and again when `lastStatus` moved out of the disabled list). Adjusted `test_integration_setup.py`'s pre-existing RSSI-has-a-live-state assertion (no longer true once RSSI is disabled by default) and hoisted its config-entry-setup/entity-lookup test helpers into `conftest.py` so the new test file didn't add a third near-identical copy. Full suite passes: 76/76 in `tests_ha/`, 25/25 in `tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)