### PR TITLE
Share Claude Code project instructions and the lk-api-spec skill

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,11 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(.venv-test/bin/python3 -m pytest *)",
+      "Bash(.venv-test/bin/python -m pytest *)",
+      "Bash(source .venv-test/bin/activate && python -m pytest *)",
+      "Bash(.venv-test/bin/python3 -m py_compile *)",
+      "Bash(git fetch *)"
+    ]
+  }
+}

--- a/.claude/skills/lk-api-spec/SKILL.md
+++ b/.claude/skills/lk-api-spec/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: lk-api-spec
+description: Fetch the current LK Systems API OpenAPI spec (Authentication, Device Control, Device Service, Messaging) from its Azure APIM developer portal and cache it for this session. Use whenever a task needs to know the real shape of an LK Systems endpoint — request/response fields, parameters, status codes — such as reviewing or extending pylksystems, debugging an API call, or checking whether the real API has drifted from what pylksystems assumes.
+---
+
+# LK Systems API spec
+
+`custom_components/lksystems/pylksystems/__init__.py` calls an LK Systems API
+that is documented on an Azure APIM developer portal
+(https://lk-home-assistant-prod.developer.azure-api.net/, linked from the
+project README). The portal's own "download API definition" button omits
+operations for unauthenticated visitors — the export comes back with
+`paths: {}`. `fetch_spec.py` (in this skill's directory) works around that by
+walking the portal's public per-operation documentation endpoints directly
+and reassembling a complete OpenAPI 3 document per API.
+
+## Usage
+
+Run it with the output directory set to this session's scratchpad — the spec
+only needs to live for the session, not the repo:
+
+```bash
+python3 .claude/skills/lk-api-spec/fetch_spec.py --out-dir <scratchpad>/lk-api-spec
+```
+
+This writes one file per API: `auth.openapi.json`, `lk-device-control.openapi.json`,
+`lk-device-service.openapi.json`, `messagingv2.openapi.json`. Takes about
+20 seconds (~85 HTTP calls to the portal, across all four APIs). Pass
+`--api <id>` (repeatable) to fetch only specific APIs when you already know
+which one you need.
+
+Read the resulting JSON file(s) to answer the task — e.g. grep `paths` for a
+`urlTemplate`, or check a schema under `components.schemas` for a DTO's real
+fields.
+
+### Before trusting a spec already fetched earlier this session
+
+The portal exposes no real version/revision signal to poll (`apiRevision` is
+permanently `"1"`, and its ETag is a constant placeholder), so there's no
+cheap "has this changed" field to read. Instead, before relying on a cached
+spec for anything consequential — and definitely if meaningful time has
+passed since it was fetched — run a cheap staleness check against the same
+directory:
+
+```bash
+python3 .claude/skills/lk-api-spec/fetch_spec.py --out-dir <scratchpad>/lk-api-spec --check
+```
+
+This re-fetches only each API's operation list and schemas (a few seconds,
+not ~20), hashes them, and compares against the fingerprint stored in the
+cached file. It prints `up to date` or `CHANGED` per API and exits nonzero if
+anything changed. On `CHANGED`, re-run the plain (non-`--check`) fetch for
+that API before using it. Note the check can miss a change confined to one
+operation's description or status codes with no schema impact — it's a fast
+smoke test, not a guarantee.
+
+If the script fails with `CERTIFICATE_VERIFY_FAILED`, the Python running it
+lacks a populated system CA bundle (seen with some pyenv builds on macOS);
+the script already falls back to `certifi`'s bundle when that package is
+importable, so `pip install certifi` into the active environment fixes it.

