### PR TITLE
pylksystems: share Retry-After cooldown across callers, add per-call max-wait

### DIFF
--- a/custom_components/lksystems/pylksystems/__init__.py
+++ b/custom_components/lksystems/pylksystems/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import json
 import logging
 import re
@@ -41,6 +41,9 @@ RATE_LIMIT_MAX_RETRIES = 3
 RATE_LIMIT_DEFAULT_BACKOFF = 5.0  # seconds, used when no Retry-After header
 RATE_LIMIT_MIN_BACKOFF = 1.0  # seconds; see _rate_limit_backoff() for why
 
+_GET_SUCCESS_STATUSES = frozenset({200})
+_POST_SUCCESS_STATUSES = frozenset({200, 201})
+
 
 def _rate_limit_backoff(response) -> float:
     """Return the delay to wait before retrying a 429 response.
@@ -58,6 +61,37 @@ def _rate_limit_backoff(response) -> float:
         except ValueError:
             pass
     return RATE_LIMIT_DEFAULT_BACKOFF
+
+
+# A 429's Retry-After is server truth, not any one caller's to own - every
+# LKSystemsManager instance in the process constructs its own session, so
+# this cooldown deadline is deliberately module-level rather than an
+# instance attribute. Keyed per endpoint path rather than one global bucket:
+# Azure APIM rate-limit policies are typically scoped per operation, and
+# every 429 observed so far has landed on one specific endpoint, none on
+# others - a single global cooldown would block unrelated endpoints for no
+# reason.
+_rate_limited_until: dict[str, datetime] = {}
+
+
+def _rate_limit_wait_remaining(endpoint: str) -> float:
+    """Return seconds still left on endpoint's shared cooldown, or 0."""
+    deadline = _rate_limited_until.get(endpoint)
+    if deadline is None:
+        return 0.0
+    return max((deadline - datetime.now(timezone.utc)).total_seconds(), 0.0)
+
+
+def _record_rate_limited(endpoint: str, backoff_seconds: float) -> None:
+    """Record a fresh 429's Retry-After as endpoint's shared cooldown."""
+    _rate_limited_until[endpoint] = datetime.now(timezone.utc) + timedelta(
+        seconds=backoff_seconds
+    )
+
+
+def _clear_rate_limit(endpoint: str) -> None:
+    """Clear endpoint's shared cooldown after a successful request."""
+    _rate_limited_until.pop(endpoint, None)
 
 
 def _retry_delay_for_response(response, attempt: int) -> float | None:
@@ -176,91 +210,131 @@ class LKSystemsManager:
             "ocp-apim-subscription-key": "d2d308826cd14e7d92660b28bc7d859c",
         }
 
+    async def _log_and_sleep(self, delay: float, message: str, *args) -> None:
+        """Log a warning and wait out delay - the shared shape behind both
+        a reactive 429 backoff and a pre-emptive shared-cooldown wait."""
+        _LOGGER.warning(message, *args)
+        await asyncio.sleep(delay)
+
     async def _sleep_before_retry(self, endpoint: str, delay: float, attempt: int) -> None:
         """Log and wait out a 429's backoff before the next retry attempt."""
