### PR TITLE
Fix MAC address leaks in diagnostics despite redaction

### DIFF
--- a/custom_components/lksystems/diagnostics.py
+++ b/custom_components/lksystems/diagnostics.py
@@ -11,10 +11,6 @@ from homeassistant.core import HomeAssistant
 
 from .const import DOMAIN
 
-# Device "identity"/serial_number fields are deliberately not redacted:
-# unlike a MAC address they're not a hardware fingerprint, and they're the
-# only way to correlate devices across the nested coordinator data when
-# debugging a report from an account with multiple Cubic Secure devices.
 TO_REDACT = {
     CONF_USERNAME,
     CONF_PASSWORD,
@@ -26,7 +22,47 @@ TO_REDACT = {
     "zip",
     "country",
     "mac",
+    "identity",
 }
+
+# device_details/hub_data are dicts keyed *by* the device's raw MAC/identity
+# itself. async_redact_data only ever redacts values under known key names,
+# never a dict's own keys, so these need rekeying to anonymous placeholders
+# instead of (or in addition to) the value-based redaction above. Each field
+# gets its own placeholder prefix so a "device_1" from one field is never
+# mistaken for referring to the same device as a "device_1" from the other.
+MAC_KEYED_COORDINATOR_FIELDS = {
+    "device_details": "device",
+    "hub_data": "hub",
+}
+
+
+def _anonymize_keys(mapping: dict[str, Any], placeholder: str) -> dict[str, Any]:
+    """Replace a dict's keys with anonymous, stably ordered placeholders."""
+    return {
+        f"{placeholder}_{index}": value
+        for index, value in enumerate(mapping.values(), start=1)
+    }
+
+
+def _redact_coordinator_data(coordinator_data: dict[str, Any]) -> dict[str, Any]:
+    data = dict(coordinator_data)
+    for field, placeholder in MAC_KEYED_COORDINATOR_FIELDS.items():
+        if field in data:
+            data[field] = _anonymize_keys(data[field], placeholder)
+
+    redacted = async_redact_data(data, TO_REDACT)
+
+    # Cubic Secure's own identity is deliberately exempted from the blanket
+    # "identity" redaction above: unlike a MAC it's not a hardware
+    # fingerprint, and it's the only way to correlate a report's nested data
+    # across multiple Cubic Secure devices on the same account.
+    for cubic_identity, device in redacted.get("cubic_devices", {}).items():
+        machine_info = device.get("machine_info")
+        if isinstance(machine_info, dict):
+            machine_info["identity"] = cubic_identity
+
+    return redacted
 
 
 async def async_get_config_entry_diagnostics(
@@ -37,5 +73,5 @@ async def async_get_config_entry_diagnostics(
 
     return {
         "entry_data": async_redact_data(dict(entry.data), TO_REDACT),
-        "coordinator_data": async_redact_data(coordinator.data, TO_REDACT),
+        "coordinator_data": _redact_coordinator_data(coordinator.data),
     }

--- a/tests_ha/test_diagnostics.py
+++ b/tests_ha/test_diagnostics.py
@@ -13,7 +13,13 @@ from custom_components.lksystems.diagnostics import (
     async_get_config_entry_diagnostics,
 )
 
-from .conftest import CUBIC_IDENTITY, THERMOSTAT_MAC, setup_entry as _setup_entry
+from .conftest import (
+    CUBIC_IDENTITY,
+    HUB_CHILD_MAC,
+    HUB_IDENTITY,
+    THERMOSTAT_MAC,
+    setup_entry as _setup_entry,
+)
 
 
 async def test_diagnostics_redacts_credentials(hass, fake_manager):
@@ -55,3 +61,34 @@ async def test_diagnostics_keeps_device_identities_for_debugging(hass, fake_mana
 
     cubic_device = diagnostics["coordinator_data"]["cubic_devices"][CUBIC_IDENTITY]
     assert cubic_device["machine_info"]["identity"] == CUBIC_IDENTITY
+
+
+async def test_diagnostics_redacts_device_title_identity(hass, fake_manager):
+    """deviceTitle.identity carries the same MAC as the sibling "mac" key
+    for Arc/hub/thermostat devices, so it must be redacted too, not just
+    "mac" itself.
+    """
+    entry = await _setup_entry(hass, fake_manager)
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    devices = diagnostics["coordinator_data"]["devices"]
+    thermostat = next(
+        d for d in devices if d["deviceTitle"].get("deviceRole") == "arc-tune"
+    )
+    assert thermostat["deviceTitle"]["identity"] == "**REDACTED**"
+
+
+async def test_diagnostics_anonymizes_mac_keyed_dicts(hass, fake_manager):
+    """device_details and hub_data are keyed by the raw device MAC itself,
+    so the MAC must not survive as a dict key even though async_redact_data
+    only ever redacts values.
+    """
+    entry = await _setup_entry(hass, fake_manager)
+
+    diagnostics = await async_get_config_entry_diagnostics(hass, entry)
+
+    coordinator_data = diagnostics["coordinator_data"]
+    assert THERMOSTAT_MAC not in coordinator_data["device_details"]
+    assert HUB_CHILD_MAC not in coordinator_data["device_details"]
+    assert HUB_IDENTITY not in coordinator_data["hub_data"]


### PR DESCRIPTION
Two distinct leaks fixed, both re-verified empirically with new failing tests before the fix:

1. Value-based: Arc/hub/thermostat devices' `deviceTitle.identity` held the same raw MAC as the redacted `mac` key, since `TO_REDACT` deliberately excluded `identity` for Cubic Secure device correlation. Fix: add `identity` to `TO_REDACT`, then explicitly re-expose only `cubic_devices[*].machine_info.identity` afterward.
2. Key-based: `device_details`/`hub_data` were dicts keyed *by* the raw MAC/identity itself, which `async_redact_data` can never catch since it only redacts values, not keys. Fix: a shared helper rekeys both dicts to anonymous placeholders (`device_1`, `hub_1`, ...) before redaction.

Tests: `tests_ha/` 112/112, `tests/` 33/34 (1 unrelated pre-existing teardown flake, see #71).

Closes #66.