--- a/.claude/skills/lk-api-spec/fetch_spec.py
+++ b/.claude/skills/lk-api-spec/fetch_spec.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""Reconstruct OpenAPI 3 specs for the LK Systems API from its Azure APIM
+developer portal.
+
+The portal's own "download API definition" export omits operations for
+unauthenticated visitors (paths come back empty), but the per-operation
+documentation endpoints the portal's UI calls to render its reference pages
+are public and fully populated. This script walks those endpoints and
+reassembles a self-contained OpenAPI 3 document per API.
+
+Usage:
+    python3 fetch_spec.py --out-dir /path/to/output [--api API_ID ...]
+    python3 fetch_spec.py --out-dir /path/to/output --check [--api API_ID ...]
+
+`--check` compares each cached spec's operation list and schemas against a
+fresh (but cheap) fetch, without walking every operation's full detail, so it
+costs a handful of requests instead of the ~20 per API that a full fetch
+takes. It catches added/removed/renamed operations and any DTO/schema
+change, but not a change confined to one operation's description or status
+codes with no schema impact — treat it as a fast smoke test, not a
+guarantee, and re-fetch outright when in doubt.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import ssl
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+PORTAL_BASE = "https://lk-home-assistant-prod.developer.azure-api.net"
+API_VERSION = "2022-04-01-preview"
+REQUEST_DELAY_SECONDS = 0.05
+
+
+def _ssl_context() -> ssl.SSLContext:
+    # Some Python builds (e.g. pyenv on macOS) ship without a populated
+    # system CA path; prefer certifi's bundle when it's installed.
+    try:
+        import certifi
+
+        return ssl.create_default_context(cafile=certifi.where())
+    except ImportError:
+        return ssl.create_default_context()
+
+
+def _get(path: str, **query: str) -> Any:
+    params = "&".join(f"{k}={v}" for k, v in {"api-version": API_VERSION, **query}.items())
+    url = f"{PORTAL_BASE}{path}?{params}"
+    request = urllib.request.Request(url, headers={"Accept": "application/json"})
+    with urllib.request.urlopen(request, timeout=30, context=_ssl_context()) as response:
+        body = json.load(response)
+    time.sleep(REQUEST_DELAY_SECONDS)
+    return body
+
+
+def _get_all_pages(path: str) -> list[dict[str, Any]]:
+    items: list[dict[str, Any]] = []
+    page_path = path
+    while page_path:
+        page = _get(page_path)
+        items.extend(page["value"])
+        next_link = page.get("nextLink")
+        page_path = next_link[len(PORTAL_BASE):] if next_link else None
+    return items
+
+
+def list_apis() -> list[dict[str, Any]]:
+    return _get_all_pages("/developer/apis")
+
+
+def _openapi_parameter(name: str, location: str, param: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "name": name,
+        "in": location,
+        "required": location == "path" or param.get("required", False),
+        "schema": {"type": param.get("type", "string")},
+    }
+
+
+def _openapi_content(representations: list[dict[str, Any]]) -> dict[str, Any]:
+    content: dict[str, Any] = {}
+    for rep in representations:
+        entry: dict[str, Any] = {}
+        if rep.get("typeName"):
+            entry["schema"] = {"$ref": f"#/components/schemas/{rep['typeName']}"}
+        example = (rep.get("examples") or {}).get("default", {}).get("value")
+        if example is not None:
+            entry["example"] = example
+        content[rep["contentType"]] = entry
+    return content
+
+
+def _openapi_operation(detail: dict[str, Any]) -> dict[str, Any]:
+    parameters = [
+        _openapi_parameter(p["name"], "path", p) for p in detail.get("templateParameters", [])
+    ]
+    parameters += [
+        _openapi_parameter(p["name"], "query", p) for p in detail["request"]["queryParameters"]
+    ]
+    parameters += [
+        _openapi_parameter(p["name"], "header", p) for p in detail["request"]["headers"]
+    ]
+
+    operation: dict[str, Any] = {"operationId": detail["id"], "parameters": parameters}
+    if detail.get("description"):
+        operation["description"] = detail["description"]
+
+    representations = detail["request"]["representations"]
+    if representations:
+        operation["requestBody"] = {"content": _openapi_content(representations)}
+
+    operation["responses"] = {
+        str(resp["statusCode"]): {
+            "description": resp.get("description") or "",
+            **({"content": _openapi_content(resp["representations"])} if resp["representations"] else {}),
+        }
+        for resp in detail["responses"]
+    }
+    return operation
+
+
+def _fetch_schemas(api_id: str) -> dict[str, Any]:
+    schemas: dict[str, Any] = {}
+    for schema_summary in _get_all_pages(f"/developer/apis/{api_id}/schemas"):
+        schema_doc = _get(f"/developer/apis/{api_id}/schemas/{schema_summary['id']}")
+        schemas.update(schema_doc.get("document", {}).get("components", {}).get("schemas", {}))
+    return schemas
+
+
+def _fingerprint(operations: list[dict[str, Any]], schemas: dict[str, Any]) -> str:
+    material = {
+        "operations": sorted((op["method"], op["urlTemplate"]) for op in operations),
+        "schemas": schemas,
+    }
+    return hashlib.sha256(json.dumps(material, sort_keys=True).encode()).hexdigest()
+
+
+def build_openapi_document(api: dict[str, Any]) -> dict[str, Any]:
+    api_id = api["id"]
+    operations = _get_all_pages(f"/developer/apis/{api_id}/operations")
+
+    paths: dict[str, Any] = {}
+    for op_summary in operations:
+        detail = _get(f"/developer/apis/{api_id}/operations/{op_summary['id']}")
+        paths.setdefault(detail["urlTemplate"], {})[detail["method"].lower()] = _openapi_operation(detail)
+
+    schemas = _fetch_schemas(api_id)
+
+    return {
+        "openapi": "3.0.1",
+        "info": {"title": api["name"], "version": "1.0"},
+        "servers": [{"url": f"https://link2.lk.nu/{api['path']}"}],
+        "paths": paths,
+        "components": {"schemas": schemas},
+        "x-fingerprint": _fingerprint(operations, schemas),
+    }
+
+
+def fetch_fingerprint(api_id: str) -> str:
+    """Cheaply recompute an API's fingerprint without walking every operation's full detail."""
+    operations = _get_all_pages(f"/developer/apis/{api_id}/operations")
+    schemas = _fetch_schemas(api_id)
+    return _fingerprint(operations, schemas)
+
+
+def run_fetch(out_dir: Path, api_ids: list[str] | None) -> int:
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        apis = list_apis()
+    except urllib.error.URLError as exc:
+        print(f"Failed to reach the developer portal: {exc}", file=sys.stderr)
+        return 1
+
+    if api_ids:
+        apis = [a for a in apis if a["id"] in api_ids]
+
+    for api in apis:
+        print(f"Fetching {api['name']} ({api['id']})...", file=sys.stderr)
+        document = build_openapi_document(api)
+        out_file = out_dir / f"{api['id']}.openapi.json"
+        out_file.write_text(json.dumps(document, indent=2, sort_keys=True))
+        print(f"  -> {out_file} ({len(document['paths'])} paths)", file=sys.stderr)
+
+    return 0
+
+
+def run_check(spec_dir: Path, api_ids: list[str] | None) -> int:
+    cached_files = {f.name.removesuffix(".openapi.json"): f for f in spec_dir.glob("*.openapi.json")}
+    if api_ids:
+        cached_files = {api_id: f for api_id, f in cached_files.items() if api_id in api_ids}
+
+    if not cached_files:
+        print(f"No cached specs found in {spec_dir}", file=sys.stderr)
+        return 1
+
+    stale_apis = []
+    for api_id, cached_file in sorted(cached_files.items()):
+        stored_fingerprint = json.loads(cached_file.read_text()).get("x-fingerprint")
+        try:
+            current_fingerprint = fetch_fingerprint(api_id)
+        except urllib.error.URLError as exc:
+            print(f"Failed to reach the developer portal: {exc}", file=sys.stderr)
+            return 1
+
+        if stored_fingerprint == current_fingerprint:
+            print(f"{api_id}: up to date")
+        else:
+            print(f"{api_id}: CHANGED since last fetch - re-run without --check to refresh")
+            stale_apis.append(api_id)
+
+    return 1 if stale_apis else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--out-dir", type=Path, required=True, help="Directory to write into (fetch mode) or read from (--check mode)")
+    parser.add_argument("--api", action="append", dest="api_ids", help="Only fetch/check this API id (repeatable); default is all APIs on the portal")
+    parser.add_argument("--check", action="store_true", help="Check cached specs for staleness instead of (re)fetching them")
+    args = parser.parse_args()
+
+    if args.check:
+        return run_check(args.out_dir, args.api_ids)
+    return run_fetch(args.out_dir, args.api_ids)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ __pycache__
 .pytest_cache/
 TODO.local.md
 .vscode/
