### PR TITLE
Fix measurement/machine spelling typos

### DIFF
--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -87,7 +87,7 @@ class LkCubicDeviceData(TypedDict):
     LkStructureResp.cubic_devices so multiple devices on one account
     don't share a single overwritable slot."""
 
-    machine_info: LkStructureMashine
+    machine_info: LkStructureMachine
     last_measurement: LkCubicSecureResp
     configuration: LKCubicSecureConfigResp
 
@@ -146,7 +146,7 @@ class LkCubicSecureResp(TypedDict):
     cacheUpdated: int
 
 
-class LkStructureMashine(TypedDict):
+class LkStructureMachine(TypedDict):
     """Machines API Resp structure"""
 
     identity: str
@@ -956,12 +956,12 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                                     device_identity
                                 )
 
-                                if lk_inst.cubic_secure_messurement is not None:
+                                if lk_inst.cubic_secure_measurement is not None:
                                     # Get time as unix timestamp
                                     timestamp = int(time.time())
                                     if (
                                         timestamp
-                                        - lk_inst.cubic_secure_messurement[
+                                        - lk_inst.cubic_secure_measurement[
                                             "cacheUpdated"
                                         ]
                                         > self.update_interval.total_seconds()
@@ -981,7 +981,7 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
 
                                 resp["cubic_devices"][device_identity][
                                     "last_measurement"
-                                ] = lk_inst.cubic_secure_messurement
+                                ] = lk_inst.cubic_secure_measurement
                                 if not await lk_inst.get_cubic_secure_configuration(
                                     device_identity
                                 ):

--- a/custom_components/lksystems/pylksystems/__init__.py
+++ b/custom_components/lksystems/pylksystems/__init__.py
@@ -120,7 +120,7 @@ class LKSystemsManager:
         self.userid = None
         self.jwt_token = None
         self.refresh_token = None
-        self._cubic_secure_messurement = None
+        self._cubic_secure_measurement = None
         self._user_structure = None
         self._cubic_secure_configuration = None
         self._cubic_secure_pressure_test_reports = None
@@ -321,14 +321,14 @@ class LKSystemsManager:
             endpoint = f"service/cubic/secure/{cubic_identity}/measurement/0"
         success, res = await self._get(endpoint)
         if success:
-            self._cubic_secure_messurement = res
+            self._cubic_secure_measurement = res
             return True
         return False
 
     @property
-    def cubic_secure_messurement(self):
-        """Property for Cubic Secure messurement"""
-        return self._cubic_secure_messurement
+    def cubic_secure_measurement(self):
+        """Property for Cubic Secure measurement"""
+        return self._cubic_secure_measurement
 
     async def get_user_structure(self):
         """Fetch user secure measurement"""

--- a/tests/test_pylksystems.py
+++ b/tests/test_pylksystems.py
@@ -246,7 +246,7 @@ class TestCubicSecureMeasurement:
                 )
 
         assert result is True
-        assert manager.cubic_secure_messurement == {"flow": 1.5}
+        assert manager.cubic_secure_measurement == {"flow": 1.5}
 
     async def test_without_force_update_selects_endpoint(self, manager):
         with aioresponses() as m:
@@ -259,7 +259,7 @@ class TestCubicSecureMeasurement:
                 result = await manager.get_cubic_secure_measurement("cubic-1")
 
         assert result is True
-        assert manager.cubic_secure_messurement == {"flow": 0.0}
+        assert manager.cubic_secure_measurement == {"flow": 0.0}
 
     async def test_error_status_returns_false_and_keeps_state(self, manager):
         with aioresponses() as m:
@@ -271,7 +271,7 @@ class TestCubicSecureMeasurement:
                 result = await manager.get_cubic_secure_measurement("cubic-1")
 
         assert result is False
-        assert manager.cubic_secure_messurement is None
+        assert manager.cubic_secure_measurement is None
 
 
 class TestSetDeviceTemperature:
@@ -393,7 +393,7 @@ class TestRateLimitBackoff:
                 result = await manager.get_cubic_secure_measurement("cubic-1")
 
         assert result is True
-        assert manager.cubic_secure_messurement == {"flow": 0.0}
+        assert manager.cubic_secure_measurement == {"flow": 0.0}
 
     async def test_429_honors_retry_after_header(self, manager, mock_sleep):
         url = BASE_URL + "service/cubic/secure/cubic-1/measurement/0"

--- a/tests_ha/conftest.py
+++ b/tests_ha/conftest.py
@@ -87,7 +87,7 @@ class FakeLKSystemsManager:
         self.device_measurements: dict = {}
         self.device_configurations: dict = {}
         self.hub_devices: dict = {}
-        self.cubic_secure_messurement: dict | None = None
+        self.cubic_secure_measurement: dict | None = None
         self.cubic_secure_configuration: dict | None = None
 
         # Per-call canned data, keyed by device/hub identity. Tests set
@@ -174,7 +174,7 @@ class FakeLKSystemsManager:
             ("get_cubic_secure_measurement", device_identity, force_update)
         )
         if self.get_cubic_secure_measurement_result:
-            self.cubic_secure_messurement = self.cubic_measurements_by_device.get(
+            self.cubic_secure_measurement = self.cubic_measurements_by_device.get(
                 device_identity, self.cubic_measurement_data
             )
         return self.get_cubic_secure_measurement_result

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -12,6 +12,7 @@ import base64
 import json
 import logging
 import time
+import typing
 from datetime import timedelta
 from unittest.mock import AsyncMock, patch
 
@@ -28,7 +29,9 @@ from pytest_homeassistant_custom_component.common import (
 
 from custom_components.lksystems import (
     TOKEN_STORAGE,
+    LkCubicDeviceData,
     LKSystemCoordinator,
+    LkStructureMachine,
     is_token_valid,
 )
 from custom_components.lksystems.const import (
@@ -75,6 +78,14 @@ def _clear_token_storage():
     TOKEN_STORAGE.clear()
     yield
     TOKEN_STORAGE.clear()
+
+
+class TestLkCubicDeviceDataTyping:
+    def test_machine_info_field_uses_correctly_spelled_machine_type(self):
+        assert (
+            typing.get_type_hints(LkCubicDeviceData)["machine_info"]
+            is LkStructureMachine
+        )
 
 
 class TestIsTokenValid:


### PR DESCRIPTION
- `LkStructureMashine` -> `LkStructureMachine` (self-contained TypedDict rename).
- `cubic_secure_messurement` -> `cubic_secure_measurement`, renamed in lockstep across `LKSystemsManager`, coordinator call sites, the `FakeLKSystemsManager` test double, and test assertions.
- Investigated the reported dead `cubic_last_messurement` key: it no longer exists anywhere in the codebase - removed by an earlier multi-device refactor commit (confirmed via `git log -S`), so there was nothing left to delete.

Confirmed neither renamed name is an LK wire-JSON field name - both are homegrown Python-side identifiers.

Tests: `tests/` 33/33 (plus 1 unrelated pre-existing teardown flake, see #71), `tests_ha/` 111/111.

Closes #67.