### PR TITLE
Add Pause/Resume Leak Detection with reliable, self-correcting state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ TODO.local.md
 .vscode/
 .claude/
 .mcp.json
+scratch/

--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import logging
 from typing import TypedDict
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta
 import asyncio
 import base64
@@ -20,7 +21,9 @@ except ImportError:
 from homeassistant.exceptions import HomeAssistantError, ConfigEntryAuthFailed
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.event import async_track_point_in_time
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
@@ -30,7 +33,15 @@ from homeassistant.util import dt as dt_util
 import voluptuous as vol
 from homeassistant.helpers import config_validation as cv
 
-from .const import CONF_UPDATE_INTERVAL, DEFAULT_UPDATE_INTERVAL, DOMAIN
+from .const import (
+    CONF_UPDATE_INTERVAL,
+    CUBIC_SECURE_MODEL,
+    DEFAULT_UPDATE_INTERVAL,
+    DOMAIN,
+    LEAK_DETECTION_EXPIRY_MAX_RETRY_SECONDS,
+    LEAK_DETECTION_EXPIRY_RETRY_INTERVAL_SECONDS,
+    MANUFACTURER,
+)
 from .pylksystems import (
     LKSystemsManager,
     LKSystemsError,
@@ -51,7 +62,7 @@ _LOGGER = logging.getLogger(__name__)
 CONSECUTIVE_FAILURE_THRESHOLD = 3
 
 # Define the platforms we support
-PLATFORMS = [Platform.SENSOR, Platform.CLIMATE]
+PLATFORMS = [Platform.SENSOR, Platform.CLIMATE, Platform.NUMBER, Platform.BUTTON]
 
 
 class LkStructureResp(TypedDict):
@@ -200,6 +211,22 @@ def is_token_valid(token: str) -> bool:
 # LkStructureResp = Dict[str, Any]
 
 
+class _LoginFailed(Exception):
+    """Raised by LKSystemCoordinator._authenticated_client() when there's
+    no valid cached token and a fresh login attempt fails."""
+
+
+def _round_to_nearest_minute(moment: datetime) -> datetime:
+    """Round a datetime to the nearest whole minute.
+
+    LK's own API has slop of up to ~90 seconds around when a pause
+    actually starts or ends - confirmed empirically against the real API -
+    so a second-precision "paused until" value would claim an accuracy the
+    underlying system doesn't have.
+    """
+    return (moment + timedelta(seconds=30)).replace(second=0, microsecond=0)
+
+
 class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
     """Data update coordinator for LK Systems."""
 
@@ -230,6 +257,32 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         self.last_successful_cloud_fetch: datetime | None = None
         self._consecutive_failures = 0
 
+        # How long the next "Pause Leak Detection" button press should pause
+        # for, per Cubic Secure device serial number. A local preference
+        # (not fetched from the API), set by number.py and read by
+        # button.py.
+        self.pause_leak_detection_seconds: dict[str, int] = {}
+
+        # When leak detection will resume for a paused Cubic Secure device,
+        # per device serial number - absent when not currently paused. The
+        # API's own muteLeak field doesn't decrement between polls and
+        # isn't a live countdown - confirmed empirically against the real
+        # API - so this is computed and tracked locally instead: set
+        # explicitly by set_leak_detection_paused_until() right after HA
+        # itself issues a pause/resume, and kept in sync with pauses/
+        # cancellations from elsewhere (e.g. the LK app) by
+        # _reconcile_leak_detection_paused_until() on every cached
+        # configuration fetch.
+        self.leak_detection_paused_until: dict[str, datetime] = {}
+
+        # Cancel handle for each device's pending
+        # _schedule_leak_detection_expiry_refresh() call, if any - reaching
+        # a target end time isn't itself an event anything reacts to, so
+        # without this, leak_detection_paused_until would just sit on a
+        # stale value until the next regular poll (up to a full
+        # update_interval later) picked up the change.
+        self._leak_detection_refresh_unsub: dict[str, CALLBACK_TYPE] = {}
+
         # Initialize coordinator with update interval
         super().__init__(
             hass,
@@ -237,6 +290,17 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
             name=DOMAIN,
             update_interval=timedelta(minutes=update_interval_minutes),
         )
+
+    @property
+    def entry(self) -> ConfigEntry:
+        """Return the config entry this coordinator was set up from.
+
+        Lets entities that need it (to call an API function directly,
+        outside the coordinator's own methods) reach it through the
+        coordinator they already hold, rather than each entity taking and
+        storing its own separate copy.
+        """
+        return self._entry
 
     async def set_thermostat_temperature(self, device_id, temperature):
         """Set thermostat temperature through the API.
@@ -391,6 +455,252 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         except Exception as ex:
             _LOGGER.error("Error during forced device update: %s", ex)
             return False
+
+    @asynccontextmanager
+    async def _authenticated_client(self):
+        """Yield a logged-in LKSystemsManager for a one-off API call,
+        reusing a still-valid stored token instead of always logging in
+        fresh. Raises _LoginFailed if there's no valid cached token and a
+        fresh login attempt fails.
+        """
+        username = self._entry.data.get(CONF_USERNAME)
+        password = self._entry.data.get(CONF_PASSWORD)
+
+        async with LKSystemsManager(username, password) as lk_inst:
+            stored_tokens = TOKEN_STORAGE.get(self._entry_id, {})
+            stored_jwt = stored_tokens.get("jwt")
+
+            if stored_jwt and is_token_valid(stored_jwt):
+                lk_inst.jwt_token = stored_jwt
+                lk_inst.refresh_token = stored_tokens.get("refresh")
+            else:
+                if not await lk_inst.login():
+                    raise _LoginFailed()
+
+                TOKEN_STORAGE[self._entry_id] = {
+                    "jwt": lk_inst.jwt_token,
+                    "refresh": lk_inst.refresh_token,
+                    "expiry": dt_util.utcnow().timestamp() + 3600,
+                }
+
+            yield lk_inst
+
+    def _pause_end_time(self, seconds: int) -> datetime:
+        """Return the (rounded) wall-clock time `seconds` from now."""
+        return _round_to_nearest_minute(dt_util.utcnow() + timedelta(seconds=seconds))
+
+    def _clear_leak_detection_paused_until(self, device_identity: str) -> None:
+        """Stop tracking a device as paused, and cancel any pending expiry
+        check for it - shared by an explicit resume and by reconciliation
+        learning the cloud considers it over."""
+        self.leak_detection_paused_until.pop(device_identity, None)
+        self._cancel_leak_detection_expiry_refresh(device_identity)
+
+    def _adopt_leak_detection_target(self, device_identity: str, seconds: int) -> None:
+        """Start tracking a device as paused for `seconds` from now, and
+        schedule its expiry check - shared by an explicit pause and by
+        reconciliation adopting one HA didn't itself start."""
+        target = self._pause_end_time(seconds)
+        self.leak_detection_paused_until[device_identity] = target
+        self._schedule_leak_detection_expiry_refresh(device_identity, target)
+
+    def set_leak_detection_paused_until(
+        self, device_identity: str, seconds: int
+    ) -> None:
+        """Set (or, for seconds=0, clear) a device's locally tracked pause
+        end time, right after HA itself issues a pause/resume that the API
+        call confirmed succeeded.
+
+        Takes effect immediately rather than waiting for
+        _reconcile_leak_detection_paused_until() to pick it up off the next
+        poll, and - for a re-pause while already active - overwrites the
+        previous target rather than leaving it in place, matching the real
+        API's reset-not-stack behavior (confirmed empirically).
+        """
+        if not seconds:
+            self._clear_leak_detection_paused_until(device_identity)
+            return
+        self._adopt_leak_detection_target(device_identity, seconds)
+
+    def _reconcile_leak_detection_paused_until(
+        self, device_identity: str, configuration: dict
+    ) -> None:
+        """Keep the locally tracked pause end time in sync with a pause
+        HA didn't itself just set - one started or cancelled from
+        elsewhere (e.g. the LK app), or one that expired naturally.
+
+        Only ever clears an untracked device or adopts a fresh target for
+        one that isn't tracked yet; never overwrites an already-tracked
+        target, since muteLeak can't tell a still-ongoing pause apart from
+        a brand new one started for a different duration - only
+        set_leak_detection_paused_until() (an explicit request HA itself
+        just made) may do that.
+        """
+        mute_leak_seconds = configuration.get("muteLeak")
+        if not mute_leak_seconds:
+            self._clear_leak_detection_paused_until(device_identity)
+            return
+        if device_identity not in self.leak_detection_paused_until:
+            self._adopt_leak_detection_target(device_identity, mute_leak_seconds)
+
+    def _schedule_leak_detection_expiry_refresh(
+        self, device_identity: str, target: datetime
+    ) -> None:
+        """Poll the cloud starting at a pause's target end time, retrying
+        every LEAK_DETECTION_EXPIRY_RETRY_INTERVAL_SECONDS until it
+        confirms the pause is actually over, so leak_detection_paused_until
+        clears promptly instead of sitting on a stale value until the next
+        regular poll. Gives up after LEAK_DETECTION_EXPIRY_MAX_RETRY_SECONDS
+        and leaves it to that regular poll instead.
+        """
+        self._cancel_leak_detection_expiry_refresh(device_identity)
+        retry_deadline = target + timedelta(
+            seconds=LEAK_DETECTION_EXPIRY_MAX_RETRY_SECONDS
+        )
+
+        def _track_at(when: datetime) -> None:
+            self._leak_detection_refresh_unsub[device_identity] = (
+                async_track_point_in_time(self.hass, _check_if_expired, when)
+            )
+
+        async def _check_if_expired(now: datetime) -> None:
+            self._leak_detection_refresh_unsub.pop(device_identity, None)
+            if not await self.refresh_cubic_secure_configuration(device_identity):
+                return
+            configuration = self.data["cubic_devices"][device_identity][
+                "configuration"
+            ]
+            self._reconcile_leak_detection_paused_until(device_identity, configuration)
+            # refresh_cubic_secure_configuration() above already notified
+            # listeners once, before this reconcile ran - entities reading
+            # leak_detection_paused_until (the Resume button, the "Leak
+            # Detection Paused Until" sensor) need a second notification to
+            # pick up what it just changed, or they're stuck showing the
+            # pre-reconcile state until the next regular poll.
+            self.async_update_listeners()
+
+            if device_identity not in self.leak_detection_paused_until:
+                # Logged at debug rather than left silent so how long the
+                # cloud actually lags past a pause's nominal end is
+                # observable from real usage over time, not just the one
+                # sample this was originally tuned from.
+                _LOGGER.debug(
+                    "Leak detection expiry for %s confirmed %s past its target",
+                    device_identity,
+                    now - target,
+                )
+                return
+            if now >= retry_deadline:
+                _LOGGER.debug(
+                    "Giving up on leak detection expiry checks for %s after %s - "
+                    "leaving it to the regular poll",
+                    device_identity,
+                    now - target,
+                )
+                return  # give up - the regular poll will pick it up eventually
+
+            _track_at(now + timedelta(seconds=LEAK_DETECTION_EXPIRY_RETRY_INTERVAL_SECONDS))
+
+        _track_at(target)
+
+    def _cancel_leak_detection_expiry_refresh(self, device_identity: str) -> None:
+        """Cancel a device's pending expiry check, if one is scheduled."""
+        if unsub := self._leak_detection_refresh_unsub.pop(device_identity, None):
+            unsub()
+
+    async def async_shutdown(self) -> None:
+        """Cancel any scheduled call, and ignore new runs.
+
+        Also cancels every pending leak-detection expiry check - they'd
+        otherwise fire against a torn-down coordinator after unload.
+        """
+        await super().async_shutdown()
+        for device_identity in list(self._leak_detection_refresh_unsub):
+            self._cancel_leak_detection_expiry_refresh(device_identity)
+
+    async def _update_cubic_secure_configuration(
+        self, device_identity: str, *, force_update: bool
+    ) -> bool:
+        """Fetch one Cubic Secure device's configuration and publish it.
+
+        Shared implementation for the two variants below - see their own
+        docstrings for which to use when.
+        """
+        try:
+            async with self._authenticated_client() as lk_inst:
+                success = await lk_inst.get_cubic_secure_configuration(
+                    device_identity, force_update=force_update
+                )
+
+                if success and self.data:
+                    self.data["cubic_devices"][device_identity]["configuration"] = (
+                        lk_inst.cubic_secure_configuration
+                    )
+                    # Deliberately doesn't call
+                    # _reconcile_leak_detection_paused_until() here: some
+                    # callers of this method (a pause/resume, an
+                    # open/close) reach it right after HA itself just
+                    # wrote something, and the cached response can still
+                    # be serving a pre-write snapshot for tens of seconds
+                    # - confirmed empirically against the real API -
+                    # reconciling off it there would race the explicit
+                    # set_leak_detection_paused_until() call the caller
+                    # already made and undo it. Reconciliation instead
+                    # happens at each call site once it's independently
+                    # established that enough time has passed for the
+                    # cached read to be trustworthy: the regular poll
+                    # (_fetch_data) isn't tied to a just-made write, and
+                    # the leak-detection expiry check
+                    # (_schedule_leak_detection_expiry_refresh) only ever
+                    # calls this at or after a pause's own target end time.
+                    self.async_set_updated_data(self.data)
+
+                return success
+
+        except _LoginFailed:
+            _LOGGER.error("Login failed when updating Cubic Secure configuration")
+            return False
+        except Exception as ex:
+            _LOGGER.error("Error updating Cubic Secure configuration: %s", ex)
+            return False
+
+    async def force_cubic_secure_configuration_update(self, device_identity: str) -> bool:
+        """Force-fetch one Cubic Secure device's configuration, bypassing
+        the LK API's own backend cache.
+
+        The regular poll (_fetch_data) only bypasses that cache once its
+        own cacheUpdated timestamp looks older than the poll interval -
+        decoupled from whether a write just happened, so it can't be
+        relied on to reflect a write promptly. Callers that just wrote a
+        physical device property (e.g. opening/closing the valve) need
+        this instead. Don't use this for server-side-tracked fields like
+        muteLeak - see refresh_cubic_secure_configuration().
+        """
+        _LOGGER.debug(
+            "Forcing configuration update for Cubic Secure device %s", device_identity
+        )
+        return await self._update_cubic_secure_configuration(
+            device_identity, force_update=True
+        )
+
+    async def refresh_cubic_secure_configuration(self, device_identity: str) -> bool:
+        """Fetch one Cubic Secure device's configuration via the LK API's
+        own cache (not bypassed).
+
+        Confirmed empirically against the real API: for server-side-
+        tracked fields like muteLeak, this cached read is the fresher
+        one - force_cubic_secure_configuration_update()'s bypass polls
+        the physical device live and doesn't carry server-managed timers
+        like muteLeak at all, while this cached snapshot updates
+        immediately on a write (e.g. button.py after pausing leak
+        detection).
+        """
+        _LOGGER.debug(
+            "Refreshing configuration for Cubic Secure device %s", device_identity
+        )
+        return await self._update_cubic_secure_configuration(
+            device_identity, force_update=False
+        )
 
     async def _async_update_data(self) -> LkStructureResp:
         """Fetch the latest data, surfacing persistent failures as repair issues.
@@ -666,6 +976,19 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                                         _LOGGER.debug(
                                             "Cubic secure configuration is older than update interval, force update"
                                         )
+                                        # The forced/bypass fetch below polls
+                                        # the physical device live rather
+                                        # than LK's backend cache, and the
+                                        # device doesn't report muteLeak at
+                                        # all - carry the cached value over
+                                        # so this staleness-triggered force
+                                        # doesn't wipe out a pause that's
+                                        # still running.
+                                        cached_mute_leak = (
+                                            lk_inst.cubic_secure_configuration.get(
+                                                "muteLeak"
+                                            )
+                                        )
                                         if not await lk_inst.get_cubic_secure_configuration(
                                             device_identity, force_update=True
                                         ):
@@ -675,10 +998,16 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                                             raise UpdateFailed(
                                                 "Unknown error get_cubic_secure_configuration"
                                             )
+                                        lk_inst.cubic_secure_configuration.setdefault(
+                                            "muteLeak", cached_mute_leak
+                                        )
 
                                 resp["cubic_devices"][device_identity][
                                     "configuration"
                                 ] = lk_inst.cubic_secure_configuration
+                                self._reconcile_leak_detection_paused_until(
+                                    device_identity, lk_inst.cubic_secure_configuration
+                                )
                             except Exception as err:
                                 # Sensors index these keys directly, so they
                                 # must exist even on failure; reuse this
@@ -820,6 +1149,30 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
             raise UpdateFailed(str(err)) from err
 
 
+def cubic_secure_device_identities(coordinator: LKSystemCoordinator) -> list[str]:
+    """Return the device identities of every Cubic Secure device on the account."""
+    return list(coordinator.data.get("cubic_devices", {}))
+
+
+def cubic_secure_device_info(
+    coordinator: LKSystemCoordinator, device_identity: str
+) -> DeviceInfo:
+    """Build the shared DeviceInfo for a Cubic Secure device.
+
+    Every platform with an entity on a Cubic Secure device (sensor,
+    number, button, ...) calls this, so they all resolve to the same HA
+    device instead of each building their own copy.
+    """
+    machine_info = coordinator.data["cubic_devices"][device_identity]["machine_info"]
+    return DeviceInfo(
+        identifiers={(DOMAIN, device_identity)},
+        manufacturer=MANUFACTURER,
+        model=CUBIC_SECURE_MODEL,
+        name=f"Cubic Secure {machine_info['zone']['zoneName']}",
+        serial_number=device_identity,
+    )
+
+
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Set up the LK Systems component."""
     hass.data[DOMAIN] = {}
@@ -912,6 +1265,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
+        # Cancels any pending leak-detection expiry checks, on top of the
+        # coordinator's own polling - see LKSystemCoordinator.async_shutdown().
+        await hass.data[DOMAIN][entry.entry_id].async_shutdown()
+
         # Clear token from cache on unload
         TOKEN_STORAGE.pop(entry.entry_id, None)
         hass.data[DOMAIN].pop(entry.entry_id)

--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -40,6 +40,7 @@ from .const import (
     DOMAIN,
     LEAK_DETECTION_EXPIRY_MAX_RETRY_SECONDS,
     LEAK_DETECTION_EXPIRY_RETRY_INTERVAL_SECONDS,
+    LEAK_DETECTION_LOCAL_WRITE_GRACE_SECONDS,
     MANUFACTURER,
 )
 from .pylksystems import (
@@ -274,6 +275,13 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         # _reconcile_leak_detection_paused_until() on every cached
         # configuration fetch.
         self.leak_detection_paused_until: dict[str, datetime] = {}
+
+        # When set_leak_detection_paused_until() last landed for a
+        # device - guards _reconcile_leak_detection_paused_until() against
+        # a poll that coincidentally lands moments after that write, while
+        # the cloud's cached response may still be serving a pre-write
+        # snapshot (see LEAK_DETECTION_LOCAL_WRITE_GRACE_SECONDS).
+        self._leak_detection_last_local_write: dict[str, datetime] = {}
 
         # Cancel handle for each device's pending
         # _schedule_leak_detection_expiry_refresh() call, if any - reaching
@@ -517,13 +525,14 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         previous target rather than leaving it in place, matching the real
         API's reset-not-stack behavior (confirmed empirically).
         """
+        self._leak_detection_last_local_write[device_identity] = dt_util.utcnow()
         if not seconds:
             self._clear_leak_detection_paused_until(device_identity)
             return
         self._adopt_leak_detection_target(device_identity, seconds)
 
     def _reconcile_leak_detection_paused_until(
-        self, device_identity: str, configuration: dict
+        self, device_identity: str, configuration: dict, now: datetime
     ) -> None:
         """Keep the locally tracked pause end time in sync with a pause
         HA didn't itself just set - one started or cancelled from
@@ -535,7 +544,24 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         a brand new one started for a different duration - only
         set_leak_detection_paused_until() (an explicit request HA itself
         just made) may do that.
+
+        Also does nothing within LEAK_DETECTION_LOCAL_WRITE_GRACE_SECONDS
+        of such a write: the caller triggering this (a regular poll or
+        the expiry retry-loop) isn't caused by the write, but nothing
+        stops it landing moments after one anyway, and `configuration`
+        can still be a pre-write cached snapshot at that point. Takes
+        `now` from the caller rather than reading dt_util.utcnow() itself,
+        so it judges the grace window against whatever moment the caller
+        is actually acting on - the expiry retry-loop already has its own
+        `now` (the point in time HA's scheduler woke it for), and reusing
+        it here keeps this check consistent with that, rather than a
+        second, independent clock read a moment later.
         """
+        last_write = self._leak_detection_last_local_write.get(device_identity)
+        if last_write is not None and now - last_write < timedelta(
+            seconds=LEAK_DETECTION_LOCAL_WRITE_GRACE_SECONDS
+        ):
+            return
         mute_leak_seconds = configuration.get("muteLeak")
         if not mute_leak_seconds:
             self._clear_leak_detection_paused_until(device_identity)
@@ -570,7 +596,9 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
             configuration = self.data["cubic_devices"][device_identity][
                 "configuration"
             ]
-            self._reconcile_leak_detection_paused_until(device_identity, configuration)
+            self._reconcile_leak_detection_paused_until(
+                device_identity, configuration, now
+            )
             # refresh_cubic_secure_configuration() above already notified
             # listeners once, before this reconcile ran - entities reading
             # leak_detection_paused_until (the Resume button, the "Leak
@@ -1006,7 +1034,9 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                                     "configuration"
                                 ] = lk_inst.cubic_secure_configuration
                                 self._reconcile_leak_detection_paused_until(
-                                    device_identity, lk_inst.cubic_secure_configuration
+                                    device_identity,
+                                    lk_inst.cubic_secure_configuration,
+                                    dt_util.utcnow(),
                                 )
                             except Exception as err:
                                 # Sensors index these keys directly, so they

--- a/custom_components/lksystems/button.py
+++ b/custom_components/lksystems/button.py
@@ -1,0 +1,110 @@
+"""Button platform for LK Systems integration."""
+
+from __future__ import annotations
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import LKSystemCoordinator, cubic_secure_device_identities, cubic_secure_device_info
+from .const import ATTRIBUTION, DEFAULT_PAUSE_LEAK_DETECTION_SECONDS, DOMAIN
+from .services import pause_leak_detection_for_serial
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up LK Systems button entities based on a config entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_entities(
+        button_class(coordinator, device_identity)
+        for device_identity in cubic_secure_device_identities(coordinator)
+        for button_class in (LKPauseLeakDetectionButton, LKResumeLeakDetectionButton)
+    )
+
+
+class _LKCubicSecureButton(ButtonEntity):
+    """Shared plumbing for the per-Cubic-Secure-device buttons below."""
+
+    _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
+    _unique_id_suffix: str
+
+    def __init__(self, coordinator: LKSystemCoordinator, device_identity: str) -> None:
+        """Initialize the button entity."""
+        self.coordinator = coordinator
+        self._device_identity = device_identity
+        self._attr_unique_id = f"LkUid_{self._unique_id_suffix}_{device_identity}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device_info of the device."""
+        return cubic_secure_device_info(self.coordinator, self._device_identity)
+
+
+class LKPauseLeakDetectionButton(_LKCubicSecureButton):
+    """Pauses leak detection for the device's configured duration.
+
+    A one-tap dashboard alternative to calling the pause_leak_detection
+    service by hand - e.g. before starting a manual watering session, or
+    wired into an irrigation automation - using whichever duration is
+    currently set on the device's "Pause Duration" number entity. Doesn't
+    subclass CoordinatorEntity: pressing it has nothing to do with
+    coordinator polls.
+    """
+
+    _attr_name = "Pause Leak Detection"
+    _attr_icon = "mdi:pause-circle-outline"
+    _unique_id_suffix = "pause_leak_detection"
+
+    async def async_press(self) -> None:
+        """Pause leak detection for this device's configured duration."""
+        seconds = self.coordinator.pause_leak_detection_seconds.get(
+            self._device_identity, DEFAULT_PAUSE_LEAK_DETECTION_SECONDS
+        )
+        await pause_leak_detection_for_serial(
+            self.hass, self.coordinator.entry, self._device_identity, seconds
+        )
+
+
+class LKResumeLeakDetectionButton(CoordinatorEntity[LKSystemCoordinator], _LKCubicSecureButton):
+    """Cancels an in-progress leak detection pause, resuming it early.
+
+    Confirmed empirically against the real API: there's no separate
+    "resume"/"cancel" endpoint - calling the same pause endpoint with
+    seconds=0 cancels an active pause rather than starting a zero-length
+    one, so this reuses pause_leak_detection_for_serial with seconds=0
+    instead of needing its own API call.
+
+    Unlike the Pause button, this one does subclass CoordinatorEntity:
+    its availability depends on the coordinator's data (there being
+    nothing to resume otherwise), so it needs to re-render whenever a
+    coordinator refresh changes that.
+    """
+
+    _attr_name = "Resume Leak Detection"
+    _attr_icon = "mdi:play-circle-outline"
+    _unique_id_suffix = "resume_leak_detection"
+
+    def __init__(self, coordinator: LKSystemCoordinator, device_identity: str) -> None:
+        """Initialize the button entity."""
+        CoordinatorEntity.__init__(self, coordinator)
+        _LKCubicSecureButton.__init__(self, coordinator, device_identity)
+
+    @property
+    def available(self) -> bool:
+        """Only pressable while a pause is actually active for this device."""
+        return (
+            super().available
+            and self._device_identity in self.coordinator.leak_detection_paused_until
+        )
+
+    async def async_press(self) -> None:
+        """Cancel this device's in-progress leak detection pause."""
+        await pause_leak_detection_for_serial(
+            self.hass, self.coordinator.entry, self._device_identity, 0
+        )

--- a/custom_components/lksystems/const.py
+++ b/custom_components/lksystems/const.py
@@ -49,6 +49,15 @@ LEAK_DETECTION_EXPIRY_RETRY_INTERVAL_SECONDS: Final = 15
 # has gone offline), not a value normal operation is expected to reach.
 LEAK_DETECTION_EXPIRY_MAX_RETRY_SECONDS: Final = 180
 
+# For this long after HA itself issues a pause/resume, don't let a
+# reconciliation pass override the local state with what the cloud
+# reports - the cloud's cached response can still be serving a pre-write
+# snapshot for tens of seconds (confirmed empirically against the real
+# API), and a poll landing in that window isn't caused by the write but
+# can still land inside it by coincidence. HA's own just-made write is
+# trusted for this window; past it, the cloud is trusted again.
+LEAK_DETECTION_LOCAL_WRITE_GRACE_SECONDS: Final = 60
+
 
 LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
     "volumetotalday": SensorEntityDescription(

--- a/custom_components/lksystems/const.py
+++ b/custom_components/lksystems/const.py
@@ -28,6 +28,27 @@ CONF_UPDATE_INTERVAL = "update_interval"
 # Default update interval in minutes
 DEFAULT_UPDATE_INTERVAL = 5
 
+# Default/bounds (in seconds) for the "Pause Duration" number
+# entity. The default matches the pause_leak_detection service's own default.
+DEFAULT_PAUSE_LEAK_DETECTION_SECONDS: Final = 3600
+PAUSE_LEAK_DETECTION_MIN_SECONDS: Final = 60
+PAUSE_LEAK_DETECTION_MAX_SECONDS: Final = 86400
+
+# Once a pause's target end time is reached, poll the cloud at this
+# interval until it confirms the pause is actually over, so "Leak
+# Detection Paused Until" clears promptly instead of waiting on the next
+# regular poll. A single delayed check isn't reliable here - how long the
+# cloud lags behind the device's real state past a pause's nominal end
+# varies (confirmed empirically against the real API, but not to one
+# fixed figure) - so this retries instead of guessing a wait long enough
+# to always be right.
+LEAK_DETECTION_EXPIRY_RETRY_INTERVAL_SECONDS: Final = 15
+
+# Stop retrying this long past the target and fall back to the regular
+# poll - a safety cap for if the cloud never resolves (e.g. the device
+# has gone offline), not a value normal operation is expected to reach.
+LEAK_DETECTION_EXPIRY_MAX_RETRY_SECONDS: Final = 180
+
 
 LK_CUBICSECURE_SENSORS: dict[str, SensorEntityDescription] = {
     "volumetotalday": SensorEntityDescription(

--- a/custom_components/lksystems/number.py
+++ b/custom_components/lksystems/number.py
@@ -1,0 +1,121 @@
+"""Number platform for LK Systems integration."""
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.number import NumberDeviceClass, NumberMode, RestoreNumber
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import UnitOfTime
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.util.unit_conversion import DurationConverter
+
+from . import LKSystemCoordinator, cubic_secure_device_identities, cubic_secure_device_info
+from .const import (
+    ATTRIBUTION,
+    DEFAULT_PAUSE_LEAK_DETECTION_SECONDS,
+    DOMAIN,
+    PAUSE_LEAK_DETECTION_MAX_SECONDS,
+    PAUSE_LEAK_DETECTION_MIN_SECONDS,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+
+def _minutes(seconds: float) -> float:
+    """Convert a seconds duration to minutes."""
+    return DurationConverter.convert(seconds, UnitOfTime.SECONDS, UnitOfTime.MINUTES)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up LK Systems number entities based on a config entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_entities(
+        LKPauseLeakDetectionDurationNumber(coordinator, device_identity)
+        for device_identity in cubic_secure_device_identities(coordinator)
+    )
+
+
+class LKPauseLeakDetectionDurationNumber(RestoreNumber):
+    """How long the device's "Pause Leak Detection" button should pause for.
+
+    A local preference, not fetched from the API - the API only takes a
+    duration on each pause-leak-detection call, it doesn't expose a
+    "currently configured duration" of its own. The coordinator holds the
+    live value (shared with button.py); this entity is a persisted view
+    onto it, restoring the last value across HA restarts. It doesn't
+    subclass CoordinatorEntity: its value has nothing to do with
+    coordinator polls, so it stays available even when the last poll
+    failed.
+
+    Displayed (and stored/restored) in minutes for readability - a pause
+    is realistically minutes-to-a-day long, and NumberEntity has no
+    suggested-unit mechanism like SensorEntity's to convert that from a
+    seconds-native value automatically. The coordinator's
+    pause_leak_detection_seconds - and everything downstream of it
+    (button.py, services.py) - keeps working in seconds, matching the
+    API's own "pause for N seconds" contract; this entity converts at its
+    own boundary instead, via DurationConverter.
+    """
+
+    _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
+    _attr_name = "Pause Duration"
+    _attr_icon = "mdi:timer-outline"
+    _attr_device_class = NumberDeviceClass.DURATION
+    _attr_native_unit_of_measurement = UnitOfTime.MINUTES
+    _attr_native_min_value = _minutes(PAUSE_LEAK_DETECTION_MIN_SECONDS)
+    _attr_native_max_value = _minutes(PAUSE_LEAK_DETECTION_MAX_SECONDS)
+    _attr_native_step = 1
+    _attr_mode = NumberMode.BOX
+
+    def __init__(self, coordinator: LKSystemCoordinator, device_identity: str) -> None:
+        """Initialize the number entity."""
+        self.coordinator = coordinator
+        self._device_identity = device_identity
+        self._attr_unique_id = f"LkUid_pause_leak_detection_duration_{device_identity}"
+        self._attr_native_value = _minutes(DEFAULT_PAUSE_LEAK_DETECTION_SECONDS)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device_info of the device."""
+        return cubic_secure_device_info(self.coordinator, self._device_identity)
+
+    def _store_duration_minutes(self, minutes: float) -> None:
+        """Set the displayed value and push the equivalent seconds
+        duration to the coordinator, where button.py/services.py read it."""
+        self._attr_native_value = minutes
+        self.coordinator.pause_leak_detection_seconds[self._device_identity] = int(
+            DurationConverter.convert(minutes, UnitOfTime.MINUTES, UnitOfTime.SECONDS)
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Restore the last configured duration, if any, on startup/reload."""
+        await super().async_added_to_hass()
+        last_number_data = await self.async_get_last_number_data()
+        if (
+            last_number_data is None
+            or last_number_data.native_value is None
+            or last_number_data.native_unit_of_measurement is None
+        ):
+            return
+        # DurationConverter is a no-op when the restored unit already
+        # matches (the common case); it only does real work for data
+        # restored while this entity's native unit was still seconds.
+        self._store_duration_minutes(
+            DurationConverter.convert(
+                last_number_data.native_value,
+                last_number_data.native_unit_of_measurement,
+                UnitOfTime.MINUTES,
+            )
+        )
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Update the configured duration."""
+        self._store_duration_minutes(value)
+        self.async_write_ha_state()

--- a/custom_components/lksystems/sensor.py
+++ b/custom_components/lksystems/sensor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import datetime
 from typing import Any, Dict, Optional
 
 from homeassistant.components.sensor import (
@@ -28,17 +29,15 @@ from homeassistant.helpers.update_coordinator import (
 )
 import homeassistant.util.dt as dt_util
 
-from . import LKSystemCoordinator
+from . import LKSystemCoordinator, cubic_secure_device_info
 from .const import (
     ATTRIBUTION,
     C_NEXT_UPDATE_TIME,
     C_UPDATE_TIME,
-    CUBIC_SECURE_MODEL,
     DOMAIN,
     INTEGRATION_NAME,
     LK_CUBICSECURE_SENSORS,
     LK_CUBICSECURE_CONFIG_SENSORS,
-    MANUFACTURER,
 )
 from .restore import RestoredNativeValueMixin, last_successful_cloud_fetch_attributes
 
@@ -175,6 +174,10 @@ async def async_setup_entry(
                                 data_source="configuration",
                             )
                         )
+
+                cubic_entities.append(
+                    LKLeakDetectionPausedUntilSensor(coordinator, device_identity)
+                )
 
                 async_add_entities(cubic_entities, True)
 
@@ -936,12 +939,7 @@ class AbstractLkCubicSensor(
         _LOGGER.debug("Creating %s sensor", description.name)
         super().__init__(coordinator)
         self._coordinator = coordinator
-        self._device_model = CUBIC_SECURE_MODEL
         self._id = device_identity
-        machine_info = coordinator.data["cubic_devices"][device_identity][
-            "machine_info"
-        ]
-        self._device_name = f"Cubic Secure {machine_info['zone']['zoneName']}"
         self.entity_description = description
         self.native_unit_of_measurement = description.native_unit_of_measurement
         self._attr_unique_id = f"LkUid_{description.key}_{device_identity}"
@@ -950,14 +948,14 @@ class AbstractLkCubicSensor(
     @property
     def device_info(self) -> DeviceInfo:
         """Return the device_info of the device."""
-        device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._id)},
-            manufacturer=MANUFACTURER,
-            model=self._device_model,
-            name=self._device_name,
-            serial_number=self._id,
+        return cubic_secure_device_info(self.coordinator, self._id)
+
+    def _cubic_configuration(self) -> dict:
+        """Return this device's last-fetched configuration dict."""
+        device_data = self._coordinator.data.get("cubic_devices", {}).get(
+            self._id, {}
         )
-        return device_info
+        return device_data.get("configuration") or {}
 
 
 class LKCubicSensor(AbstractLkCubicSensor):
@@ -1024,7 +1022,7 @@ class LKCubicSensor(AbstractLkCubicSensor):
         )
 
         if self._data_source == "configuration":
-            cubic_configuration = device_data.get("configuration") or {}
+            cubic_configuration = self._cubic_configuration()
             if self._data_key in cubic_configuration:
                 value = cubic_configuration[self._data_key]
             elif "." in self._data_key:
@@ -1053,5 +1051,43 @@ class LKCubicSensor(AbstractLkCubicSensor):
                 return dt_util.utc_from_timestamp(float(value))
             except (ValueError, TypeError):
                 pass
-        
+
         return value
+
+
+class LKLeakDetectionPausedUntilSensor(AbstractLkCubicSensor):
+    """When the device's leak detection will resume, if currently paused.
+
+    Reads LKSystemCoordinator.leak_detection_paused_until through
+    unchanged - see that attribute's own docstring for why it's tracked
+    locally rather than computed from the API's data on every read.
+    """
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_icon = "mdi:timer-pause-outline"
+    _attr_translation_key = "leak_detection_paused_until_sensor"
+
+    def __init__(self, coordinator: LKSystemCoordinator, device_identity: str) -> None:
+        """Initialize the sensor."""
+        description = SensorEntityDescription(
+            key="leakDetectionPausedUntil",
+            name="Leak Detection Paused Until",
+        )
+        super().__init__(
+            coordinator=coordinator,
+            description=description,
+            device_identity=device_identity,
+        )
+
+    def _live_native_value(self) -> datetime | None:
+        """Get the latest state value from the coordinator's live data."""
+        return self.coordinator.leak_detection_paused_until.get(self._id)
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose the last-successful-cloud-fetch timestamp, matching every
+        other cubic sensor - see restore.py for why it needs to survive
+        across a restart."""
+        return last_successful_cloud_fetch_attributes(
+            self.coordinator.last_successful_cloud_fetch
+        )

--- a/custom_components/lksystems/services.py
+++ b/custom_components/lksystems/services.py
@@ -9,6 +9,7 @@ from homeassistant.helpers import (
 )
 
 from .const import (
+    DEFAULT_PAUSE_LEAK_DETECTION_SECONDS,
     DOMAIN,
 )
 
@@ -29,27 +30,50 @@ def _get_serial_number(hass: HomeAssistant, device_id: str) -> str | None:
     return device_entry.serial_number
 
 
+async def pause_leak_detection_for_serial(
+    hass: HomeAssistant, entry: ConfigEntry, serial_number: str, seconds: int
+) -> None:
+    """Log in and pause leak detection for one device.
+
+    Shared by the pause_leak_detection service handler below (which
+    resolves a device_id to a serial number first) and button.py's "Pause
+    Leak Detection"/"Resume Leak Detection" buttons, which already have
+    the serial number and would otherwise have to round-trip it through
+    the device registry into a device_id just to go through the service
+    call layer. Updates the coordinator's locally tracked pause end time
+    and refreshes the "Leak Detection Paused Until" sensor immediately on
+    success, rather than leaving either to the next scheduled poll -
+    living here means every caller gets that, not just whichever one
+    remembers to ask for it.
+    """
+    _LOGGER.info("Pausing leak detection for %s for %s seconds", serial_number, seconds)
+    try:
+        username = entry.data.get(CONF_USERNAME)
+        password = entry.data.get(CONF_PASSWORD)
+
+        async with LKSystemsManager(username, password) as lk_inst:
+            if not await lk_inst.login():
+                _LOGGER.error("Failed to login, abort update")
+                raise Exception("Failed to login")
+            await lk_inst.cubic_secure_pause_leak_detection(serial_number, seconds)
+
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+        coordinator.set_leak_detection_paused_until(serial_number, seconds)
+        await coordinator.refresh_cubic_secure_configuration(serial_number)
+    except Exception as e:
+        _LOGGER.error("Error pausing leak detection: %s", e)
+
+
 async def async_setup_services(hass: HomeAssistant, entry: ConfigEntry) -> None:
     @callback
     async def pause_leak_detection(call: ServiceCall) -> None:
         """Handle the service action call."""
         device_id = call.data.get("device_id")
-        seconds = int(call.data.get("seconds", 3600))
+        seconds = int(call.data.get("seconds", DEFAULT_PAUSE_LEAK_DETECTION_SECONDS))
         sn = _get_serial_number(hass, device_id)
         if not sn:
             return
-        _LOGGER.info(f"Closing valve {sn}")
-        try:
-            username = entry.data.get(CONF_USERNAME)
-            password = entry.data.get(CONF_PASSWORD)
-
-            async with LKSystemsManager(username, password) as lk_inst:
-                if not await lk_inst.login():
-                    _LOGGER.error("Failed to login, abort update")
-                    raise Exception("Failed to login")
-                await lk_inst.cubic_secure_pause_leak_detection(sn, seconds)
-        except Exception as e:
-            _LOGGER.error("Error closing valve: %s", e)
+        await pause_leak_detection_for_serial(hass, entry, sn, seconds)
 
     @callback
     async def close_valve(call: ServiceCall) -> None:

--- a/tests_ha/conftest.py
+++ b/tests_ha/conftest.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
@@ -102,6 +103,12 @@ class FakeLKSystemsManager:
         # single-device tests can keep using the simpler singular fields.
         self.cubic_measurements_by_device: dict[str, dict] = {}
         self.cubic_configurations_by_device: dict[str, dict] = {}
+        # Per-device override for what get_cubic_secure_configuration returns
+        # when *not* force_update - distinct from cubic_configurations_by_device
+        # above (used otherwise, and always when force_update=True) - lets
+        # tests simulate the real API's own server-side cache (the bypass=0
+        # path) serving a stale snapshot independently of the live value.
+        self.cubic_configurations_cached_by_device: dict[str, dict] = {}
 
         # Configurable outcomes for each call, so tests can force failures.
         self.login_result = True
@@ -179,9 +186,19 @@ class FakeLKSystemsManager:
             ("get_cubic_secure_configuration", device_identity, force_update)
         )
         if self.get_cubic_secure_configuration_result:
-            self.cubic_secure_configuration = self.cubic_configurations_by_device.get(
-                device_identity, self.cubic_configuration_data
-            )
+            if (
+                not force_update
+                and device_identity in self.cubic_configurations_cached_by_device
+            ):
+                self.cubic_secure_configuration = (
+                    self.cubic_configurations_cached_by_device[device_identity]
+                )
+            else:
+                self.cubic_secure_configuration = (
+                    self.cubic_configurations_by_device.get(
+                        device_identity, self.cubic_configuration_data
+                    )
+                )
         return self.get_cubic_secure_configuration_result
 
     async def set_thermostat_temperature(self, device_id, temperature):
@@ -357,13 +374,22 @@ def build_cubic_measurement(volume_total: int = 45000) -> dict:
     }
 
 
-def build_cubic_configuration(valve_state: str = "open") -> dict:
+def build_cubic_configuration(valve_state: str = "open", mute_leak: int = 0) -> dict:
     return {
         "cacheUpdated": int(time.time()),
         "valveState": valve_state,
         "firmwareVersion": "1.2.3",
         "hardwareVersion": 4,
+        "muteLeak": mute_leak,
     }
+
+
+def build_live_config_without_mute_leak(**kwargs) -> dict:
+    """A cubic configuration as the real bypass/"live" endpoint returns it -
+    it never carries muteLeak at all, unlike the cached endpoint."""
+    config = build_cubic_configuration(**kwargs)
+    del config["muteLeak"]
+    return config
 
 
 def configure_fake_manager_with_sample_data(manager: FakeLKSystemsManager) -> None:
@@ -428,6 +454,44 @@ def entity_id(hass, platform: str, unique_id: str) -> str:
     found = er.async_get(hass).async_get_entity_id(platform, DOMAIN, unique_id)
     assert found is not None, f"no {platform} entity registered for {unique_id!r}"
     return found
+
+
+def patch_coordinator_manager(manager: FakeLKSystemsManager):
+    """Patch the LKSystemsManager the coordinator itself constructs
+    (setup, polling refresh)."""
+    return patch("custom_components.lksystems.LKSystemsManager", return_value=manager)
+
+
+def patch_services_manager(manager: FakeLKSystemsManager):
+    """Patch the LKSystemsManager used by services.py's own handlers.
+
+    Needed by anything that ends up going through a service call - either
+    directly (hass.services.async_call) or indirectly (an entity whose
+    action delegates to a service, e.g. button.py's pause-leak-detection
+    button) - since each service handler opens its own LKSystemsManager
+    rather than reusing the one patched for coordinator setup.
+    """
+    return patch(
+        "custom_components.lksystems.services.LKSystemsManager", return_value=manager
+    )
+
+
+@contextmanager
+def patch_all_managers(manager: FakeLKSystemsManager):
+    """Patch every place LKSystemsManager gets constructed: the coordinator
+    (its polling refresh) and services.py (service handlers).
+
+    patch_services_manager() alone only covers a service call itself;
+    needed on top of that by anything that also triggers a coordinator
+    refresh in the same action (e.g. button.py's pause-leak-detection
+    button, which refreshes the paused-until sensor after pausing),
+    since that refresh would otherwise fall through to a real, unpatched
+    LKSystemsManager and attempt a genuine network call.
+    """
+    with patch_coordinator_manager(manager), patch_services_manager(manager):
+        yield
+
+
 @pytest.fixture
 def fake_manager_with_two_cubic_devices() -> FakeLKSystemsManager:
     """A FakeLKSystemsManager pre-populated with two Cubic Secure devices
@@ -447,9 +511,9 @@ async def setup_entry(
 ) -> MockConfigEntry:
     """Drive a real config-entry setup against a FakeLKSystemsManager.
 
-    Runs the coordinator's first refresh and both the sensor.py and
-    climate.py platforms' async_setup_entry() for real, so tests can inspect
-    the entities/entity registry they actually produce.
+    Runs the coordinator's first refresh and every platform's
+    async_setup_entry() for real (see __init__.py's PLATFORMS), so tests can
+    inspect the entities/entity registry they actually produce.
     """
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -457,10 +521,19 @@ async def setup_entry(
         options=options or {},
     )
     entry.add_to_hass(hass)
-    with patch("custom_components.lksystems.LKSystemsManager", return_value=manager):
+    with patch_coordinator_manager(manager):
         assert await hass.config_entries.async_setup(entry.entry_id)
         await hass.async_block_till_done()
     return entry
+
+
+def pause_leak_detection_duration_unique_id(device_identity: str) -> str:
+    """unique_id of a device's "Pause Duration" number entity.
+
+    Shared by test_number.py (which owns the entity) and test_button.py
+    (which needs to look it up to drive the paired button's tests).
+    """
+    return f"LkUid_pause_leak_detection_duration_{device_identity}"
 
 
 def entity_id(hass, platform: str, unique_id: str) -> str:

--- a/tests_ha/test_button.py
+++ b/tests_ha/test_button.py
@@ -1,0 +1,215 @@
+"""Tests for button.py: the per-device "Pause Leak Detection" button.
+
+A one-tap dashboard alternative to calling the pause_leak_detection service
+by hand - it uses whichever duration is currently set on the device's
+"Pause Duration" number entity (see test_number.py).
+"""
+
+from __future__ import annotations
+
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+
+from custom_components.lksystems.const import DEFAULT_PAUSE_LEAK_DETECTION_SECONDS, DOMAIN
+
+from .conftest import (
+    CUBIC_IDENTITY,
+    CUBIC_IDENTITY_2,
+    build_cubic_configuration,
+    entity_id,
+    patch_all_managers,
+    pause_leak_detection_duration_unique_id as _number_unique_id,
+    setup_entry,
+)
+
+
+def _button_unique_id(device_identity: str) -> str:
+    return f"LkUid_pause_leak_detection_{device_identity}"
+
+
+def _resume_button_unique_id(device_identity: str) -> str:
+    return f"LkUid_resume_leak_detection_{device_identity}"
+
+
+async def test_belongs_to_the_cubic_secure_device(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+    button_entity_id = entity_id(hass, "button", _button_unique_id(CUBIC_IDENTITY))
+
+    device = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, CUBIC_IDENTITY)})
+    entry = er.async_get(hass).async_get(button_entity_id)
+
+    assert entry.device_id == device.id
+
+
+async def test_press_pauses_leak_detection_for_the_default_duration(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+    button_entity_id = entity_id(hass, "button", _button_unique_id(CUBIC_IDENTITY))
+
+    with patch_all_managers(fake_manager):
+        await hass.services.async_call(
+            "button", "press", {"entity_id": button_entity_id}, blocking=True
+        )
+
+    assert (
+        "cubic_secure_pause_leak_detection",
+        CUBIC_IDENTITY,
+        DEFAULT_PAUSE_LEAK_DETECTION_SECONDS,
+    ) in fake_manager.calls
+
+
+async def test_press_uses_the_configured_duration(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+    number_entity_id = entity_id(hass, "number", _number_unique_id(CUBIC_IDENTITY))
+    button_entity_id = entity_id(hass, "button", _button_unique_id(CUBIC_IDENTITY))
+
+    await hass.services.async_call(
+        "number", "set_value", {"entity_id": number_entity_id, "value": 15}, blocking=True
+    )
+
+    with patch_all_managers(fake_manager):
+        await hass.services.async_call(
+            "button", "press", {"entity_id": button_entity_id}, blocking=True
+        )
+
+    assert (
+        "cubic_secure_pause_leak_detection",
+        CUBIC_IDENTITY,
+        900,
+    ) in fake_manager.calls
+
+
+async def test_two_cubic_secure_devices_have_independent_buttons(
+    hass, fake_manager_with_two_cubic_devices
+):
+    await setup_entry(hass, fake_manager_with_two_cubic_devices)
+    first_number = entity_id(hass, "number", _number_unique_id(CUBIC_IDENTITY))
+    first_button = entity_id(hass, "button", _button_unique_id(CUBIC_IDENTITY))
+    second_button = entity_id(hass, "button", _button_unique_id(CUBIC_IDENTITY_2))
+
+    await hass.services.async_call(
+        "number", "set_value", {"entity_id": first_number, "value": 2}, blocking=True
+    )
+
+    with patch_all_managers(fake_manager_with_two_cubic_devices):
+        await hass.services.async_call(
+            "button", "press", {"entity_id": first_button}, blocking=True
+        )
+        await hass.services.async_call(
+            "button", "press", {"entity_id": second_button}, blocking=True
+        )
+
+    calls = fake_manager_with_two_cubic_devices.calls
+    assert ("cubic_secure_pause_leak_detection", CUBIC_IDENTITY, 120) in calls
+    assert (
+        "cubic_secure_pause_leak_detection",
+        CUBIC_IDENTITY_2,
+        DEFAULT_PAUSE_LEAK_DETECTION_SECONDS,
+    ) in calls
+
+
+async def test_press_refreshes_the_paused_until_sensor(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+    button_entity_id = entity_id(hass, "button", _button_unique_id(CUBIC_IDENTITY))
+    paused_until_entity_id = entity_id(
+        hass, "sensor", f"LkUid_leakDetectionPausedUntil_{CUBIC_IDENTITY}"
+    )
+    assert hass.states.get(paused_until_entity_id).state == "unknown"
+
+    # The fake client only reflects the paused state once refreshed -
+    # confirms the post-press coordinator refresh actually happened.
+    fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+        build_cubic_configuration(mute_leak=900)
+    )
+
+    with patch_all_managers(fake_manager):
+        await hass.services.async_call(
+            "button", "press", {"entity_id": button_entity_id}, blocking=True
+        )
+
+    assert hass.states.get(paused_until_entity_id).state != "unknown"
+
+
+async def test_resume_belongs_to_the_cubic_secure_device(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+    button_entity_id = entity_id(hass, "button", _resume_button_unique_id(CUBIC_IDENTITY))
+
+    device = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, CUBIC_IDENTITY)})
+    entry = er.async_get(hass).async_get(button_entity_id)
+
+    assert entry.device_id == device.id
+
+
+async def test_resume_press_calls_client_with_zero_seconds(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+    pause_button_entity_id = entity_id(hass, "button", _button_unique_id(CUBIC_IDENTITY))
+    resume_button_entity_id = entity_id(
+        hass, "button", _resume_button_unique_id(CUBIC_IDENTITY)
+    )
+    # The resume button is only available once a pause is actually active.
+    fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+        build_cubic_configuration(mute_leak=900)
+    )
+    with patch_all_managers(fake_manager):
+        await hass.services.async_call(
+            "button", "press", {"entity_id": pause_button_entity_id}, blocking=True
+        )
+
+        await hass.services.async_call(
+            "button", "press", {"entity_id": resume_button_entity_id}, blocking=True
+        )
+
+    assert ("cubic_secure_pause_leak_detection", CUBIC_IDENTITY, 0) in fake_manager.calls
+
+
+async def test_resume_press_refreshes_the_paused_until_sensor(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+    pause_button_entity_id = entity_id(hass, "button", _button_unique_id(CUBIC_IDENTITY))
+    resume_button_entity_id = entity_id(
+        hass, "button", _resume_button_unique_id(CUBIC_IDENTITY)
+    )
+    paused_until_entity_id = entity_id(
+        hass, "sensor", f"LkUid_leakDetectionPausedUntil_{CUBIC_IDENTITY}"
+    )
+    fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+        build_cubic_configuration(mute_leak=900)
+    )
+    with patch_all_managers(fake_manager):
+        await hass.services.async_call(
+            "button", "press", {"entity_id": pause_button_entity_id}, blocking=True
+        )
+    assert hass.states.get(paused_until_entity_id).state != "unknown"
+
+    fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+        build_cubic_configuration(mute_leak=0)
+    )
+    with patch_all_managers(fake_manager):
+        await hass.services.async_call(
+            "button", "press", {"entity_id": resume_button_entity_id}, blocking=True
+        )
+
+    assert hass.states.get(paused_until_entity_id).state == "unknown"
+
+
+async def test_resume_button_unavailable_when_not_paused(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+    button_entity_id = entity_id(hass, "button", _resume_button_unique_id(CUBIC_IDENTITY))
+
+    assert hass.states.get(button_entity_id).state == "unavailable"
+
+
+async def test_resume_button_available_once_a_pause_is_active(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+    pause_button_entity_id = entity_id(hass, "button", _button_unique_id(CUBIC_IDENTITY))
+    resume_button_entity_id = entity_id(
+        hass, "button", _resume_button_unique_id(CUBIC_IDENTITY)
+    )
+    fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+        build_cubic_configuration(mute_leak=900)
+    )
+
+    with patch_all_managers(fake_manager):
+        await hass.services.async_call(
+            "button", "press", {"entity_id": pause_button_entity_id}, blocking=True
+        )
+
+    assert hass.states.get(resume_button_entity_id).state != "unavailable"

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -37,6 +37,8 @@ from custom_components.lksystems.const import (
     DOMAIN,
     LEAK_DETECTION_EXPIRY_MAX_RETRY_SECONDS,
     LEAK_DETECTION_EXPIRY_RETRY_INTERVAL_SECONDS,
+    LEAK_DETECTION_LOCAL_WRITE_GRACE_SECONDS,
+    PAUSE_LEAK_DETECTION_MIN_SECONDS,
 )
 from custom_components.lksystems.repairs import _issue_id
 
@@ -761,15 +763,43 @@ class TestLeakDetectionPausedUntilTracking:
         assert CUBIC_IDENTITY in coordinator.leak_detection_paused_until
         await coordinator.async_shutdown()  # cancel the scheduled expiry check
 
+    async def test_regular_poll_does_not_clear_a_pause_moments_after_it_was_set(
+        self, hass, fake_manager
+    ):
+        """A regular poll isn't triggered by a write, but nothing stops
+        its own independent timer from landing moments after one anyway.
+        The cloud's cached response can still be serving a pre-write
+        snapshot for tens of seconds after HA's own pause API call
+        succeeded (confirmed empirically against the real API) - a poll
+        that lands in that window must not let a stale muteLeak=0
+        override the pause HA itself just set."""
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+        coordinator.set_leak_detection_paused_until(CUBIC_IDENTITY, 900)
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(mute_leak=0)
+        )
+
+        with _patch_manager(fake_manager):
+            await coordinator._async_update_data()
+
+        assert CUBIC_IDENTITY in coordinator.leak_detection_paused_until
+        await coordinator.async_shutdown()  # cancel the scheduled expiry check
+
     async def test_regular_poll_clears_it_once_the_cloud_reports_inactive(
         self, hass, fake_manager
     ):
         """Covers both natural expiry and a cancel issued from elsewhere
         (e.g. the LK app's own "Stop" action) - either way, the cloud
-        reporting muteLeak=0 is what HA learns it from."""
+        reporting muteLeak=0 is what HA learns it from, once enough time
+        has passed since the last HA-issued write for that to be
+        trustworthy rather than a stale pre-write snapshot."""
         entry = _make_entry(hass)
         coordinator = LKSystemCoordinator(hass, entry)
         coordinator.set_leak_detection_paused_until(CUBIC_IDENTITY, 900)
+        coordinator._leak_detection_last_local_write[CUBIC_IDENTITY] -= timedelta(
+            seconds=LEAK_DETECTION_LOCAL_WRITE_GRACE_SECONDS
+        )
         fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
             build_cubic_configuration(mute_leak=0)
         )
@@ -829,10 +859,16 @@ class TestLeakDetectionPausedUntilTracking:
         await coordinator.async_shutdown()  # cancel the scheduled expiry check
 
 
-async def _paused_coordinator(hass, fake_manager, seconds=60):
+async def _paused_coordinator(hass, fake_manager, seconds=300):
     """Build a coordinator with an already-completed initial refresh and
     an active local pause, for the retry-loop tests below - they all start
-    from this same state and only differ in what happens next."""
+    from this same state and only differ in what happens next.
+
+    Deliberately well clear of both PAUSE_LEAK_DETECTION_MIN_SECONDS and
+    LEAK_DETECTION_LOCAL_WRITE_GRACE_SECONDS (currently equal, at 60s) -
+    these tests are about the retry loop's own timing, not about its
+    interaction with the write-grace window right at a minimum-duration
+    pause's target, which is covered separately."""
     entry = _make_entry(hass)
     coordinator = LKSystemCoordinator(hass, entry)
     with _patch_manager(fake_manager):
@@ -931,6 +967,43 @@ class TestLeakDetectionExpiryRefresh:
         fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
             build_cubic_configuration(mute_leak=0)
         )
+
+        with _patch_manager(fake_manager):
+            async_fire_time_changed(
+                hass,
+                target
+                + timedelta(seconds=LEAK_DETECTION_EXPIRY_RETRY_INTERVAL_SECONDS),
+            )
+            await hass.async_block_till_done()
+
+        assert CUBIC_IDENTITY not in coordinator.leak_detection_paused_until
+
+    async def test_minimum_duration_pause_self_heals_past_a_grace_window_no_op(
+        self, hass, fake_manager
+    ):
+        """PAUSE_LEAK_DETECTION_MIN_SECONDS and
+        LEAK_DETECTION_LOCAL_WRITE_GRACE_SECONDS are currently equal (60s),
+        so a minimum-duration pause's target can land inside its own
+        write-grace window - the first check that lands there is a
+        deliberate no-op (see _reconcile_leak_detection_paused_until), not
+        a resolution. It isn't left stuck there: the loop's own next retry,
+        LEAK_DETECTION_EXPIRY_RETRY_INTERVAL_SECONDS later, is always past
+        the grace window and resolves it normally."""
+        coordinator, target = await _paused_coordinator(
+            hass, fake_manager, seconds=PAUSE_LEAK_DETECTION_MIN_SECONDS
+        )
+        coordinator._leak_detection_last_local_write[CUBIC_IDENTITY] = (
+            target - timedelta(seconds=LEAK_DETECTION_LOCAL_WRITE_GRACE_SECONDS - 10)
+        )
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(mute_leak=0)
+        )
+
+        with _patch_manager(fake_manager):
+            async_fire_time_changed(hass, target)
+            await hass.async_block_till_done()
+
+        assert CUBIC_IDENTITY in coordinator.leak_detection_paused_until
 
         with _patch_manager(fake_manager):
             async_fire_time_changed(

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import base64
 import json
 import logging
+import time
 from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 
@@ -20,7 +21,10 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.update_coordinator import UpdateFailed
 from homeassistant.util import dt as dt_util
-from pytest_homeassistant_custom_component.common import MockConfigEntry
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    async_fire_time_changed,
+)
 
 from custom_components.lksystems import (
     TOKEN_STORAGE,
@@ -31,6 +35,8 @@ from custom_components.lksystems.const import (
     CONF_UPDATE_INTERVAL,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
+    LEAK_DETECTION_EXPIRY_MAX_RETRY_SECONDS,
+    LEAK_DETECTION_EXPIRY_RETRY_INTERVAL_SECONDS,
 )
 from custom_components.lksystems.repairs import _issue_id
 
@@ -41,6 +47,8 @@ from .conftest import (
     HUB_IDENTITY,
     SENSOR_MAC,
     THERMOSTAT_MAC,
+    build_cubic_configuration,
+    build_live_config_without_mute_leak,
     get_issue,
 )
 
@@ -392,6 +400,36 @@ class TestCubicFetchFailureFallback:
         )
 
 
+class TestCubicConfigurationStalenessForceFetch:
+
+    async def test_preserves_mute_leak_across_a_staleness_triggered_force_fetch(
+        self, hass, fake_manager
+    ):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        stale_cache_updated = (
+            int(time.time()) - int(coordinator.update_interval.total_seconds()) - 60
+        )
+        cached_config = build_cubic_configuration(mute_leak=1200)
+        cached_config["cacheUpdated"] = stale_cache_updated
+        fake_manager.cubic_configurations_cached_by_device[CUBIC_IDENTITY] = (
+            cached_config
+        )
+
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_live_config_without_mute_leak()
+        )
+
+        with _patch_manager(fake_manager):
+            data = await coordinator._async_update_data()
+
+        assert (
+            data["cubic_devices"][CUBIC_IDENTITY]["configuration"]["muteLeak"] == 1200
+        )
+        await coordinator.async_shutdown()  # cancel the expiry check this adopted
+
+
 class TestMultipleCubicSecureDevices:
     """Two Cubic Secure devices registered under the same property used to
     stomp on each other, since the coordinator kept a single unkeyed slot
@@ -482,6 +520,517 @@ class TestForceDeviceUpdate:
             result = await coordinator.force_device_update(THERMOSTAT_MAC)
 
         assert result is False
+
+
+class TestForceCubicSecureConfigurationUpdate:
+    """_fetch_data()'s regular poll only force-bypasses the LK API's own
+    backend cache for a Cubic Secure device's configuration (valveState,
+    firmwareVersion, ...) once that cache looks older than the poll
+    interval - decoupled from whether a write actually just happened. A
+    write-triggered refresh (e.g. valve.py after open/close) needs its
+    own, unconditionally-forced fetch instead, or it can keep serving the
+    same stale cached snapshot.
+    """
+
+    async def test_success_updates_stored_configuration(self, hass, fake_manager):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            data = await coordinator._async_update_data()
+        coordinator.async_set_updated_data(data)
+
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(valve_state="closed")
+        )
+
+        with _patch_manager(fake_manager):
+            result = await coordinator.force_cubic_secure_configuration_update(
+                CUBIC_IDENTITY
+            )
+
+        assert result is True
+        assert (
+            coordinator.data["cubic_devices"][CUBIC_IDENTITY]["configuration"][
+                "valveState"
+            ]
+            == "closed"
+        )
+
+    async def test_configuration_fetch_failure_returns_false(self, hass, fake_manager):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+        fake_manager.get_cubic_secure_configuration_result = False
+
+        with _patch_manager(fake_manager):
+            result = await coordinator.force_cubic_secure_configuration_update(
+                CUBIC_IDENTITY
+            )
+
+        assert result is False
+
+    async def test_bypasses_the_backend_cache_unlike_a_regular_refresh(
+        self, hass, fake_manager
+    ):
+        """Regression test for the actual bug this method exists to work
+        around: a regular refresh only escalates to force_update=True once
+        the cached response's own cacheUpdated timestamp looks older than
+        the poll interval - so right after a write, it can keep serving
+        the same pre-write cached snapshot.
+        """
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            data = await coordinator._async_update_data()
+        coordinator.async_set_updated_data(data)
+
+        # The LK backend's own cache still serving a pre-write snapshot
+        # (a fresh cacheUpdated, so _fetch_data()'s own staleness check
+        # won't escalate to force_update=True on its own), while the
+        # force_update=True/"live" value already reflects a fresh write.
+        fake_manager.cubic_configurations_cached_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(valve_state="open")
+        )
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(valve_state="closed")
+        )
+
+        with _patch_manager(fake_manager):
+            await coordinator.async_request_refresh()
+
+        assert (
+            coordinator.data["cubic_devices"][CUBIC_IDENTITY]["configuration"][
+                "valveState"
+            ]
+            == "open"
+        ), "a regular refresh should still be serving the stale cached value"
+
+        with _patch_manager(fake_manager):
+            result = await coordinator.force_cubic_secure_configuration_update(
+                CUBIC_IDENTITY
+            )
+
+        assert result is True
+        assert (
+            coordinator.data["cubic_devices"][CUBIC_IDENTITY]["configuration"][
+                "valveState"
+            ]
+            == "closed"
+        )
+
+    async def test_login_failure_returns_false(self, hass, fake_manager):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+        fake_manager.login_result = False
+
+        with _patch_manager(fake_manager):
+            result = await coordinator.force_cubic_secure_configuration_update(
+                CUBIC_IDENTITY
+            )
+
+        assert result is False
+
+
+class TestRefreshCubicSecureConfiguration:
+    """See refresh_cubic_secure_configuration()'s own docstring for why
+    this reads the cached response rather than bypassing it."""
+
+    async def test_success_updates_stored_configuration(self, hass, fake_manager):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            data = await coordinator._async_update_data()
+        coordinator.async_set_updated_data(data)
+
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(valve_state="closed")
+        )
+
+        with _patch_manager(fake_manager):
+            result = await coordinator.refresh_cubic_secure_configuration(
+                CUBIC_IDENTITY
+            )
+
+        assert result is True
+        assert (
+            coordinator.data["cubic_devices"][CUBIC_IDENTITY]["configuration"][
+                "valveState"
+            ]
+            == "closed"
+        )
+
+    async def test_reads_the_cached_value_unlike_a_forced_fetch(
+        self, hass, fake_manager
+    ):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            data = await coordinator._async_update_data()
+        coordinator.async_set_updated_data(data)
+
+        # The cached (force_update=False) response and the "live"
+        # (force_update=True) one deliberately disagree here, so the two
+        # coordinator methods are distinguishable by which one they read.
+        fake_manager.cubic_configurations_cached_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(valve_state="open")
+        )
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(valve_state="closed")
+        )
+
+        with _patch_manager(fake_manager):
+            result = await coordinator.refresh_cubic_secure_configuration(
+                CUBIC_IDENTITY
+            )
+
+        assert result is True
+        assert (
+            coordinator.data["cubic_devices"][CUBIC_IDENTITY]["configuration"][
+                "valveState"
+            ]
+            == "open"
+        )
+
+    async def test_configuration_fetch_failure_returns_false(self, hass, fake_manager):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+        fake_manager.get_cubic_secure_configuration_result = False
+
+        with _patch_manager(fake_manager):
+            result = await coordinator.refresh_cubic_secure_configuration(
+                CUBIC_IDENTITY
+            )
+
+        assert result is False
+
+    async def test_login_failure_returns_false(self, hass, fake_manager):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+        fake_manager.login_result = False
+
+        with _patch_manager(fake_manager):
+            result = await coordinator.refresh_cubic_secure_configuration(
+                CUBIC_IDENTITY
+            )
+
+        assert result is False
+
+
+class TestLeakDetectionPausedUntilTracking:
+    """See LKSystemCoordinator.leak_detection_paused_until's own docstring
+    for why it's tracked locally instead of recomputed from muteLeak on
+    every poll."""
+
+    async def test_set_rounds_to_the_nearest_minute(self, hass):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        before = dt_util.utcnow()
+        coordinator.set_leak_detection_paused_until(CUBIC_IDENTITY, 130)
+        target = coordinator.leak_detection_paused_until[CUBIC_IDENTITY]
+
+        assert target.second == 0 and target.microsecond == 0
+        assert abs((target - (before + timedelta(seconds=130))).total_seconds()) <= 30
+        await coordinator.async_shutdown()  # cancel the scheduled expiry check
+
+    async def test_set_with_zero_seconds_clears_it(self, hass):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+        coordinator.set_leak_detection_paused_until(CUBIC_IDENTITY, 900)
+
+        coordinator.set_leak_detection_paused_until(CUBIC_IDENTITY, 0)
+
+        assert CUBIC_IDENTITY not in coordinator.leak_detection_paused_until
+
+    async def test_regular_poll_adopts_a_pause_ha_did_not_itself_start(
+        self, hass, fake_manager
+    ):
+        """E.g. one started from the LK app instead of an HA button/service."""
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(mute_leak=900)
+        )
+
+        with _patch_manager(fake_manager):
+            await coordinator._async_update_data()
+
+        assert CUBIC_IDENTITY in coordinator.leak_detection_paused_until
+        await coordinator.async_shutdown()  # cancel the scheduled expiry check
+
+    async def test_regular_poll_clears_it_once_the_cloud_reports_inactive(
+        self, hass, fake_manager
+    ):
+        """Covers both natural expiry and a cancel issued from elsewhere
+        (e.g. the LK app's own "Stop" action) - either way, the cloud
+        reporting muteLeak=0 is what HA learns it from."""
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+        coordinator.set_leak_detection_paused_until(CUBIC_IDENTITY, 900)
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(mute_leak=0)
+        )
+
+        with _patch_manager(fake_manager):
+            await coordinator._async_update_data()
+
+        assert CUBIC_IDENTITY not in coordinator.leak_detection_paused_until
+
+    async def test_regular_poll_does_not_override_an_already_tracked_target(
+        self, hass, fake_manager
+    ):
+        """muteLeak is a static number, not a live countdown - re-deriving
+        a target from it on every poll would make the displayed time drift
+        later and later. Once a target is tracked, only an explicit
+        set_leak_detection_paused_until() call (a fresh pause/resume HA
+        itself issued) may change it - not the passive reconciliation a
+        regular poll does."""
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+        coordinator.set_leak_detection_paused_until(CUBIC_IDENTITY, 900)
+        original_target = coordinator.leak_detection_paused_until[CUBIC_IDENTITY]
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(mute_leak=1)
+        )
+
+        with _patch_manager(fake_manager):
+            await coordinator._async_update_data()
+
+        assert coordinator.leak_detection_paused_until[CUBIC_IDENTITY] == original_target
+        await coordinator.async_shutdown()  # cancel the scheduled expiry check
+
+    async def test_forced_live_fetch_does_not_touch_local_tracking(
+        self, hass, fake_manager
+    ):
+        """The live/bypass fetch doesn't reliably carry muteLeak at all
+        (see force_cubic_secure_configuration_update's own docstring) - a
+        write-triggered forced fetch (e.g. valve.py after open/close) must
+        not clear a genuinely active pause just because that response
+        doesn't mention it."""
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            data = await coordinator._async_update_data()
+        coordinator.async_set_updated_data(data)
+        coordinator.set_leak_detection_paused_until(CUBIC_IDENTITY, 900)
+
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_live_config_without_mute_leak()
+        )
+
+        with _patch_manager(fake_manager):
+            await coordinator.force_cubic_secure_configuration_update(CUBIC_IDENTITY)
+
+        assert CUBIC_IDENTITY in coordinator.leak_detection_paused_until
+        await coordinator.async_shutdown()  # cancel the scheduled expiry check
+
+
+async def _paused_coordinator(hass, fake_manager, seconds=60):
+    """Build a coordinator with an already-completed initial refresh and
+    an active local pause, for the retry-loop tests below - they all start
+    from this same state and only differ in what happens next."""
+    entry = _make_entry(hass)
+    coordinator = LKSystemCoordinator(hass, entry)
+    with _patch_manager(fake_manager):
+        data = await coordinator._async_update_data()
+    coordinator.async_set_updated_data(data)
+
+    coordinator.set_leak_detection_paused_until(CUBIC_IDENTITY, seconds)
+    target = coordinator.leak_detection_paused_until[CUBIC_IDENTITY]
+    return coordinator, target
+
+
+class TestLeakDetectionExpiryRefresh:
+    """A pause's target end time passing doesn't itself cause anything to
+    happen - nothing watches the clock for it, so without this, "Leak
+    Detection Paused Until" would just sit there showing a stale value
+    until the next regular poll (up to a full update_interval later).
+    These poll the cloud starting at the target, retrying at
+    LEAK_DETECTION_EXPIRY_RETRY_INTERVAL_SECONDS until it confirms the
+    pause is actually over - see that constant's docstring for why a
+    single delayed check isn't used instead.
+    """
+
+    async def test_resolves_on_the_first_check_if_already_over(
+        self, hass, fake_manager
+    ):
+        coordinator, target = await _paused_coordinator(hass, fake_manager)
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(mute_leak=0)
+        )
+
+        with _patch_manager(fake_manager):
+            async_fire_time_changed(hass, target)
+            await hass.async_block_till_done()
+
+        assert CUBIC_IDENTITY not in coordinator.leak_detection_paused_until
+
+    async def test_notifies_listeners_after_resolving_not_before(
+        self, hass, fake_manager
+    ):
+        """A coordinator listener (standing in for the Resume button and
+        the "Leak Detection Paused Until" sensor, both of which re-render
+        off a listener notification) must see the pause actually cleared
+        by the time it's called - not be notified while
+        leak_detection_paused_until is still stale, with nothing telling
+        it to re-render again once the clear happens a moment later."""
+        coordinator, target = await _paused_coordinator(hass, fake_manager)
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(mute_leak=0)
+        )
+
+        paused_at_last_notify = []
+        coordinator.async_add_listener(
+            lambda: paused_at_last_notify.append(
+                CUBIC_IDENTITY in coordinator.leak_detection_paused_until
+            )
+        )
+
+        with _patch_manager(fake_manager):
+            async_fire_time_changed(hass, target)
+            await hass.async_block_till_done()
+
+        assert CUBIC_IDENTITY not in coordinator.leak_detection_paused_until
+        assert paused_at_last_notify[-1] is False
+        await coordinator.async_shutdown()  # cancel the now-listened-for refresh interval
+
+    async def test_does_not_check_before_the_target(self, hass, fake_manager):
+        coordinator, target = await _paused_coordinator(hass, fake_manager)
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(mute_leak=0)
+        )
+
+        with _patch_manager(fake_manager):
+            async_fire_time_changed(hass, target - timedelta(seconds=5))
+            await hass.async_block_till_done()
+
+        assert CUBIC_IDENTITY in coordinator.leak_detection_paused_until
+        await coordinator.async_shutdown()  # cancel the still-pending check
+
+    async def test_retries_until_the_cloud_confirms_it_is_over(
+        self, hass, fake_manager
+    ):
+        """The cloud can still report a pause as active right at its
+        target end time (confirmed empirically against the real API) -
+        the first check seeing that must not be treated as final."""
+        coordinator, target = await _paused_coordinator(hass, fake_manager)
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(mute_leak=60)
+        )
+
+        with _patch_manager(fake_manager):
+            async_fire_time_changed(hass, target)
+            await hass.async_block_till_done()
+
+        assert CUBIC_IDENTITY in coordinator.leak_detection_paused_until
+
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(mute_leak=0)
+        )
+
+        with _patch_manager(fake_manager):
+            async_fire_time_changed(
+                hass,
+                target
+                + timedelta(seconds=LEAK_DETECTION_EXPIRY_RETRY_INTERVAL_SECONDS),
+            )
+            await hass.async_block_till_done()
+
+        assert CUBIC_IDENTITY not in coordinator.leak_detection_paused_until
+
+    async def test_gives_up_after_the_max_retry_window(self, hass, fake_manager):
+        """A safety cap for if the cloud never resolves (e.g. the device
+        has gone offline) - falls back to the regular poll rather than
+        retrying forever."""
+        coordinator, target = await _paused_coordinator(hass, fake_manager)
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(mute_leak=60)
+        )
+
+        # async_fire_time_changed only fires whatever's already scheduled
+        # at the moment it's called - a follow-up retry scheduled
+        # reactively during that firing needs its own separate jump to
+        # fire in turn, so step through the retries one interval at a
+        # time rather than jumping straight to a point past all of them.
+        steps = LEAK_DETECTION_EXPIRY_MAX_RETRY_SECONDS // LEAK_DETECTION_EXPIRY_RETRY_INTERVAL_SECONDS + 2
+        with _patch_manager(fake_manager):
+            for step in range(1, steps + 1):
+                async_fire_time_changed(
+                    hass,
+                    target
+                    + timedelta(
+                        seconds=step * LEAK_DETECTION_EXPIRY_RETRY_INTERVAL_SECONDS
+                    ),
+                )
+                await hass.async_block_till_done()
+
+        # Never confirmed resolved - still tracked under its original
+        # target - but no retry left pending (the test's own teardown
+        # would fail on a lingering timer if one were).
+        assert CUBIC_IDENTITY in coordinator.leak_detection_paused_until
+
+    async def test_resuming_cancels_the_pending_retries(self, hass, fake_manager):
+        coordinator, target = await _paused_coordinator(hass, fake_manager)
+        coordinator.set_leak_detection_paused_until(CUBIC_IDENTITY, 0)
+        calls_before = len(fake_manager.calls)
+
+        with _patch_manager(fake_manager):
+            async_fire_time_changed(
+                hass, target + timedelta(seconds=LEAK_DETECTION_EXPIRY_MAX_RETRY_SECONDS)
+            )
+            await hass.async_block_till_done()
+
+        assert len(fake_manager.calls) == calls_before
+
+    async def test_re_pausing_replaces_the_pending_retries(self, hass, fake_manager):
+        """Re-pausing while already active resets the target (confirmed
+        empirically against the real API) - the scheduled retries must
+        move with it rather than firing early against the old target."""
+        coordinator, original_target = await _paused_coordinator(hass, fake_manager)
+        coordinator.set_leak_detection_paused_until(CUBIC_IDENTITY, 600)
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(mute_leak=0)
+        )
+
+        with _patch_manager(fake_manager):
+            async_fire_time_changed(hass, original_target)
+            await hass.async_block_till_done()
+
+        # The old target's check must not have fired - the pause is still
+        # tracked, under its new (later) target.
+        assert CUBIC_IDENTITY in coordinator.leak_detection_paused_until
+        assert coordinator.leak_detection_paused_until[CUBIC_IDENTITY] != original_target
+        await coordinator.async_shutdown()  # cancel the still-pending new check
+
+    async def test_shutdown_cancels_pending_retries(self, hass, fake_manager):
+        """Otherwise a retry scheduled before unload would fire against a
+        torn-down coordinator afterwards - including one scheduled by a
+        previous retry iteration, not just the first check."""
+        coordinator, target = await _paused_coordinator(hass, fake_manager)
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(mute_leak=60)
+        )
+
+        with _patch_manager(fake_manager):
+            async_fire_time_changed(hass, target)  # still active - schedules a retry
+            await hass.async_block_till_done()
+        calls_before = len(fake_manager.calls)
+
+        await coordinator.async_shutdown()
+
+        with _patch_manager(fake_manager):
+            async_fire_time_changed(
+                hass,
+                target
+                + timedelta(seconds=LEAK_DETECTION_EXPIRY_MAX_RETRY_SECONDS + 30),
+            )
+            await hass.async_block_till_done()
+
+        assert len(fake_manager.calls) == calls_before
 
 
 class TestSetThermostatTemperature:

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -978,6 +978,31 @@ class TestLeakDetectionExpiryRefresh:
 
         assert CUBIC_IDENTITY not in coordinator.leak_detection_paused_until
 