-.claude/
+.claude/settings.local.json
+.claude/scheduled_tasks.lock
 .mcp.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,102 @@
+# Working on this repo with Claude Code
+
+This file is read automatically by Claude Code (and compatible tools) for
+anyone working in this checkout - it's how contributors using an AI coding
+assistant here end up working the same way, without each having to agree on
+conventions from scratch.
+
+For environment setup, running the two test suites, deploying to a live test
+instance, and the optional Home Assistant MCP server integration, see the
+**Contributing** section of [README.md](README.md) - it's not repeated here.
+
+## Test-driven development
+
+Work test-driven whenever a change touches `pylksystems` or anything under
+`tests_ha/`'s coverage: write a test that captures the desired behavior
+*before* touching production code, confirm it fails for the expected reason
+(RED), then write the minimal implementation that makes it pass (GREEN),
+then refactor with the test still green.
+
+When fixing a bug, the failing test should reproduce the bug itself - ideally
+in its own scenario, mirroring how it was actually observed - before the fix
+lands, not just assert the fixed behavior after the fact. A test that was
+never seen failing hasn't proven it tests anything.
+
+This applies to any change with production-code impact and a test harness
+capable of exercising it. It doesn't apply to pure docs/config changes,
+one-off scratch scripts, or exploratory spikes.
+
+## Clean code
+
+Apply Robert C. Martin's Clean Code principles broadly - naming, function
+shape, duplication, structure - not just comments.
+([reference checklist](https://gist.github.com/wojteklu/73c6914cc446146b8b533c0988cf8d29))
+
+- **Naming**: descriptive, unambiguous, no noise suffixes (`data2`, `_tmp`).
+  Named constants over magic numbers/strings.
+- **Functions**: small, single-purpose, one level of abstraction inside.
+  Prefer 0-2 arguments; a boolean flag that branches internal behavior is
+  usually two functions pretending to be one.
+- **Duplication**: when the same pattern gets copied across a few
+  classes/functions (this codebase's coordinator/entity split makes that easy
+  to do by accident), look for the shared abstraction - a helper, a base
+  method, a single call site - before accepting several near-identical
+  copies.
+
+### Comments
+
+Self-documenting code (naming, structure) is the default. Add a comment only
+when the *why*, or a genuinely non-obvious *what*, can't be expressed through
+naming/structure alone - and never to restate what the next line already
+says.
+
+A comment must describe the code as it currently stands - never narrate a
+diff ("this used to do X", "removed the Y check"). Git history already
+records what changed. Before finalizing an edit, reread every comment you
+touched: does it survive a rename/restructure attempt first, does it avoid
+narrating a diff, is it not repeating the same rationale that already lives
+at another site (state it once where it's owned, let other sites reach it
+through the code), and does it avoid pointing at "elsewhere in the codebase"
+without an actual import/call backing that connection.
+
+**Never reference an issue/PR/ticket number in a comment or docstring, in any
+file - no exception for test names/docstrings.** A number pointing at "the
+tracker of the moment" goes stale the day the repo migrates host or the
+tracker changes; the rationale belongs in prose with no number, or in the
+commit message / PR description instead, never inline in code.
+
+### Process
+
+Once a change's tests are green, do a dedicated pass over the diff for
+naming, duplication, function shape, and comment hygiene before considering
+it done - TDD only verifies correctness, it doesn't catch those on its own.
+
+## Verify against the real API before documenting behavior
+
+This codebase has a strong existing convention (grep for "confirmed
+empirically against the real API" across `custom_components/lksystems/` to
+see it in practice) of not trusting assumptions about what the LK Systems API
+actually returns or how a field behaves - `muteLeak`'s true semantics (a
+static duration, not a live countdown) is a good example of behavior that
+looked obvious from the field name and wasn't. Keep this up:
+
+- Use the `lk-api-spec` skill (`.claude/skills/lk-api-spec/`) to check the
+  real OpenAPI spec for an endpoint's actual request/response shape rather
+  than guessing from `pylksystems`'s existing assumptions.
+- For behavior the spec alone can't answer (timing, whether a value
+  decrements, cache staleness), test against a real account/device before
+  writing a comment that asserts it as fact. A comment that got this from
+  testing should say so; one that's inferred/still a guess should say that
+  too, not read as more certain than it is.
+
+## Before opening a pull request
+
+- Run `/simplify` (or an equivalent focused review) over the diff.
+- Keep the branch's commit history clean - squash exploratory/investigation
+  commits (anything that was only ever meant to be temporary, e.g. debug
+  logging added to chase down a bug) rather than leaving them for reviewers
+  to read through. `git cherry <base> HEAD` is useful for spotting which
+  commits are actually unique to your branch when it's had `main` merged
+  into it repeatedly.
+- Full test suite green (`pytest tests/ -p no:homeassistant` and
+  `pytest tests_ha/`, per the README).


### PR DESCRIPTION
Other contributors have started reaching out wanting to work on this repo alongside Claude Code, so this shares what was previously only local:

- **`CLAUDE.md`**: TDD, clean code/comments (incl. never referencing an issue/PR number in a code comment), and this codebase's own "verify against the real API, don't assume" convention. Points to the README's Contributing section for environment/test/deploy mechanics rather than duplicating them.
- **`.claude/settings.json`**: a small, already-safe permission allowlist (test venv, `git fetch`) - previously caught by a blanket `.claude/` gitignore rule along with everything else.
- **`.claude/skills/lk-api-spec/`**: fetches the real LK Systems OpenAPI spec from its developer portal - useful whenever a change needs to know an endpoint's actual shape rather than assuming from `pylksystems`.

`.claude/settings.local.json` and `.mcp.json` stay gitignored - genuinely personal (an individual permission history, and a live HA access token).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