-        _LOGGER.warning(
+        await self._log_and_sleep(
+            delay,
             "Rate limited (429) by LK Systems API, retrying %s in %.1fs (attempt %d/%d)",
             self.BASE_URL + endpoint,
             delay,
             attempt + 1,
             RATE_LIMIT_MAX_RETRIES,
         )
-        await asyncio.sleep(delay)
 
-    async def _get(self, endpoint):
+    async def _wait_out_shared_cooldown(self, endpoint: str, url: str) -> None:
+        """Wait out any cooldown an earlier 429 already recorded for endpoint.
+
+        Checked pre-emptively before firing a request, so a caller that
+        already knows it's cooling down doesn't spend a request to find
+        that out again.
+        """
+        remaining = _rate_limit_wait_remaining(endpoint)
+        if remaining <= 0:
+            return
+        await self._log_and_sleep(
+            remaining,
+            "Endpoint %s is under a shared rate-limit cooldown from an "
+            "earlier request, waiting %.1fs before requesting",
+            url,
+            remaining,
+        )
+
+    async def _request_with_retry(
+        self,
+        endpoint: str,
+        send_request,
+        success_statuses: frozenset[int],
+        parse_response,
+        max_wait: float | None,
+    ):
+        """Shared GET/POST retry loop: honors the endpoint's shared 429
+        cooldown pre-emptively, retries a fresh 429 with backoff up to
+        RATE_LIMIT_MAX_RETRIES, and records/clears that shared cooldown
+        from what this call itself observes.
+
+        When max_wait is given, the whole call - any pre-emptive wait plus
+        any retries - is capped to that many seconds; running out of budget
+        is treated like any other failed fetch and never touches the shared
+        cooldown, which is real server-side state for whoever asks next.
+        """
+        url = self.BASE_URL + endpoint
+
+        async def attempt() -> tuple[bool, dict | None]:
+            await self._wait_out_shared_cooldown(endpoint, url)
+            headers = {}
+            retry_attempt = 0
+            while True:
+                try:
+                    headers = {
+                        **self._get_headers(),
+                        "authorization": f"Bearer {self.jwt_token}",
+                    }
+
+                    async with send_request(headers) as response:
+                        if response.status == RATE_LIMIT_STATUS:
+                            _record_rate_limited(
+                                endpoint, _rate_limit_backoff(response)
+                            )
+
+                        delay = _retry_delay_for_response(response, retry_attempt)
+                        if delay is None:
+                            response.raise_for_status()
+                            if response.status in success_statuses:
+                                _clear_rate_limit(endpoint)
+                                return True, await parse_response(response)
+
+                            _LOGGER.error(
+                                "Request to URL %s failed with status code %d",
+                                url,
+                                response.status,
+                            )
+                            return False, None
+
+                    # Deliberately kept outside the `async with` above -
+                    # moving it back in would hold the connection open for
+                    # the whole backoff instead of releasing it first.
+                    await self._sleep_before_retry(endpoint, delay, retry_attempt)
+                    retry_attempt += 1
+
+                except (ClientResponseError, ClientError) as error:
+                    return (
+                        await self.handle_client_error(endpoint, headers, error)
+                    ), None
+
+        try:
+            return await asyncio.wait_for(attempt(), timeout=max_wait)
+        except asyncio.TimeoutError:
+            return False, None
+
+    async def _get(self, endpoint, max_wait: float | None = None):
         """Helper method to perform GET requests."""
-        headers = {}
-        attempt = 0
-        while True:
-            try:
-                # Define headers with the JwtToken
-                headers = {
-                    **self._get_headers(),
-                    "authorization": f"Bearer {self.jwt_token}",
-                }
+        return await self._request_with_retry(
+            endpoint,
+            lambda headers: self.session.get(
+                self.BASE_URL + endpoint, headers=headers
+            ),
+            success_statuses=_GET_SUCCESS_STATUSES,
+            parse_response=lambda response: response.json(),
+            max_wait=max_wait,
+        )
 
-                async with self.session.get(
-                    self.BASE_URL + endpoint, headers=headers
-                ) as response:
-                    delay = _retry_delay_for_response(response, attempt)
-                    if delay is None:
-                        response.raise_for_status()
-                        if response.status == 200:
-                            res = await response.json()
-
-                            return True, res
-
-                        _LOGGER.error(
-                            "Obtaining data from URL %s failed with status code %d",
-                            self.BASE_URL + endpoint,
-                            response.status,
-                        )
-                        return False, None
-
-                # Deliberately kept outside the `async with` above - moving
-                # it back in would hold the connection open for the whole
-                # backoff instead of releasing it first.
-                await self._sleep_before_retry(endpoint, delay, attempt)
-                attempt += 1
-
-            except (ClientResponseError, ClientError) as error:
-                return (await self.handle_client_error(endpoint, headers, error)), None
-
-    async def _post(self, endpoint, payload):
+    async def _post(self, endpoint, payload, max_wait: float | None = None):
         """Helper method to perform POST requests."""
-        headers = {}
-        attempt = 0
-        while True:
-            try:
-                # Define headers with the JwtToken
-                headers = {
-                    **self._get_headers(),
-                    "authorization": f"Bearer {self.jwt_token}",
-                }
-
-                async with self.session.post(
-                    self.BASE_URL + endpoint, json=payload, headers=headers
-                ) as response:
-                    delay = _retry_delay_for_response(response, attempt)
-                    if delay is None:
-                        response.raise_for_status()
-                        if response.status in [200, 201]:
-                            res = await response.json(content_type=None)
-
-                            return True, res
-
-                        _LOGGER.error(
-                            "Posting data to URL %s failed with status code %d",
-                            self.BASE_URL + endpoint,
-                            response.status,
-                        )
-                        return False, None
-
-                await self._sleep_before_retry(endpoint, delay, attempt)
-                attempt += 1
-
-            except (ClientResponseError, ClientError) as error:
-                return (await self.handle_client_error(endpoint, headers, error)), None
+        return await self._request_with_retry(
+            endpoint,
+            lambda headers: self.session.post(
+                self.BASE_URL + endpoint, json=payload, headers=headers
+            ),
+            success_statuses=_POST_SUCCESS_STATUSES,
+            parse_response=lambda response: response.json(content_type=None),
+            max_wait=max_wait,
+        )
 
     async def login(self):
         """Login to LK systems and get userId"""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,27 @@ def _load_pylksystems():
 pylksystems = _load_pylksystems()
 
 
+def _new_manager():
+    return pylksystems.LKSystemsManager("user@example.com", "hunter2")
+
+
 @pytest.fixture
 def manager():
     """A fresh, unauthenticated LKSystemsManager instance."""
-    return pylksystems.LKSystemsManager("user@example.com", "hunter2")
+    return _new_manager()
+
+
+@pytest.fixture
+def other_manager():
+    """A second, independent LKSystemsManager instance - for tests that
+    exercise state meant to be shared *across* instances."""
+    return _new_manager()
+
+
+@pytest.fixture(autouse=True)
+def rate_limit_cooldowns():
+    """The shared per-endpoint 429 cooldown store, reset before each test
+    so it doesn't leak between them."""
+    pylksystems._rate_limited_until.clear()
+    yield pylksystems._rate_limited_until
+    pylksystems._rate_limited_until.clear()

--- a/tests/test_pylksystems.py
+++ b/tests/test_pylksystems.py
@@ -14,7 +14,16 @@ import pytest
 from aiohttp import ClientConnectionError
 from aioresponses import aioresponses
 
+import pylksystems
+
 BASE_URL = "https://link2.lk.nu/"
+
+
+@pytest.fixture
+def mock_sleep():
+    """Patch asyncio.sleep so a test never actually waits out a real delay."""
+    with patch("asyncio.sleep", new=AsyncMock()) as mock:
+        yield mock
 
 
 class TestLogin:
@@ -369,19 +378,13 @@ class TestClientSessionTimeout:
         assert timeout.total <= 30
 
 
+@pytest.mark.usefixtures("mock_sleep")
 class TestRateLimitBackoff:
     """LK's cloud API rate-limits (429) during bursts of activity - this is
     an expected, routine condition on LK's end, not a genuine error. The
     client should retry with backoff (honoring Retry-After when present)
     instead of failing immediately, and log at warning rather than error.
     """
-
-    @pytest.fixture(autouse=True)
-    def mock_sleep(self):
-        """Patch asyncio.sleep for every test in this class - none of them
-        should actually wait out a real backoff delay."""
-        with patch("asyncio.sleep", new=AsyncMock()) as mock:
-            yield mock
 
     async def test_429_is_retried_and_eventually_succeeds(self, manager, mock_sleep):
         url = BASE_URL + "service/cubic/secure/cubic-1/measurement/0"
@@ -491,3 +494,144 @@ class TestRateLimitBackoff:
 
         assert result is False
         assert any(record.levelno >= logging.ERROR for record in caplog.records)
+
+
+class TestSharedRateLimitCooldown:
+    """A 429's Retry-After becomes a cooldown deadline for its endpoint,
+    visible to every LKSystemsManager instance in the process - not just
+    the one call that happened to observe it.
+    """
+
+    FORCED_ENDPOINT = "service/cubic/secure/cubic-1/configuration/1"
+    CACHED_ENDPOINT = "service/cubic/secure/cubic-1/configuration/0"
+
+    async def test_429_exhausting_one_instances_retries_still_delays_another(
+        self, manager, other_manager, mock_sleep
+    ):
+        """A caller that exhausts its own retries and gives up must still
+        leave the cooldown it observed for the next caller to see - giving
+        up is not the same as the rate limit having lifted."""
+        url = BASE_URL + self.FORCED_ENDPOINT
+
+        with aioresponses() as m:
+            m.get(url, status=429, headers={"Retry-After": "50"}, repeat=True)
+            async with manager:
+                result = await manager.get_cubic_secure_configuration(
+                    "cubic-1", force_update=True
+                )
+
+        assert result is False
+        mock_sleep.reset_mock()
+
+        with aioresponses() as m:
+            m.get(url, payload={"flow": 2.0}, status=200)
+            async with other_manager:
+                result = await other_manager.get_cubic_secure_configuration(
+                    "cubic-1", force_update=True
+                )
+
+        assert result is True
+        mock_sleep.assert_awaited_once()
+        assert mock_sleep.await_args.args[0] == pytest.approx(50.0, abs=1.0)
+
+    async def test_cooldown_is_scoped_per_endpoint_path(
+        self, manager, other_manager, mock_sleep
+    ):
+        """The cached and force-update variants of the same resource are
+        different paths - a 429 on one must not delay the other."""
+        forced_url = BASE_URL + self.FORCED_ENDPOINT
+        cached_url = BASE_URL + self.CACHED_ENDPOINT
+
+        with aioresponses() as m:
+            m.get(forced_url, status=429, headers={"Retry-After": "50"})
+            m.get(forced_url, payload={"flow": 1.0}, status=200)
+            async with manager:
+                await manager.get_cubic_secure_configuration(
+                    "cubic-1", force_update=True
+                )
+
+        mock_sleep.reset_mock()
+
+        with aioresponses() as m:
+            m.get(cached_url, payload={"flow": 2.0}, status=200)
+            async with other_manager:
+                result = await other_manager.get_cubic_secure_configuration(
+                    "cubic-1", force_update=False
+                )
+
+        assert result is True
+        mock_sleep.assert_not_awaited()
+
+    async def test_success_clears_the_cooldown_for_that_endpoint(
+        self, manager, other_manager, mock_sleep
+    ):
+        url = BASE_URL + self.FORCED_ENDPOINT
+
+        with aioresponses() as m:
+            m.get(url, status=429, headers={"Retry-After": "1"})
+            m.get(url, payload={"flow": 1.0}, status=200)
+            async with manager:
+                await manager.get_cubic_secure_configuration(
+                    "cubic-1", force_update=True
+                )
+
+        mock_sleep.reset_mock()
+
+        with aioresponses() as m:
+            m.get(url, payload={"flow": 2.0}, status=200)
+            async with other_manager:
+                await other_manager.get_cubic_secure_configuration(
+                    "cubic-1", force_update=True
+                )
+
+        mock_sleep.assert_not_awaited()
+
+
+class TestPerCallMaxWait:
+    """`_get`/`_post` accept an optional per-call `max_wait` budget - how
+    long *this* caller is willing to wait, independent of the shared
+    cooldown. Giving up on that budget must never touch the shared
+    deadline: the remaining cooldown is still real server-side state that
+    applies to whoever asks next.
+    """
+
+    ENDPOINT = "service/cubic/secure/cubic-1/configuration/1"
+
+    async def test_gives_up_once_its_own_budget_is_exhausted(
+        self, manager, rate_limit_cooldowns
+    ):
+        pylksystems._record_rate_limited(self.ENDPOINT, 0.4)
+
+        with aioresponses():
+            async with manager:
+                success, data = await manager._get(self.ENDPOINT, max_wait=0.05)
+
+        assert success is False
+        assert data is None
+
+    async def test_giving_up_does_not_shorten_the_shared_cooldown(
+        self, manager, rate_limit_cooldowns
+    ):
+        pylksystems._record_rate_limited(self.ENDPOINT, 0.4)
+        deadline = rate_limit_cooldowns[self.ENDPOINT]
+
+        with aioresponses():
+            async with manager:
+                await manager._get(self.ENDPOINT, max_wait=0.05)
+
+        assert rate_limit_cooldowns[self.ENDPOINT] == deadline
+
+    async def test_without_max_wait_keeps_waiting_out_the_full_cooldown(
+        self, manager, rate_limit_cooldowns, mock_sleep
+    ):
+        pylksystems._record_rate_limited(self.ENDPOINT, 50)
+
+        with aioresponses() as m:
+            m.get(BASE_URL + self.ENDPOINT, payload={"flow": 1.0}, status=200)
+            async with manager:
+                success, data = await manager._get(self.ENDPOINT)
+
+        assert success is True
+        assert data == {"flow": 1.0}
+        mock_sleep.assert_awaited_once()
+        assert mock_sleep.await_args.args[0] == pytest.approx(50.0, abs=1.0)


### PR DESCRIPTION
Implements the two-part design from the issue: a shared, per-endpoint-path rate-limit cooldown checked pre-emptively by every caller and updated only by a fresh 429 or success, plus a separate optional per-call max-wait budget on `_get`/`_post` that lets one caller give up without touching the shared cooldown.

`_get`/`_post` were consolidated onto one shared retry loop to avoid duplicating the new cooldown logic.

Tests: `tests/` 39 passed (1 unrelated pre-existing teardown flake, see #71), `tests_ha/` 110 passed.

Note: several other request methods (`login`, `get_devices`, etc.) still call the session directly and bypass this cooldown - tracked separately in #85.

Closes #83.