+    async def test_a_still_active_retry_check_never_touches_the_tracked_target(
+        self, hass, fake_manager
+    ):
+        """Unlike a poll landing right after a write (which risks clobbering
+        a fresher local value with a staler cloud one - see
+        LEAK_DETECTION_LOCAL_WRITE_GRACE_SECONDS), a retry check reading
+        stale "still active" data has nothing to clobber: the device is
+        already tracked for its own pause the whole time this loop runs,
+        so _reconcile_leak_detection_paused_until()'s own
+        never-overwrite-an-already-tracked-target rule applies regardless
+        of what muteLeak says, not just when it happens to match. Proves
+        that by using a muteLeak value a naive re-adopt would compute a
+        different target from, and asserting the original is untouched."""
+        coordinator, target = await _paused_coordinator(hass, fake_manager)
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(mute_leak=9999)
+        )
+
+        with _patch_manager(fake_manager):
+            async_fire_time_changed(hass, target)
+            await hass.async_block_till_done()
+
+        assert coordinator.leak_detection_paused_until[CUBIC_IDENTITY] == target
+        await coordinator.async_shutdown()  # cancel the still-pending retry
+
     async def test_minimum_duration_pause_self_heals_past_a_grace_window_no_op(
         self, hass, fake_manager
     ):

