### PR TITLE
Drop a GitHub issue reference from a code comment

### DIFF
--- a/tests/test_pylksystems.py
+++ b/tests/test_pylksystems.py
@@ -90,8 +90,7 @@ class TestGetUserStructure:
     async def test_empty_list_response_does_not_raise(self, manager):
         """Account with no devices/realestates: API returns `[]`.
 
-        Regression test for issue #30 - this used to raise
-        `IndexError: list index out of range`.
+        This used to raise `IndexError: list index out of range`.
         """
         manager.userid = "user-123"
 


### PR DESCRIPTION
Code comments and docstrings - including test docstrings - should never reference a GitHub issue or PR number. It's a nonlocal pointer one level further out than pointing at another file: the tracker entry can be renumbered, migrated, or deleted, and a reader has to leave the code entirely to resolve it. The rationale itself should just live in the comment, in prose, with no number; the number belongs in the commit message/PR description.

Fixes the one instance already on `main` (surfaced while sweeping every other open PR branch for the same pattern as part of an unrelated review pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)