### PR TITLE
Fix set_thermostat_temperature never authenticating (issue #24)

### DIFF
--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -268,6 +268,26 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
             password = self._entry.data.get(CONF_PASSWORD)
 
             async with LKSystemsManager(username, password) as lk_inst:
+                # Use existing token if available
+                stored_tokens = TOKEN_STORAGE.get(self._entry_id, {})
+                stored_jwt = stored_tokens.get("jwt")
+
+                if stored_jwt and is_token_valid(stored_jwt):
+                    lk_inst.jwt_token = stored_jwt
+                    lk_inst.refresh_token = stored_tokens.get("refresh")
+                else:
+                    # Login if no valid token
+                    if not await lk_inst.login():
+                        _LOGGER.error("Login failed when setting temperature")
+                        return False
+
+                    # Store the new tokens
+                    TOKEN_STORAGE[self._entry_id] = {
+                        "jwt": lk_inst.jwt_token,
+                        "refresh": lk_inst.refresh_token,
+                        "expiry": dt_util.utcnow().timestamp() + 3600,
+                    }
+
                 # Call the LKSystemsManager method to set the temperature
                 result = await lk_inst.set_thermostat_temperature(
                     device_id, temperature

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -381,3 +381,47 @@ class TestSetThermostatTemperature:
             )
 
         assert result is False
+
+    async def test_logs_in_before_calling_the_api(self, hass, fake_manager):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            result = await coordinator.set_thermostat_temperature(
+                THERMOSTAT_MAC, 225
+            )
+
+        assert result is True
+        call_names = [call[0] for call in fake_manager.calls]
+        assert call_names.index("login") < call_names.index(
+            "set_thermostat_temperature"
+        )
+
+    async def test_login_failure_returns_false(self, hass, fake_manager):
+        fake_manager.login_result = False
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            result = await coordinator.set_thermostat_temperature(
+                THERMOSTAT_MAC, 225
+            )
+
+        assert result is False
+
+    async def test_reuses_stored_valid_token(self, hass, fake_manager):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+        TOKEN_STORAGE[entry.entry_id] = {
+            "jwt": _make_token(3600),
+            "refresh": "stored-refresh-token",
+            "expiry": dt_util.utcnow().timestamp() + 3600,
+        }
+
+        with _patch_manager(fake_manager):
+            result = await coordinator.set_thermostat_temperature(
+                THERMOSTAT_MAC, 225
+            )
+
+        assert result is True
+        assert ("login",) not in fake_manager.calls


### PR DESCRIPTION
Fixes #24.

`set_thermostat_temperature()` created a fresh `LKSystemsManager` but
never called `login()` or restored a stored JWT, unlike
`force_device_update()` a few lines below which does both. Every real
"set temperature" call went out with an empty `Authorization` header
and silently failed at the API layer while the coordinator still
walked through its local success path.

Mirrors `force_device_update()`'s existing token handling: reuse a
valid stored token, otherwise log in and cache the new one.

Covered by new tests in `tests_ha/test_coordinator.py`
(`TestSetThermostatTemperature`), written test-first:
- logs in before calling the API (was previously not logging in at all)
- login failure returns `False`
- a valid stored token is reused instead of re-logging in

Merges cleanly onto current `main` (which now includes #56 and #61); full suite passes (87 passed, 1 pre-existing unrelated teardown error tracked in #71).