--- a/tests_ha/test_number.py
+++ b/tests_ha/test_number.py
@@ -1,0 +1,173 @@
+"""Tests for number.py: the per-device "Pause Duration" entity.
+
+This entity holds a local preference only - the API has no "get configured
+pause duration" endpoint, just "pause for N seconds" on each call - so its
+value is read/written straight to the coordinator and persisted via HA's
+restore-state mechanism rather than fetched from the coordinator's polled
+data. Displayed (and stored) in minutes for readability; the coordinator's
+pause_leak_detection_seconds - and everything downstream of it - stays in
+seconds, matching the API's own "pause for N seconds" contract.
+"""
+
+from __future__ import annotations
+
+from homeassistant.core import State
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import mock_restore_cache_with_extra_data
+
+from custom_components.lksystems.const import (
+    DEFAULT_PAUSE_LEAK_DETECTION_SECONDS,
+    DOMAIN,
+    PAUSE_LEAK_DETECTION_MAX_SECONDS,
+    PAUSE_LEAK_DETECTION_MIN_SECONDS,
+)
+
+from .conftest import (
+    CUBIC_IDENTITY,
+    CUBIC_IDENTITY_2,
+    entity_id,
+    pause_leak_detection_duration_unique_id as _number_unique_id,
+    setup_entry,
+)
+
+SECONDS_PER_MINUTE = 60
+
+
+async def test_defaults_to_the_service_default(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+    number_entity_id = entity_id(hass, "number", _number_unique_id(CUBIC_IDENTITY))
+
+    state = hass.states.get(number_entity_id)
+
+    assert (
+        float(state.state)
+        == DEFAULT_PAUSE_LEAK_DETECTION_SECONDS / SECONDS_PER_MINUTE
+    )
+
+
+async def test_bounds_match_pause_leak_detection_limits(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+    number_entity_id = entity_id(hass, "number", _number_unique_id(CUBIC_IDENTITY))
+
+    state = hass.states.get(number_entity_id)
+
+    assert (
+        float(state.attributes["min"])
+        == PAUSE_LEAK_DETECTION_MIN_SECONDS / SECONDS_PER_MINUTE
+    )
+    assert (
+        float(state.attributes["max"])
+        == PAUSE_LEAK_DETECTION_MAX_SECONDS / SECONDS_PER_MINUTE
+    )
+
+
+async def test_belongs_to_the_cubic_secure_device(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+    number_entity_id = entity_id(hass, "number", _number_unique_id(CUBIC_IDENTITY))
+
+    device = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, CUBIC_IDENTITY)})
+    entry = er.async_get(hass).async_get(number_entity_id)
+
+    assert entry.device_id == device.id
+
+
+async def test_setting_a_value_updates_the_coordinator(hass, fake_manager):
+    entry = await setup_entry(hass, fake_manager)
+    number_entity_id = entity_id(hass, "number", _number_unique_id(CUBIC_IDENTITY))
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    await hass.services.async_call(
+        "number", "set_value", {"entity_id": number_entity_id, "value": 15}, blocking=True
+    )
+
+    assert coordinator.pause_leak_detection_seconds[CUBIC_IDENTITY] == 900
+    assert float(hass.states.get(number_entity_id).state) == 15
+
+
+async def test_two_cubic_secure_devices_get_independent_durations(
+    hass, fake_manager_with_two_cubic_devices
+):
+    entry = await setup_entry(hass, fake_manager_with_two_cubic_devices)
+    first_id = entity_id(hass, "number", _number_unique_id(CUBIC_IDENTITY))
+    second_id = entity_id(hass, "number", _number_unique_id(CUBIC_IDENTITY_2))
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    await hass.services.async_call(
+        "number", "set_value", {"entity_id": first_id, "value": 5}, blocking=True
+    )
+
+    assert coordinator.pause_leak_detection_seconds[CUBIC_IDENTITY] == 300
+    assert CUBIC_IDENTITY_2 not in coordinator.pause_leak_detection_seconds
+    assert float(hass.states.get(second_id).state) == (
+        DEFAULT_PAUSE_LEAK_DETECTION_SECONDS / SECONDS_PER_MINUTE
+    )
+
+
+async def test_restores_last_value_on_startup(hass, fake_manager):
+    """Seed the restore cache before the entity is ever created, the way
+    HA repopulates it from disk on a real restart - a live entity has no
+    prior instance to hand data to, so there's nothing to reload here.
+    """
+    # Predictable from has_entity_name=True: "<device slug>_<entity slug>".
+    number_entity_id = "number.cubic_secure_utility_room_pause_duration"
+    mock_restore_cache_with_extra_data(
+        hass,
+        [
+            (
+                State(number_entity_id, "30"),
+                {
+                    "native_max_value": PAUSE_LEAK_DETECTION_MAX_SECONDS
+                    / SECONDS_PER_MINUTE,
+                    "native_min_value": PAUSE_LEAK_DETECTION_MIN_SECONDS
+                    / SECONDS_PER_MINUTE,
+                    "native_step": 1,
+                    "native_unit_of_measurement": "min",
+                    "native_value": 30,
+                },
+            )
+        ],
+    )
+
+    entry = await setup_entry(hass, fake_manager)
+
+    # Confirms the guessed entity_id above actually matches what HA
+    # assigned - if slugify rules ever changed, this fails loudly instead
+    # of the restore silently not applying.
+    assert entity_id(hass, "number", _number_unique_id(CUBIC_IDENTITY)) == number_entity_id
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    assert coordinator.pause_leak_detection_seconds[CUBIC_IDENTITY] == 1800
+    assert float(hass.states.get(number_entity_id).state) == 30
+
+
+async def test_restores_seconds_data_from_before_the_unit_changed_to_minutes(
+    hass, fake_manager
+):
+    """Regression test: an installation that already had a value restored
+    while this entity's native unit was still seconds must not reinterpret
+    that raw number as minutes after the change - 300 (seconds) restoring
+    as "300 min" would be a 60x jump, not the equivalent ~5 min.
+    """
+    number_entity_id = "number.cubic_secure_utility_room_pause_duration"
+    mock_restore_cache_with_extra_data(
+        hass,
+        [
+            (
+                State(number_entity_id, "300"),
+                {
+                    "native_max_value": PAUSE_LEAK_DETECTION_MAX_SECONDS,
+                    "native_min_value": PAUSE_LEAK_DETECTION_MIN_SECONDS,
+                    "native_step": 60,
+                    "native_unit_of_measurement": "s",
+                    "native_value": 300,
+                },
+            )
+        ],
+    )
+
+    entry = await setup_entry(hass, fake_manager)
+
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+    assert coordinator.pause_leak_detection_seconds[CUBIC_IDENTITY] == 300
+    assert float(hass.states.get(number_entity_id).state) == 5

