### PR TITLE
Add a Pause Leak Detection button, with configurable duration

### DIFF
--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -21,6 +21,7 @@ from homeassistant.exceptions import HomeAssistantError, ConfigEntryAuthFailed
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
@@ -30,7 +31,13 @@ from homeassistant.util import dt as dt_util
 import voluptuous as vol
 from homeassistant.helpers import config_validation as cv
 
-from .const import CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL, DOMAIN
+from .const import (
+    CONF_UPDATE_INTERVAL,
+    CUBIC_SECURE_MODEL,
+    DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+    MANUFACTURER,
+)
 from .pylksystems import (
     LKSystemsManager,
     LKSystemsError,
@@ -51,7 +58,7 @@ _LOGGER = logging.getLogger(__name__)
 CONSECUTIVE_FAILURE_THRESHOLD = 3
 
 # Define the platforms we support
-PLATFORMS = [Platform.SENSOR, Platform.CLIMATE]
+PLATFORMS = [Platform.SENSOR, Platform.CLIMATE, Platform.NUMBER, Platform.BUTTON]
 
 
 class LkStructureResp(TypedDict):
@@ -228,6 +235,12 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         self._last_update_time = dt_util.now()
         self._entry_id = entry.entry_id
         self._consecutive_failures = 0
+
+        # How long the next "Pause Leak Detection" button press should pause
+        # for, per Cubic Secure device serial number. A local preference
+        # (not fetched from the API), set by number.py and read by
+        # button.py.
+        self.pause_leak_detection_seconds: dict[str, int] = {}
 
         # Initialize coordinator with update interval
         super().__init__(
@@ -815,6 +828,30 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         except LKSystemsError as err:
             _LOGGER.error("LK Systems error during update: %s", str(err))
             raise UpdateFailed(str(err)) from err
+
+
+def cubic_secure_device_identities(coordinator: LKSystemCoordinator) -> list[str]:
+    """Return the device identities of every Cubic Secure device on the account."""
+    return list(coordinator.data.get("cubic_devices", {}))
+
+
+def cubic_secure_device_info(
+    coordinator: LKSystemCoordinator, device_identity: str
+) -> DeviceInfo:
+    """Build the shared DeviceInfo for a Cubic Secure device.
+
+    Every platform with an entity on a Cubic Secure device (sensor,
+    number, button, ...) calls this, so they all resolve to the same HA
+    device instead of each building their own copy.
+    """
+    machine_info = coordinator.data["cubic_devices"][device_identity]["machine_info"]
+    return DeviceInfo(
+        identifiers={(DOMAIN, device_identity)},
+        manufacturer=MANUFACTURER,
+        model=CUBIC_SECURE_MODEL,
+        name=f"Cubic Secure {machine_info['zone']['zoneName']}",
+        serial_number=device_identity,
+    )
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/custom_components/lksystems/button.py
+++ b/custom_components/lksystems/button.py
@@ -1,0 +1,80 @@
+"""Button platform for LK Systems integration."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import LKSystemCoordinator, cubic_secure_device_identities, cubic_secure_device_info
+from .const import ATTRIBUTION, DEFAULT_PAUSE_LEAK_DETECTION_SECONDS, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up LK Systems button entities based on a config entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_entities(
+        LKPauseLeakDetectionButton(coordinator, device_identity)
+        for device_identity in cubic_secure_device_identities(coordinator)
+    )
+
+
+class LKPauseLeakDetectionButton(ButtonEntity):
+    """Pauses leak detection for the device's configured duration.
+
+    A one-tap dashboard alternative to calling the pause_leak_detection
+    service by hand - e.g. before starting a manual watering session, or
+    wired into an irrigation automation. Delegates to that same service
+    (rather than duplicating its login/error-handling) using whichever
+    duration is currently set on the device's "Pause Leak Detection
+    Duration" number entity. Doesn't subclass CoordinatorEntity: pressing
+    it has nothing to do with coordinator polls.
+    """
+
+    _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
+    _attr_name = "Pause Leak Detection"
+    _attr_icon = "mdi:pause-circle-outline"
+
+    def __init__(self, coordinator: LKSystemCoordinator, device_identity: str) -> None:
+        """Initialize the button entity."""
+        self.coordinator = coordinator
+        self._device_identity = device_identity
+        self._attr_unique_id = f"LkUid_pause_leak_detection_{device_identity}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device_info of the device."""
+        return cubic_secure_device_info(self.coordinator, self._device_identity)
+
+    async def async_press(self) -> None:
+        """Pause leak detection for this device's configured duration."""
+        device_entry = dr.async_get(self.hass).async_get_device(
+            identifiers={(DOMAIN, self._device_identity)}
+        )
+        if device_entry is None:
+            _LOGGER.error(
+                "No registered device found for %s, cannot pause leak detection",
+                self._device_identity,
+            )
+            return
+
+        seconds = self.coordinator.pause_leak_detection_seconds.get(
+            self._device_identity, DEFAULT_PAUSE_LEAK_DETECTION_SECONDS
+        )
+        await self.hass.services.async_call(
+            DOMAIN,
+            "pause_leak_detection",
+            {"device_id": device_entry.id, "seconds": seconds},
+            blocking=True,
+        )

--- a/custom_components/lksystems/const.py
+++ b/custom_components/lksystems/const.py
@@ -27,6 +27,12 @@ CONF_UPDATE_INTERVAL = "update_interval"
 # Default update interval in minutes
 DEFAULT_UPDATE_INTERVAL = 5
 
+# Default/bounds (in seconds) for the "Pause Leak Detection Duration" number
+# entity. The default matches the pause_leak_detection service's own default.
+DEFAULT_PAUSE_LEAK_DETECTION_SECONDS: Final = 3600
+PAUSE_LEAK_DETECTION_MIN_SECONDS: Final = 60
+PAUSE_LEAK_DETECTION_MAX_SECONDS: Final = 86400
+
 
 LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
     "volumetotalday": SensorEntityDescription(

--- a/custom_components/lksystems/number.py
+++ b/custom_components/lksystems/number.py
@@ -1,0 +1,89 @@
+"""Number platform for LK Systems integration."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.number import NumberDeviceClass, NumberMode, RestoreNumber
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from . import LKSystemCoordinator, cubic_secure_device_identities, cubic_secure_device_info
+from .const import (
+    ATTRIBUTION,
+    DEFAULT_PAUSE_LEAK_DETECTION_SECONDS,
+    DOMAIN,
+    PAUSE_LEAK_DETECTION_MAX_SECONDS,
+    PAUSE_LEAK_DETECTION_MIN_SECONDS,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up LK Systems number entities based on a config entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_entities(
+        LKPauseLeakDetectionDurationNumber(coordinator, device_identity)
+        for device_identity in cubic_secure_device_identities(coordinator)
+    )
+
+
+class LKPauseLeakDetectionDurationNumber(RestoreNumber):
+    """How long the device's "Pause Leak Detection" button should pause for.
+
+    A local preference, not fetched from the API - the API only takes a
+    duration on each pause-leak-detection call, it doesn't expose a
+    "currently configured duration" of its own. The coordinator holds the
+    live value (shared with button.py); this entity is a persisted view
+    onto it, restoring the last value across HA restarts. It doesn't
+    subclass CoordinatorEntity: its value has nothing to do with
+    coordinator polls, so it stays available even when the last poll
+    failed.
+    """
+
+    _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
+    _attr_name = "Pause Leak Detection Duration"
+    _attr_icon = "mdi:timer-outline"
+    _attr_device_class = NumberDeviceClass.DURATION
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
+    _attr_native_min_value = PAUSE_LEAK_DETECTION_MIN_SECONDS
+    _attr_native_max_value = PAUSE_LEAK_DETECTION_MAX_SECONDS
+    _attr_native_step = 60
+    _attr_mode = NumberMode.BOX
+
+    def __init__(self, coordinator: LKSystemCoordinator, device_identity: str) -> None:
+        """Initialize the number entity."""
+        self.coordinator = coordinator
+        self._device_identity = device_identity
+        self._attr_unique_id = f"LkUid_pause_leak_detection_duration_{device_identity}"
+        self._attr_native_value = DEFAULT_PAUSE_LEAK_DETECTION_SECONDS
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device_info of the device."""
+        return cubic_secure_device_info(self.coordinator, self._device_identity)
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last configured duration, if any, on startup/reload."""
+        await super().async_added_to_hass()
+        last_number_data = await self.async_get_last_number_data()
+        if last_number_data is None or last_number_data.native_value is None:
+            return
+        self._attr_native_value = last_number_data.native_value
+        self.coordinator.pause_leak_detection_seconds[self._device_identity] = int(
+            last_number_data.native_value
+        )
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the configured duration."""
+        self._attr_native_value = value
+        self.coordinator.pause_leak_detection_seconds[self._device_identity] = int(value)
+        self.async_write_ha_state()

--- a/custom_components/lksystems/sensor.py
+++ b/custom_components/lksystems/sensor.py
@@ -26,17 +26,15 @@ from homeassistant.helpers.update_coordinator import (
 )
 import homeassistant.util.dt as dt_util
 
-from . import LKSystemCoordinator
+from . import LKSystemCoordinator, cubic_secure_device_info
 from .const import (
     ATTRIBUTION,
     C_NEXT_UPDATE_TIME,
     C_UPDATE_TIME,
-    CUBIC_SECURE_MODEL,
     DOMAIN,
     INTEGRATION_NAME,
     LK_CUBICSECURE_SENSORS,
     LK_CUBICSECURE_CONFIG_SENSORS,
-    MANUFACTURER,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -910,12 +908,7 @@ class AbstractLkCubicSensor(CoordinatorEntity[LKSystemCoordinator], SensorEntity
         _LOGGER.debug("Creating %s sensor", description.name)
         super().__init__(coordinator)
         self._coordinator = coordinator
-        self._device_model = CUBIC_SECURE_MODEL
         self._id = device_identity
-        machine_info = coordinator.data["cubic_devices"][device_identity][
-            "machine_info"
-        ]
-        self._device_name = f"Cubic Secure {machine_info['zone']['zoneName']}"
         self.entity_description = description
         self.native_unit_of_measurement = description.native_unit_of_measurement
         self._attr_unique_id = f"LkUid_{description.key}_{device_identity}"
@@ -924,14 +917,7 @@ class AbstractLkCubicSensor(CoordinatorEntity[LKSystemCoordinator], SensorEntity
     @property
     def device_info(self) -> DeviceInfo:
         """Return the device_info of the device."""
-        device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._id)},
-            manufacturer=MANUFACTURER,
-            model=self._device_model,
-            name=self._device_name,
-            serial_number=self._id,
-        )
-        return device_info
+        return cubic_secure_device_info(self.coordinator, self._id)
 
 
 class LKCubicSensor(AbstractLkCubicSensor):

--- a/tests_ha/conftest.py
+++ b/tests_ha/conftest.py
@@ -428,6 +428,22 @@ def entity_id(hass, platform: str, unique_id: str) -> str:
     found = er.async_get(hass).async_get_entity_id(platform, DOMAIN, unique_id)
     assert found is not None, f"no {platform} entity registered for {unique_id!r}"
     return found
+
+
+def patch_services_manager(manager: FakeLKSystemsManager):
+    """Patch the LKSystemsManager used by services.py's own handlers.
+
+    Needed by anything that ends up going through a service call - either
+    directly (hass.services.async_call) or indirectly (an entity whose
+    action delegates to a service, e.g. button.py's pause-leak-detection
+    button) - since each service handler opens its own LKSystemsManager
+    rather than reusing the one patched for coordinator setup.
+    """
+    return patch(
+        "custom_components.lksystems.services.LKSystemsManager", return_value=manager
+    )
+
+
 @pytest.fixture
 def fake_manager_with_two_cubic_devices() -> FakeLKSystemsManager:
     """A FakeLKSystemsManager pre-populated with two Cubic Secure devices
@@ -447,9 +463,9 @@ async def setup_entry(
 ) -> MockConfigEntry:
     """Drive a real config-entry setup against a FakeLKSystemsManager.
 
-    Runs the coordinator's first refresh and both the sensor.py and
-    climate.py platforms' async_setup_entry() for real, so tests can inspect
-    the entities/entity registry they actually produce.
+    Runs the coordinator's first refresh and every platform's
+    async_setup_entry() for real (see __init__.py's PLATFORMS), so tests can
+    inspect the entities/entity registry they actually produce.
     """
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -461,6 +477,15 @@ async def setup_entry(
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
     return entry
+
+
+def pause_leak_detection_duration_unique_id(device_identity: str) -> str:
+    """unique_id of a device's "Pause Leak Detection Duration" number entity.
+
+    Shared by test_number.py (which owns the entity) and test_button.py
+    (which needs to look it up to drive the paired button's tests).
+    """
+    return f"LkUid_pause_leak_detection_duration_{device_identity}"
 
 
 def entity_id(hass, platform: str, unique_id: str) -> str:

--- a/tests_ha/test_button.py
+++ b/tests_ha/test_button.py
@@ -1,0 +1,102 @@
+"""Tests for button.py: the per-device "Pause Leak Detection" button.
+
+A one-tap dashboard alternative to calling the pause_leak_detection service
+by hand - it uses whichever duration is currently set on the device's
+"Pause Leak Detection Duration" number entity (see test_number.py).
+"""
+
+from __future__ import annotations
+
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+
+from custom_components.lksystems.const import DEFAULT_PAUSE_LEAK_DETECTION_SECONDS, DOMAIN
+
+from .conftest import (
+    CUBIC_IDENTITY,
+    CUBIC_IDENTITY_2,
+    entity_id,
+    pause_leak_detection_duration_unique_id as _number_unique_id,
+    patch_services_manager,
+    setup_entry,
+)
+
+
+def _button_unique_id(device_identity: str) -> str:
+    return f"LkUid_pause_leak_detection_{device_identity}"
+
+
+async def test_belongs_to_the_cubic_secure_device(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+    button_entity_id = entity_id(hass, "button", _button_unique_id(CUBIC_IDENTITY))
+
+    device = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, CUBIC_IDENTITY)})
+    entry = er.async_get(hass).async_get(button_entity_id)
+
+    assert entry.device_id == device.id
+
+
+async def test_press_pauses_leak_detection_for_the_default_duration(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+    button_entity_id = entity_id(hass, "button", _button_unique_id(CUBIC_IDENTITY))
+
+    with patch_services_manager(fake_manager):
+        await hass.services.async_call(
+            "button", "press", {"entity_id": button_entity_id}, blocking=True
+        )
+
+    assert (
+        "cubic_secure_pause_leak_detection",
+        CUBIC_IDENTITY,
+        DEFAULT_PAUSE_LEAK_DETECTION_SECONDS,
+    ) in fake_manager.calls
+
+
+async def test_press_uses_the_configured_duration(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+    number_entity_id = entity_id(hass, "number", _number_unique_id(CUBIC_IDENTITY))
+    button_entity_id = entity_id(hass, "button", _button_unique_id(CUBIC_IDENTITY))
+
+    await hass.services.async_call(
+        "number", "set_value", {"entity_id": number_entity_id, "value": 900}, blocking=True
+    )
+
+    with patch_services_manager(fake_manager):
+        await hass.services.async_call(
+            "button", "press", {"entity_id": button_entity_id}, blocking=True
+        )
+
+    assert (
+        "cubic_secure_pause_leak_detection",
+        CUBIC_IDENTITY,
+        900,
+    ) in fake_manager.calls
+
+
+async def test_two_cubic_secure_devices_have_independent_buttons(
+    hass, fake_manager_with_two_cubic_devices
+):
+    await setup_entry(hass, fake_manager_with_two_cubic_devices)
+    first_number = entity_id(hass, "number", _number_unique_id(CUBIC_IDENTITY))
+    first_button = entity_id(hass, "button", _button_unique_id(CUBIC_IDENTITY))
+    second_button = entity_id(hass, "button", _button_unique_id(CUBIC_IDENTITY_2))
+
+    await hass.services.async_call(
+        "number", "set_value", {"entity_id": first_number, "value": 120}, blocking=True
+    )
+
+    with patch_services_manager(fake_manager_with_two_cubic_devices):
+        await hass.services.async_call(
+            "button", "press", {"entity_id": first_button}, blocking=True
+        )
+        await hass.services.async_call(
+            "button", "press", {"entity_id": second_button}, blocking=True
+        )
+
+    calls = fake_manager_with_two_cubic_devices.calls
+    assert ("cubic_secure_pause_leak_detection", CUBIC_IDENTITY, 120) in calls
+    assert (
+        "cubic_secure_pause_leak_detection",
+        CUBIC_IDENTITY_2,
+        DEFAULT_PAUSE_LEAK_DETECTION_SECONDS,
+    ) in calls

--- a/tests_ha/test_number.py
+++ b/tests_ha/test_number.py
@@ -1,0 +1,124 @@
+"""Tests for number.py: the per-device "Pause Leak Detection Duration" entity.
+
+This entity holds a local preference only - the API has no "get configured
+pause duration" endpoint, just "pause for N seconds" on each call - so its
+value is read/written straight to the coordinator and persisted via HA's
+restore-state mechanism rather than fetched from the coordinator's polled
+data.
+"""
+
+from __future__ import annotations
+
+from homeassistant.core import State
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import mock_restore_cache_with_extra_data
+
+from custom_components.lksystems.const import (
+    DEFAULT_PAUSE_LEAK_DETECTION_SECONDS,
+    DOMAIN,
+    PAUSE_LEAK_DETECTION_MAX_SECONDS,
+    PAUSE_LEAK_DETECTION_MIN_SECONDS,
+)
+
+from .conftest import (
+    CUBIC_IDENTITY,
+    CUBIC_IDENTITY_2,
+    entity_id,
+    pause_leak_detection_duration_unique_id as _number_unique_id,
+    setup_entry,
+)
+
+
+async def test_defaults_to_the_service_default(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+    number_entity_id = entity_id(hass, "number", _number_unique_id(CUBIC_IDENTITY))
+
+    state = hass.states.get(number_entity_id)
+
+    assert float(state.state) == DEFAULT_PAUSE_LEAK_DETECTION_SECONDS
+
+
+async def test_bounds_match_pause_leak_detection_limits(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+    number_entity_id = entity_id(hass, "number", _number_unique_id(CUBIC_IDENTITY))
+
+    state = hass.states.get(number_entity_id)
+
+    assert float(state.attributes["min"]) == PAUSE_LEAK_DETECTION_MIN_SECONDS
+    assert float(state.attributes["max"]) == PAUSE_LEAK_DETECTION_MAX_SECONDS
+
+
+async def test_belongs_to_the_cubic_secure_device(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+    number_entity_id = entity_id(hass, "number", _number_unique_id(CUBIC_IDENTITY))
+
+    device = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, CUBIC_IDENTITY)})
+    entry = er.async_get(hass).async_get(number_entity_id)
+
+    assert entry.device_id == device.id
+
+
+async def test_setting_a_value_updates_the_coordinator(hass, fake_manager):
+    entry = await setup_entry(hass, fake_manager)
+    number_entity_id = entity_id(hass, "number", _number_unique_id(CUBIC_IDENTITY))
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    await hass.services.async_call(
+        "number", "set_value", {"entity_id": number_entity_id, "value": 900}, blocking=True
+    )
+
+    assert coordinator.pause_leak_detection_seconds[CUBIC_IDENTITY] == 900
+    assert float(hass.states.get(number_entity_id).state) == 900
+
+
+async def test_two_cubic_secure_devices_get_independent_durations(
+    hass, fake_manager_with_two_cubic_devices
+):
+    entry = await setup_entry(hass, fake_manager_with_two_cubic_devices)
+    first_id = entity_id(hass, "number", _number_unique_id(CUBIC_IDENTITY))
+    second_id = entity_id(hass, "number", _number_unique_id(CUBIC_IDENTITY_2))
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    await hass.services.async_call(
+        "number", "set_value", {"entity_id": first_id, "value": 300}, blocking=True
+    )
+
+    assert coordinator.pause_leak_detection_seconds[CUBIC_IDENTITY] == 300
+    assert CUBIC_IDENTITY_2 not in coordinator.pause_leak_detection_seconds
+    assert float(hass.states.get(second_id).state) == DEFAULT_PAUSE_LEAK_DETECTION_SECONDS
+
+
+async def test_restores_last_value_on_startup(hass, fake_manager):
+    """Seed the restore cache before the entity is ever created, the way
+    HA repopulates it from disk on a real restart - a live entity has no
+    prior instance to hand data to, so there's nothing to reload here.
+    """
+    # Predictable from has_entity_name=True: "<device slug>_<entity slug>".
+    number_entity_id = "number.cubic_secure_utility_room_pause_leak_detection_duration"
+    mock_restore_cache_with_extra_data(
+        hass,
+        [
+            (
+                State(number_entity_id, "1800"),
+                {
+                    "native_max_value": PAUSE_LEAK_DETECTION_MAX_SECONDS,
+                    "native_min_value": PAUSE_LEAK_DETECTION_MIN_SECONDS,
+                    "native_step": 60,
+                    "native_unit_of_measurement": "s",
+                    "native_value": 1800,
+                },
+            )
+        ],
+    )
+
+    entry = await setup_entry(hass, fake_manager)
+
+    # Confirms the guessed entity_id above actually matches what HA
+    # assigned - if slugify rules ever changed, this fails loudly instead
+    # of the restore silently not applying.
+    assert entity_id(hass, "number", _number_unique_id(CUBIC_IDENTITY)) == number_entity_id
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    assert coordinator.pause_leak_detection_seconds[CUBIC_IDENTITY] == 1800
+    assert float(hass.states.get(number_entity_id).state) == 1800

--- a/tests_ha/test_services.py
+++ b/tests_ha/test_services.py
@@ -19,13 +19,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.lksystems.const import DOMAIN
 
-from .conftest import CUBIC_IDENTITY
-
-
-def _patch_services_manager(manager):
-    return patch(
-        "custom_components.lksystems.services.LKSystemsManager", return_value=manager
-    )
+from .conftest import CUBIC_IDENTITY, patch_services_manager
 
 
 async def _setup_entry_and_get_cubic_device(hass, manager):
@@ -49,7 +43,7 @@ async def _setup_entry_and_get_cubic_device(hass, manager):
 async def test_close_valve_calls_client(hass, fake_manager):
     _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
 
-    with _patch_services_manager(fake_manager):
+    with patch_services_manager(fake_manager):
         await hass.services.async_call(
             DOMAIN, "close_valve", {"device_id": device_entry.id}, blocking=True
         )
@@ -60,7 +54,7 @@ async def test_close_valve_calls_client(hass, fake_manager):
 async def test_open_valve_calls_client(hass, fake_manager):
     _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
 
-    with _patch_services_manager(fake_manager):
+    with patch_services_manager(fake_manager):
         await hass.services.async_call(
             DOMAIN, "open_valve", {"device_id": device_entry.id}, blocking=True
         )
@@ -71,7 +65,7 @@ async def test_open_valve_calls_client(hass, fake_manager):
 async def test_pause_leak_detection_calls_client(hass, fake_manager):
     _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
 
-    with _patch_services_manager(fake_manager):
+    with patch_services_manager(fake_manager):
         await hass.services.async_call(
             DOMAIN,
             "pause_leak_detection",
@@ -89,7 +83,7 @@ async def test_pause_leak_detection_calls_client(hass, fake_manager):
 async def test_set_pressure_test_schedule_calls_client(hass, fake_manager):
     _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
 
-    with _patch_services_manager(fake_manager):
+    with patch_services_manager(fake_manager):
         await hass.services.async_call(
             DOMAIN,
             "set_pressure_test_schedule",
@@ -108,7 +102,7 @@ async def test_set_pressure_test_schedule_calls_client(hass, fake_manager):
 async def test_set_thresholds_calls_client_with_defaults(hass, fake_manager):
     _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
 
-    with _patch_services_manager(fake_manager):
+    with patch_services_manager(fake_manager):
         await hass.services.async_call(
             DOMAIN,
             "set_thresholds",
@@ -131,7 +125,7 @@ async def test_close_valve_login_failure_does_not_raise(hass, fake_manager):
     _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
     fake_manager.login_result = False
 
-    with _patch_services_manager(fake_manager):
+    with patch_services_manager(fake_manager):
         await hass.services.async_call(
             DOMAIN, "close_valve", {"device_id": device_entry.id}, blocking=True
         )
@@ -163,7 +157,7 @@ async def test_unknown_device_does_not_raise(
     """
     await _setup_entry_and_get_cubic_device(hass, fake_manager)
 
-    with _patch_services_manager(fake_manager):
+    with patch_services_manager(fake_manager):
         await hass.services.async_call(
             DOMAIN,
             service,


### PR DESCRIPTION
Closes #28.

## What

Adds two entities per Cubic Secure device:

- **`button.<device>_pause_leak_detection`** — "Pause Leak Detection": a one-tap dashboard alternative to calling the `pause_leak_detection` service by hand.
- **`number.<device>_pause_leak_detection_duration`** — "Pause Leak Detection Duration": how long the button's next press should pause for. A local preference (the API only takes a duration per call, it has no "currently configured duration" of its own), persisted across HA restarts and shared with the button through the coordinator.

## Why

#28 asks for a way to bypass leak detection during irrigation without cutting power to the device. That capability already exists as the `pause_leak_detection` service (`disable-leak-detection` under the hood), but a *service* alone means Developer Tools → Actions or hand-written YAML — no dashboard tile, nothing a non-technical household member could press before starting the sprinklers. This gives it a real entity, the same gap #32 raised for the valve.

The button calls the existing `pause_leak_detection` service rather than duplicating its login/error-handling, so this PR stays self-contained to the two new platforms plus a `DeviceInfo`-building helper (`cubic_secure_device_info`) factored out of `sensor.py` so all three platforms share it instead of each keeping their own copy.

## Follow-ups deliberately left out of this PR

- `services.py`'s `pause_leak_detection` handler could hand the button a direct call (skipping a device-registry round trip it currently does only to reach that same service), and has a pre-existing copy-pasted log line ("Closing valve" logged from the leak-detection handler). Both touch already-shipped code unrelated to whether this feature works, so they're better reviewed on their own - noted separately.
- Configurable duration was scoped to this PR per discussion; a `number` entity remembers the last value you set (default 3600s, matching the service's own default) rather than reusing a fixed duration on every press.

## Testing

`tests_ha/test_button.py` and `tests_ha/test_number.py` (TDD'd - written failing first), covering: default duration, min/max bounds, device linkage, updating the coordinator, per-device independence with two Cubic Secure devices, and restore-across-restart. Full suite green: 132/132 (`tests_ha/` 99, `tests/` 33).

🤖 Generated with [Claude Code](https://claude.com/claude-code)