### PR TITLE
Fix leaked aiohttp shutdown thread in test teardown

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,9 @@ import importlib.util
 import sys
 from pathlib import Path
 
+import aiohttp.connector
 import pytest
+from aiohttp import ThreadedResolver
 
 # The pylksystems client is a plain aiohttp-based module with no Home
 # Assistant dependency, but it lives inside the `custom_components.lksystems`
@@ -37,6 +39,19 @@ pylksystems = _load_pylksystems()
 
 def _new_manager():
     return pylksystems.LKSystemsManager("user@example.com", "hunter2")
+
+
+@pytest.fixture(autouse=True)
+def _use_threaded_dns_resolver(monkeypatch):
+    """Make every ClientSession in this suite use aiohttp's threaded resolver.
+
+    aiohttp otherwise defaults to the aiodns-backed resolver, whose pycares
+    channel spawns a permanent daemon thread the first time it is torn
+    down. That happens even for a fully-mocked session that never performs
+    a real lookup, and the thread outlives the test, so
+    pytest-homeassistant-custom-component's leaked-thread check flags it.
+    """
+    monkeypatch.setattr(aiohttp.connector, "DefaultResolver", ThreadedResolver)
 
 
 @pytest.fixture


### PR DESCRIPTION
Root cause: not this repo's code (session close was already correct), but `aiohttp`'s default resolver eagerly constructing an `aiodns`/`pycares` channel that starts a permanent daemon thread on teardown, even though `aioresponses` never lets a real DNS lookup happen. Fix: an autouse fixture in `tests/conftest.py` forcing `ThreadedResolver` for the test session. Test-only change, no production code touched.

Tests: `tests/` 33/33, `tests_ha/` 110/110 - the leaked-thread teardown failure is gone in both runs.

Closes #71.