--- a/tests_ha/test_sensor.py
+++ b/tests_ha/test_sensor.py
@@ -30,6 +30,7 @@ from custom_components.lksystems.sensor import (
     LKArcHubEntity,
     LKArcSensorEntity,
     LKCubicSensor,
+    LKLeakDetectionPausedUntilSensor,
 )
 
 from .conftest import (
@@ -37,6 +38,7 @@ from .conftest import (
     HUB_IDENTITY,
     SENSOR_MAC,
     THERMOSTAT_MAC,
+    build_cubic_configuration,
     entity_id,
     setup_entry,
 )
@@ -285,6 +287,80 @@ class TestCubicSensorRestore:
             CUBIC_IDENTITY
         ]["configuration"]["firmwareVersion"]
         assert entity.native_value != "old-version"
+
+
+class TestLeakDetectionPausedUntilSensor:
+    """See LKLeakDetectionPausedUntilSensor's own docstring for why it
+    reads the coordinator's locally tracked target rather than computing
+    one from muteLeak itself."""
+
+    async def test_none_when_not_currently_paused(self, hass, fake_manager):
+        entry = await setup_entry(hass, fake_manager)
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+
+        entity = LKLeakDetectionPausedUntilSensor(coordinator, CUBIC_IDENTITY)
+
+        assert entity.native_value is None
+
+    async def test_reflects_the_coordinators_locally_tracked_target(
+        self, hass, fake_manager
+    ):
+        entry = await setup_entry(hass, fake_manager)
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+        coordinator.set_leak_detection_paused_until(CUBIC_IDENTITY, 300)
+
+        entity = LKLeakDetectionPausedUntilSensor(coordinator, CUBIC_IDENTITY)
+
+        assert (
+            entity.native_value
+            == coordinator.leak_detection_paused_until[CUBIC_IDENTITY]
+        )
+
+    async def test_belongs_to_the_cubic_secure_device(self, hass, fake_manager):
+        await setup_entry(hass, fake_manager)
+        sensor_entity_id = entity_id(
+            hass, "sensor", f"LkUid_leakDetectionPausedUntil_{CUBIC_IDENTITY}"
+        )
+
+        device = dr.async_get(hass).async_get_device(
+            identifiers={(DOMAIN, CUBIC_IDENTITY)}
+        )
+        registry_entry = er.async_get(hass).async_get(sensor_entity_id)
+
+        assert registry_entry.device_id == device.id
+        assert registry_entry.disabled_by is None
+
+    async def test_extra_state_attributes_carries_last_successful_cloud_fetch(
+        self, hass, fake_manager
+    ):
+        """Every other cubic sensor exposes this attribute (see
+        AbstractLkCubicSensor's sibling classes) - restore.py reads it back
+        out of the restored state to decide whether a restored value is
+        still fresh across an HA restart, so this sensor needs it too."""
+        entry = await setup_entry(hass, fake_manager)
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+
+        entity = LKLeakDetectionPausedUntilSensor(coordinator, CUBIC_IDENTITY)
+
+        assert ATTR_LAST_SUCCESSFUL_CLOUD_FETCH in entity.extra_state_attributes
+
+    async def test_restores_value_when_live_fetch_failed_and_restore_is_fresh(
+        self, hass, fake_manager
+    ):
+        entity_id_str = "sensor.test_restore_paused_until"
+        restored_value = dt_util.utcnow() + timedelta(minutes=5)
+        _seed_restore_cache(hass, entity_id_str, restored_value, dt_util.utcnow())
+
+        entry = await setup_entry(hass, fake_manager)
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+        # No live muteLeak - the only value available is the restored one.
+
+        entity = LKLeakDetectionPausedUntilSensor(coordinator, CUBIC_IDENTITY)
+        entity.hass = hass
+        entity.entity_id = entity_id_str
+        await entity.async_added_to_hass()
+
+        assert entity.native_value == restored_value
 
 
 def _thermostat_device(coordinator) -> dict:

--- a/tests_ha/test_services.py
+++ b/tests_ha/test_services.py
@@ -18,14 +18,15 @@ from homeassistant.helpers import device_registry as dr
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.lksystems.const import DOMAIN
+from custom_components.lksystems.services import pause_leak_detection_for_serial
 
-from .conftest import CUBIC_IDENTITY
-
-
-def _patch_services_manager(manager):
-    return patch(
-        "custom_components.lksystems.services.LKSystemsManager", return_value=manager
-    )
+from .conftest import (
+    CUBIC_IDENTITY,
+    build_cubic_configuration,
+    entity_id,
+    patch_all_managers,
+    patch_services_manager,
+)
 
 
 async def _setup_entry_and_get_cubic_device(hass, manager):
@@ -49,7 +50,7 @@ async def _setup_entry_and_get_cubic_device(hass, manager):
 async def test_close_valve_calls_client(hass, fake_manager):
     _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
 
-    with _patch_services_manager(fake_manager):
+    with patch_services_manager(fake_manager):
         await hass.services.async_call(
             DOMAIN, "close_valve", {"device_id": device_entry.id}, blocking=True
         )
@@ -60,7 +61,7 @@ async def test_close_valve_calls_client(hass, fake_manager):
 async def test_open_valve_calls_client(hass, fake_manager):
     _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
 
