### PR TITLE
Extract pause_leak_detection_for_serial, fix its log message

### DIFF
--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -250,6 +250,17 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
             update_interval=timedelta(minutes=update_interval_minutes),
         )
 
+    @property
+    def entry(self) -> ConfigEntry:
+        """Return the config entry this coordinator was set up from.
+
+        Lets entities that need it (to call an API function directly,
+        outside the coordinator's own methods) reach it through the
+        coordinator they already hold, rather than each entity taking and
+        storing its own separate copy.
+        """
+        return self._entry
+
     async def set_thermostat_temperature(self, device_id, temperature):
         """Set thermostat temperature through the API.
 

--- a/custom_components/lksystems/button.py
+++ b/custom_components/lksystems/button.py
@@ -2,19 +2,15 @@
 
 from __future__ import annotations
 
-import logging
-
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from . import LKSystemCoordinator, cubic_secure_device_identities, cubic_secure_device_info
 from .const import ATTRIBUTION, DEFAULT_PAUSE_LEAK_DETECTION_SECONDS, DOMAIN
-
-_LOGGER = logging.getLogger(__name__)
+from .services import pause_leak_detection_for_serial
 
 
 async def async_setup_entry(
@@ -34,11 +30,10 @@ class LKPauseLeakDetectionButton(ButtonEntity):
 
     A one-tap dashboard alternative to calling the pause_leak_detection
     service by hand - e.g. before starting a manual watering session, or
-    wired into an irrigation automation. Delegates to that same service
-    (rather than duplicating its login/error-handling) using whichever
-    duration is currently set on the device's "Pause Leak Detection
-    Duration" number entity. Doesn't subclass CoordinatorEntity: pressing
-    it has nothing to do with coordinator polls.
+    wired into an irrigation automation - using whichever duration is
+    currently set on the device's "Pause Leak Detection Duration" number
+    entity. Doesn't subclass CoordinatorEntity: pressing it has nothing
+    to do with coordinator polls.
     """
 
     _attr_attribution = ATTRIBUTION
@@ -59,22 +54,9 @@ class LKPauseLeakDetectionButton(ButtonEntity):
 
     async def async_press(self) -> None:
         """Pause leak detection for this device's configured duration."""
-        device_entry = dr.async_get(self.hass).async_get_device(
-            identifiers={(DOMAIN, self._device_identity)}
-        )
-        if device_entry is None:
-            _LOGGER.error(
-                "No registered device found for %s, cannot pause leak detection",
-                self._device_identity,
-            )
-            return
-
         seconds = self.coordinator.pause_leak_detection_seconds.get(
             self._device_identity, DEFAULT_PAUSE_LEAK_DETECTION_SECONDS
         )
-        await self.hass.services.async_call(
-            DOMAIN,
-            "pause_leak_detection",
-            {"device_id": device_entry.id, "seconds": seconds},
-            blocking=True,
+        await pause_leak_detection_for_serial(
+            self.coordinator.entry, self._device_identity, seconds
         )

--- a/custom_components/lksystems/services.py
+++ b/custom_components/lksystems/services.py
@@ -9,6 +9,7 @@ from homeassistant.helpers import (
 )
 
 from .const import (
+    DEFAULT_PAUSE_LEAK_DETECTION_SECONDS,
     DOMAIN,
 )
 
@@ -29,27 +30,41 @@ def _get_serial_number(hass: HomeAssistant, device_id: str) -> str | None:
     return device_entry.serial_number
 
 
+async def pause_leak_detection_for_serial(
+    entry: ConfigEntry, serial_number: str, seconds: int
+) -> None:
+    """Log in and pause leak detection for one device.
+
+    Shared by the pause_leak_detection service handler below (which
+    resolves a device_id to a serial number first) and button.py's "Pause
+    Leak Detection" button, which already has the serial number and would
+    otherwise have to round-trip it through the device registry into a
+    device_id just to go through the service call layer.
+    """
+    _LOGGER.info("Pausing leak detection for %s for %s seconds", serial_number, seconds)
+    try:
+        username = entry.data.get(CONF_USERNAME)
+        password = entry.data.get(CONF_PASSWORD)
+
+        async with LKSystemsManager(username, password) as lk_inst:
+            if not await lk_inst.login():
+                _LOGGER.error("Failed to login, abort update")
+                raise Exception("Failed to login")
+            await lk_inst.cubic_secure_pause_leak_detection(serial_number, seconds)
+    except Exception as e:
+        _LOGGER.error("Error pausing leak detection: %s", e)
+
+
 async def async_setup_services(hass: HomeAssistant, entry: ConfigEntry) -> None:
     @callback
     async def pause_leak_detection(call: ServiceCall) -> None:
         """Handle the service action call."""
         device_id = call.data.get("device_id")
-        seconds = int(call.data.get("seconds", 3600))
+        seconds = int(call.data.get("seconds", DEFAULT_PAUSE_LEAK_DETECTION_SECONDS))
         sn = _get_serial_number(hass, device_id)
         if not sn:
             return
-        _LOGGER.info(f"Closing valve {sn}")
-        try:
-            username = entry.data.get(CONF_USERNAME)
-            password = entry.data.get(CONF_PASSWORD)
-
-            async with LKSystemsManager(username, password) as lk_inst:
-                if not await lk_inst.login():
-                    _LOGGER.error("Failed to login, abort update")
-                    raise Exception("Failed to login")
-                await lk_inst.cubic_secure_pause_leak_detection(sn, seconds)
-        except Exception as e:
-            _LOGGER.error("Error closing valve: %s", e)
+        await pause_leak_detection_for_serial(entry, sn, seconds)
 
     @callback
     async def close_valve(call: ServiceCall) -> None:

--- a/tests_ha/test_services.py
+++ b/tests_ha/test_services.py
@@ -18,6 +18,7 @@ from homeassistant.helpers import device_registry as dr
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.lksystems.const import DOMAIN
+from custom_components.lksystems.services import pause_leak_detection_for_serial
 
 from .conftest import CUBIC_IDENTITY, patch_services_manager
 
@@ -78,6 +79,59 @@ async def test_pause_leak_detection_calls_client(hass, fake_manager):
         CUBIC_IDENTITY,
         1800,
     ) in fake_manager.calls
