### PR TITLE
Log routine coordinator startup at debug, not warning

### DIFF
--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -210,7 +210,7 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
             )
         )
 
-        _LOGGER.warning(
+        _LOGGER.debug(
             "Initializing LK Systems coordinator with update interval: %d minutes",
             update_interval_minutes,
         )
@@ -227,27 +227,6 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
             _LOGGER,
             name=DOMAIN,
             update_interval=timedelta(minutes=update_interval_minutes),
-        )
-
-        # Schedule regular updates
-        self._setup_update_interval()
-
-    def _setup_update_interval(self):
-        """Set up the update interval."""
-        _LOGGER.warning(
-            f"Setting up update interval for {DOMAIN} to {self._update_interval_minutes} minutes"
-        )
-
-        # Cancel any existing scheduled updates
-        self._unsub_refresh = None
-
-        # Ensure the update interval is correctly set
-        self.update_interval = timedelta(minutes=self._update_interval_minutes)
-
-        # Log next update time
-        next_update = dt_util.utcnow() + self.update_interval
-        _LOGGER.warning(
-            f"Next automatic update scheduled for: {next_update.isoformat()}"
         )
 
     async def set_thermostat_temperature(self, device_id, temperature):

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
 from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 
@@ -106,6 +107,19 @@ class TestCoordinatorConstruction:
         assert coordinator.update_interval == timedelta(
             minutes=DEFAULT_UPDATE_INTERVAL
         )
+
+    async def test_construction_does_not_log_above_debug(self, hass, caplog):
+        # Setting up the coordinator's update interval is routine, expected
+        # behaviour on every startup/reload - it shouldn't show up in a
+        # user's log unless they've turned on debug logging.
+        entry = _make_entry(hass)
+
+        with caplog.at_level(
+            logging.WARNING, logger="custom_components.lksystems"
+        ):
+            LKSystemCoordinator(hass, entry)
+
+        assert caplog.records == []
 
 
 class TestAsyncUpdateData:


### PR DESCRIPTION
Coordinator startup was logging three routine, expected-on-every-boot/reload messages at `WARNING`:

- "Initializing LK Systems coordinator with update interval: ..."
- "Setting up update interval for lksystems to ..."
- "Next automatic update scheduled for: ..."

None of these indicate anything unexpected - they fire on every normal startup and reload, so `WARNING` was misleading noise in a user's log.

## Fix

- Downgraded the one message worth keeping to `debug`.
- Removed `_setup_update_interval()` entirely. It only ever ran once, from `__init__` - options changes go through a full config-entry reload rather than calling it again - so it was dead weight: it re-set `self.update_interval` to the exact value the constructor two lines above it had already set, and its "Next automatic update scheduled for: ..." log was actively misleading, since it never got reissued and so never reflected the coordinator's real recurring poll schedule.

## Testing

Built test-driven: added `tests_ha/test_coordinator.py::TestCoordinatorConstruction::test_construction_does_not_log_above_debug` (asserts no `WARNING`+ records from `custom_components.lksystems` on construction), confirmed it failed against the pre-fix code for the expected reason (three `WARNING` records), then applied the fix and confirmed it passes.

Also deployed to a real HA instance and confirmed the warnings are gone after a full restart (a plain integration "Reload" doesn't re-import changed `.py` files, since the module stays cached in `sys.modules` - only a full HA restart does).

Merges cleanly onto current `main` (no conflicts); full suite passes (122 passed, 1 pre-existing unrelated teardown error tracked in #71).