-    with _patch_services_manager(fake_manager):
+    with patch_services_manager(fake_manager):
         await hass.services.async_call(
             DOMAIN, "open_valve", {"device_id": device_entry.id}, blocking=True
         )
@@ -71,7 +72,7 @@ async def test_open_valve_calls_client(hass, fake_manager):
 async def test_pause_leak_detection_calls_client(hass, fake_manager):
     _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
 
-    with _patch_services_manager(fake_manager):
+    with patch_services_manager(fake_manager):
         await hass.services.async_call(
             DOMAIN,
             "pause_leak_detection",
@@ -86,10 +87,97 @@ async def test_pause_leak_detection_calls_client(hass, fake_manager):
     ) in fake_manager.calls
 
 
+async def test_pause_leak_detection_logs_its_own_action(hass, fake_manager, caplog):
+    """Regression test: the handler used to log "Closing valve %s",
+    copy-pasted from close_valve and never updated."""
+    _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
+
+    with patch_services_manager(fake_manager), caplog.at_level("INFO"):
+        await hass.services.async_call(
+            DOMAIN,
+            "pause_leak_detection",
+            {"device_id": device_entry.id, "seconds": 1800},
+            blocking=True,
+        )
+
+    assert "closing valve" not in caplog.text.lower()
+    assert "pausing leak detection" in caplog.text.lower()
+
+
+class TestPauseLeakDetectionForSerial:
+    """Direct tests for pause_leak_detection_for_serial (see its own
+    docstring for why it's called directly rather than only through the
+    service)."""
+
+    async def test_calls_the_client(self, hass, fake_manager):
+        entry, _ = await _setup_entry_and_get_cubic_device(hass, fake_manager)
+
+        with patch_all_managers(fake_manager):
+            await pause_leak_detection_for_serial(hass, entry, CUBIC_IDENTITY, 1800)
+
+        assert (
+            "cubic_secure_pause_leak_detection",
+            CUBIC_IDENTITY,
+            1800,
+        ) in fake_manager.calls
+
+    async def test_login_failure_does_not_raise(self, hass, fake_manager):
+        entry, _ = await _setup_entry_and_get_cubic_device(hass, fake_manager)
+        fake_manager.login_result = False
+
+        with patch_all_managers(fake_manager):
+            await pause_leak_detection_for_serial(hass, entry, CUBIC_IDENTITY, 1800)
+
+        assert not any(c[0] == "cubic_secure_pause_leak_detection" for c in fake_manager.calls)
+
+    async def test_refreshes_the_paused_until_sensor(self, hass, fake_manager):
+        """Regression test: the refresh used to live only in button.py,
+        so calling this function any other way (e.g. the raw HA service)
+        never updated the "Leak Detection Paused Until" sensor."""
+        entry, _ = await _setup_entry_and_get_cubic_device(hass, fake_manager)
+        paused_until_entity_id = entity_id(
+            hass, "sensor", f"LkUid_leakDetectionPausedUntil_{CUBIC_IDENTITY}"
+        )
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(mute_leak=1800)
+        )
+
+        with patch_all_managers(fake_manager):
+            await pause_leak_detection_for_serial(hass, entry, CUBIC_IDENTITY, 1800)
+
+        assert hass.states.get(paused_until_entity_id).state != "unknown"
+
+    async def test_sets_the_local_paused_until_target_immediately(
+        self, hass, fake_manager
+    ):
+        """Doesn't wait on the cloud to confirm the pause - muteLeak is
+        static and can lag by up to a poll interval, so the coordinator's
+        own target is set right away rather than left to reconciliation."""
+        entry, _ = await _setup_entry_and_get_cubic_device(hass, fake_manager)
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+
+        with patch_all_managers(fake_manager):
+            await pause_leak_detection_for_serial(hass, entry, CUBIC_IDENTITY, 1800)
+
+        assert CUBIC_IDENTITY in coordinator.leak_detection_paused_until
+
+    async def test_zero_seconds_clears_the_local_paused_until_target(
+        self, hass, fake_manager
+    ):
+        entry, _ = await _setup_entry_and_get_cubic_device(hass, fake_manager)
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+        coordinator.set_leak_detection_paused_until(CUBIC_IDENTITY, 1800)
+
+        with patch_all_managers(fake_manager):
+            await pause_leak_detection_for_serial(hass, entry, CUBIC_IDENTITY, 0)
+
+        assert CUBIC_IDENTITY not in coordinator.leak_detection_paused_until
+
+
 async def test_set_pressure_test_schedule_calls_client(hass, fake_manager):
     _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
 