+
+
+async def test_pause_leak_detection_logs_its_own_action(hass, fake_manager, caplog):
+    """Regression test: the handler used to log "Closing valve %s",
+    copy-pasted from close_valve and never updated."""
+    _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
+
+    with patch_services_manager(fake_manager), caplog.at_level("INFO"):
+        await hass.services.async_call(
+            DOMAIN,
+            "pause_leak_detection",
+            {"device_id": device_entry.id, "seconds": 1800},
+            blocking=True,
+        )
+
+    assert "closing valve" not in caplog.text.lower()
+    assert "pausing leak detection" in caplog.text.lower()
+
+
+def _bare_entry() -> MockConfigEntry:
+    """A config entry with just the credentials pause_leak_detection_for_serial
+    needs - unlike _setup_entry_and_get_cubic_device()'s entry, this one is
+    never added to hass, since these tests call the function directly rather
+    than through a service call.
+    """
+    return MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_USERNAME: "user@example.com", CONF_PASSWORD: "hunter2"},
+    )
+
+
+class TestPauseLeakDetectionForSerial:
+    """Direct tests for pause_leak_detection_for_serial (see its own
+    docstring for why it's called directly rather than only through the
+    service)."""
+
+    async def test_calls_the_client(self, fake_manager):
+        with patch_services_manager(fake_manager):
+            await pause_leak_detection_for_serial(_bare_entry(), CUBIC_IDENTITY, 1800)
+
+        assert (
+            "cubic_secure_pause_leak_detection",
+            CUBIC_IDENTITY,
+            1800,
+        ) in fake_manager.calls
+
+    async def test_login_failure_does_not_raise(self, fake_manager):
+        fake_manager.login_result = False
+
+        with patch_services_manager(fake_manager):
+            await pause_leak_detection_for_serial(_bare_entry(), CUBIC_IDENTITY, 1800)
+
+        assert not any(c[0] == "cubic_secure_pause_leak_detection" for c in fake_manager.calls)
 
 
 async def test_set_pressure_test_schedule_calls_client(hass, fake_manager):


### PR DESCRIPTION
Addresses #75.

Was `karl-petter/ha-lksystems#6`, stacked on #74 while that was still open - reopened directly against `main` now that #74 has merged (clean, no conflicts against current `main`).

## What

- Fixes a pre-existing copy-pasted log line: `pause_leak_detection`'s handler logged `"Closing valve %s"` (copied from `close_valve`, never updated).
- Extracts the handler's login/call/error-handling body into `pause_leak_detection_for_serial(entry, serial_number, seconds)`, so `button.py`'s button can call it directly with the serial number it already has, instead of round-tripping that identity through the device registry into a `device_id` just to reach the same function via the service-call layer.
- Points the handler's `seconds` default at `DEFAULT_PAUSE_LEAK_DETECTION_SECONDS` instead of a second, independent `3600` literal.
- Adds `LKSystemCoordinator.entry`: button.py needed a `ConfigEntry` to call the extracted function with, and the coordinator it already holds already stores one privately - no need for the button to carry a second copy.

## Deliberately out of scope

The same login/try-except/log-error shape is still duplicated across `close_valve`, `open_valve`, `set_pressure_test_schedule`, and `set_thresholds` - review surfaced this while extracting `pause_leak_detection`'s copy, but none of those four have a caller needing to bypass the service layer yet. Tracked in #75 as a follow-up, along with a second finding from unrelated valve-entity work (generalizing the coordinator's cache-bypass mechanism).

## Testing

`tests_ha/test_services.py`: a caplog-based regression test for the log message, plus direct unit tests for `pause_leak_detection_for_serial` (success, login-failure-swallowed). Full suite green: 156/156.

🤖 Generated with [Claude Code](https://claude.com/claude-code)