-    with _patch_services_manager(fake_manager):
+    with patch_services_manager(fake_manager):
         await hass.services.async_call(
             DOMAIN,
             "set_pressure_test_schedule",
@@ -108,7 +196,7 @@ async def test_set_pressure_test_schedule_calls_client(hass, fake_manager):
 async def test_set_thresholds_calls_client_with_defaults(hass, fake_manager):
     _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
 
-    with _patch_services_manager(fake_manager):
+    with patch_services_manager(fake_manager):
         await hass.services.async_call(
             DOMAIN,
             "set_thresholds",
@@ -131,7 +219,7 @@ async def test_close_valve_login_failure_does_not_raise(hass, fake_manager):
     _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
     fake_manager.login_result = False
 
-    with _patch_services_manager(fake_manager):
+    with patch_services_manager(fake_manager):
         await hass.services.async_call(
             DOMAIN, "close_valve", {"device_id": device_entry.id}, blocking=True
         )
@@ -163,7 +251,7 @@ async def test_unknown_device_does_not_raise(
     """
     await _setup_entry_and_get_cubic_device(hass, fake_manager)
 
-    with _patch_services_manager(fake_manager):
+    with patch_services_manager(fake_manager):
         await hass.services.async_call(
             DOMAIN,
             service,


### PR DESCRIPTION
Redo of #74 (reverted in #78) - same idea, addressing the feedback that it "was not ready for review" and "not very user-friendly".

## What's in this version

- **Pause Leak Detection** / **Resume Leak Detection** buttons, a **Pause Duration** number entity (minutes), and a **Leak Detection Paused Until** sensor - a fuller UI than the original bare button.
- Reliable local state tracking instead of recomputing `utcnow() + muteLeak` on every poll (which drifted later each time, since `muteLeak` is a static duration that doesn't decrement between polls - confirmed empirically against the real API).
- Self-correcting: an expiry retry-loop polls the cloud every 15s once a pause's target time is reached, until it confirms the pause is actually over (giving up after 180s and falling back to the regular poll) - and reconciliation picks up pauses/resumes made outside HA entirely (e.g. from the LK app), not just ones HA itself issued.
- Resume button is disabled unless the device is actually tracked as paused.

## Testing

161 tests passing. Beyond the test suite, live-verified against a real Cubic Secure device across several full pause/expiry cycles - both HA-initiated (button and service call) and app-initiated (to exercise reconciliation) - confirming the app and HA agree throughout: pause set, countdown, natural expiry, and restore back to normal.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
