### PR TITLE
Add a native valve entity for the Cubic Secure's shutoff valve

### DIFF
--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -662,6 +662,36 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         if unsub := self._leak_detection_refresh_unsub.pop(device_identity, None):
             unsub()
 
+    def mark_valve_action_pending(
+        self, device_identity: str, expect_closed: bool
+    ) -> None:
+        """Show a device as opening/closing straight away.
+
+        Called by valve.py right before it even issues the open/close
+        write, not just once _schedule_valve_state_confirmation()'s
+        confirmation retries start - the write itself (login and the API
+        call) goes through the same unbounded Retry-After-honoring
+        network layer as any other request, so it can itself take a long
+        time (confirmed missing live: a slow write left the entity
+        showing nothing until the frontend's own optimistic toggle
+        reverted). See valve_action_pending's own comment for why
+        tracking this at all matters.
+        """
+        self._cancel_valve_action_confirmation(device_identity)
+        self.valve_action_pending[device_identity] = expect_closed
+        self.async_update_listeners()
+
+    def clear_valve_action_pending(self, device_identity: str) -> None:
+        """Abort a pending open/close confirmation without assuming
+        anything about the outcome - for when the write itself never
+        got attempted (e.g. the device wasn't found), so there's nothing
+        to confirm and nothing will otherwise resolve the pending state
+        mark_valve_action_pending() just set.
+        """
+        self._cancel_valve_action_confirmation(device_identity)
+        self.valve_action_pending.pop(device_identity, None)
+        self.async_update_listeners()
+
     def _schedule_valve_state_confirmation(
         self, device_identity: str, expect_closed: bool
     ) -> None:
@@ -670,17 +700,8 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         actually reached the requested state, giving up after
         VALVE_ACTION_MAX_RETRY_SECONDS - see that constant's own comment
         for what happens then.
-
-        Also marks the device pending in valve_action_pending immediately
-        (before the first check even runs) and clears it once resolved -
-        see that attribute's own comment for why: without it, each
-        retry's own possibly-still-stale read would get shown as the
-        entity's literal open/closed state along the way, instead of a
-        steady "closing"/"opening" for the real time the motor takes.
         """
-        self._cancel_valve_action_confirmation(device_identity)
-        self.valve_action_pending[device_identity] = expect_closed
-        self.async_update_listeners()
+        self.mark_valve_action_pending(device_identity, expect_closed)
         retry_deadline = dt_util.utcnow() + timedelta(
             seconds=VALVE_ACTION_MAX_RETRY_SECONDS
         )

--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -700,17 +700,22 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
             # state until the next regular poll.
             self.async_update_listeners()
 
-        async def _check_valve_state(now: datetime) -> None:
+        async def _check_valve_state(_scheduled_for: datetime) -> None:
             self._valve_action_unsub.pop(device_identity, None)
-            fetch_started_at = dt_util.utcnow()
             if not await self.force_cubic_secure_configuration_update(device_identity):
                 return
-            # LK's API rate-limits this specific endpoint (confirmed
-            # empirically) and pylksystems honors its Retry-After, so a
-            # single attempt can genuinely take tens of seconds - measured
-            # here so the next check (below) doesn't fire on schedule
-            # right into the same rate limit that just delayed this one.
-            fetch_duration = dt_util.utcnow() - fetch_started_at
+            # dt_util.utcnow(), not _scheduled_for: the fetch above can
+            # itself take a while - LK's API rate-limits this specific
+            # endpoint (confirmed empirically, up to a 93s Retry-After
+            # observed on a real attempt) and pylksystems correctly
+            # honors it, so a single attempt can single-handedly outlast
+            # the entire retry window. Judging the deadline, or scheduling
+            # the next check, off the stale pre-fetch time would miss
+            # that entirely - the loop would keep going well past
+            # VALVE_ACTION_MAX_RETRY_SECONDS of real elapsed time, and the
+            # next check could fire straight into the same rate limit
+            # that just delayed this one.
+            now = dt_util.utcnow()
 
             valve_state = self.data["cubic_devices"][device_identity][
                 "configuration"
@@ -749,10 +754,7 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                 )
                 return
 
-            next_delay = max(
-                timedelta(seconds=VALVE_ACTION_RETRY_INTERVAL_SECONDS), fetch_duration
-            )
-            _track_at(now + next_delay)
+            _track_at(now + timedelta(seconds=VALVE_ACTION_RETRY_INTERVAL_SECONDS))
 
         _track_at(dt_util.utcnow() + timedelta(seconds=VALVE_ACTION_RETRY_INTERVAL_SECONDS))
 

--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -306,6 +306,16 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         # method's own docstring.
         self._valve_action_unsub: dict[str, CALLBACK_TYPE] = {}
 
+        # Whether a device is currently mid-open/close, per device
+        # identity - True while closing, False while opening, absent once
+        # confirmed (or given up on). valve.py's is_closing/is_opening
+        # read this directly, so the entity shows a transitional state
+        # for the real time the physical motor takes to move instead of
+        # flashing through whatever intermediate (possibly stale) reads
+        # _schedule_valve_state_confirmation()'s retries publish along
+        # the way.
+        self.valve_action_pending: dict[str, bool] = {}
+
         # Initialize coordinator with update interval
         super().__init__(
             hass,
@@ -659,15 +669,16 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         actually reached the requested state, giving up after
         VALVE_ACTION_MAX_RETRY_SECONDS and leaving it to the regular poll.
 
-        Without this, valve.py's single immediate force-refresh right
-        after the write reads a stale pre-action snapshot - the physical
-        motor takes on the order of 10-30s to finish moving (confirmed
-        against a real device) and the API doesn't report the change
-        until then - and publishes it as if it were final, flipping the
-        entity right back to the old state until the next regular poll,
-        possibly minutes later.
+        Also marks the device pending in valve_action_pending immediately
+        (before the first check even runs) and clears it once resolved -
+        see that attribute's own comment for why: without it, each
+        retry's own possibly-still-stale read would get shown as the
+        entity's literal open/closed state along the way, instead of a
+        steady "closing"/"opening" for the real time the motor takes.
         """
         self._cancel_valve_action_confirmation(device_identity)
+        self.valve_action_pending[device_identity] = expect_closed
+        self.async_update_listeners()
         retry_deadline = dt_util.utcnow() + timedelta(
             seconds=VALVE_ACTION_MAX_RETRY_SECONDS
         )
@@ -676,6 +687,16 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
             self._valve_action_unsub[device_identity] = async_track_point_in_time(
                 self.hass, _check_valve_state, when
             )
+
+        def _resolve() -> None:
+            self.valve_action_pending.pop(device_identity, None)
+            # force_cubic_secure_configuration_update() below already
+            # notified listeners once with this check's raw fetch -
+            # entities reading valve_action_pending (is_closing/
+            # is_opening) need a second notification to pick up that it
+            # just cleared, or they're stuck showing the transitional
+            # state until the next regular poll.
+            self.async_update_listeners()
 
         async def _check_valve_state(now: datetime) -> None:
             self._valve_action_unsub.pop(device_identity, None)
@@ -687,6 +708,7 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
             actually_closed = valve_state == CUBIC_SECURE_VALVE_STATE_CLOSED
 
             if actually_closed == expect_closed:
+                _resolve()
                 _LOGGER.debug(
                     "Valve %s confirmed %s",
                     device_identity,
@@ -694,6 +716,7 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                 )
                 return
             if now >= retry_deadline:
+                _resolve()
                 _LOGGER.debug(
                     "Giving up on confirming valve %s reached the requested "
                     "state after %ss - leaving it to the regular poll",

--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -38,6 +38,7 @@ from .const import (
     CONF_UPDATE_INTERVAL,
     CUBIC_SECURE_MODEL,
     CUBIC_SECURE_VALVE_STATE_CLOSED,
+    CUBIC_SECURE_VALVE_STATE_OPEN,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
     LEAK_DETECTION_EXPIRY_MAX_RETRY_SECONDS,
@@ -667,7 +668,8 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         """After an open/close write, poll the cloud every
         VALVE_ACTION_RETRY_INTERVAL_SECONDS until it confirms the valve
         actually reached the requested state, giving up after
-        VALVE_ACTION_MAX_RETRY_SECONDS and leaving it to the regular poll.
+        VALVE_ACTION_MAX_RETRY_SECONDS - see that constant's own comment
+        for what happens then.
 
         Also marks the device pending in valve_action_pending immediately
         (before the first check even runs) and clears it once resolved -
@@ -700,8 +702,16 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
 
         async def _check_valve_state(now: datetime) -> None:
             self._valve_action_unsub.pop(device_identity, None)
+            fetch_started_at = dt_util.utcnow()
             if not await self.force_cubic_secure_configuration_update(device_identity):
                 return
+            # LK's API rate-limits this specific endpoint (confirmed
+            # empirically) and pylksystems honors its Retry-After, so a
+            # single attempt can genuinely take tens of seconds - measured
+            # here so the next check (below) doesn't fire on schedule
+            # right into the same rate limit that just delayed this one.
+            fetch_duration = dt_util.utcnow() - fetch_started_at
+
             valve_state = self.data["cubic_devices"][device_identity][
                 "configuration"
             ].get("valveState")
@@ -716,16 +726,33 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                 )
                 return
             if now >= retry_deadline:
+                # HA already issued the write - assume it succeeded rather
+                # than leave the entity showing a stale pre-action reading
+                # for longer than VALVE_ACTION_MAX_RETRY_SECONDS. Wrong
+                # only if the write itself failed downstream of the API
+                # call succeeding, in which case the next regular poll
+                # corrects it.
+                self.data["cubic_devices"][device_identity]["configuration"][
+                    "valveState"
+                ] = (
+                    CUBIC_SECURE_VALVE_STATE_CLOSED
+                    if expect_closed
+                    else CUBIC_SECURE_VALVE_STATE_OPEN
+                )
                 _resolve()
                 _LOGGER.debug(
                     "Giving up on confirming valve %s reached the requested "
-                    "state after %ss - leaving it to the regular poll",
+                    "state after %ss - assuming it did, the regular poll "
+                    "will correct this if not",
                     device_identity,
                     VALVE_ACTION_MAX_RETRY_SECONDS,
                 )
-                return  # give up - the regular poll will pick it up eventually
+                return
 
-            _track_at(now + timedelta(seconds=VALVE_ACTION_RETRY_INTERVAL_SECONDS))
+            next_delay = max(
+                timedelta(seconds=VALVE_ACTION_RETRY_INTERVAL_SECONDS), fetch_duration
+            )
+            _track_at(now + next_delay)
 
         _track_at(dt_util.utcnow() + timedelta(seconds=VALVE_ACTION_RETRY_INTERVAL_SECONDS))
 

--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -700,23 +700,58 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
             # state until the next regular poll.
             self.async_update_listeners()
 
+        def _give_up() -> None:
+            # HA already issued the write - assume it succeeded rather
+            # than leave the entity showing a stale pre-action reading
+            # for longer than VALVE_ACTION_MAX_RETRY_SECONDS. Wrong only
+            # if the write itself failed downstream of a successful API
+            # call, in which case the next regular poll corrects it.
+            self.data["cubic_devices"][device_identity]["configuration"][
+                "valveState"
+            ] = (
+                CUBIC_SECURE_VALVE_STATE_CLOSED
+                if expect_closed
+                else CUBIC_SECURE_VALVE_STATE_OPEN
+            )
+            _resolve()
+            _LOGGER.debug(
+                "Giving up on confirming valve %s reached the requested "
+                "state after %ss - assuming it did, the regular poll "
+                "will correct this if not",
+                device_identity,
+                VALVE_ACTION_MAX_RETRY_SECONDS,
+            )
+
         async def _check_valve_state(_scheduled_for: datetime) -> None:
             self._valve_action_unsub.pop(device_identity, None)
-            if not await self.force_cubic_secure_configuration_update(device_identity):
+            remaining = (retry_deadline - dt_util.utcnow()).total_seconds()
+            if remaining <= 0:
+                _give_up()
                 return
-            # dt_util.utcnow(), not _scheduled_for: the fetch above can
-            # itself take a while - LK's API rate-limits this specific
-            # endpoint (confirmed empirically, up to a 93s Retry-After
-            # observed on a real attempt) and pylksystems correctly
-            # honors it, so a single attempt can single-handedly outlast
-            # the entire retry window. Judging the deadline, or scheduling
-            # the next check, off the stale pre-fetch time would miss
-            # that entirely - the loop would keep going well past
-            # VALVE_ACTION_MAX_RETRY_SECONDS of real elapsed time, and the
-            # next check could fire straight into the same rate limit
-            # that just delayed this one.
-            now = dt_util.utcnow()
+            try:
+                # A bounded wait, not an open-ended await: LK rate-limits
+                # this specific endpoint (confirmed empirically, up to a
+                # 93s Retry-After observed on a real attempt) and
+                # pylksystems correctly honors it - meaning a single fetch
+                # can, on its own, take longer than the entire retry
+                # window. Passively waiting for it to finish before
+                # checking the deadline would let one slow attempt block
+                # the entity on a transitional state well past
+                # VALVE_ACTION_MAX_RETRY_SECONDS, the opposite of what
+                # that cap is for. Abandoning it here, rather than only
+                # ignoring its result afterwards, is what actually bounds
+                # the wait.
+                fetched = await asyncio.wait_for(
+                    self.force_cubic_secure_configuration_update(device_identity),
+                    timeout=remaining,
+                )
+            except asyncio.TimeoutError:
+                _give_up()
+                return
+            if not fetched:
+                return
 
+            now = dt_util.utcnow()
             valve_state = self.data["cubic_devices"][device_identity][
                 "configuration"
             ].get("valveState")
@@ -731,27 +766,7 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                 )
                 return
             if now >= retry_deadline:
-                # HA already issued the write - assume it succeeded rather
-                # than leave the entity showing a stale pre-action reading
-                # for longer than VALVE_ACTION_MAX_RETRY_SECONDS. Wrong
-                # only if the write itself failed downstream of the API
-                # call succeeding, in which case the next regular poll
-                # corrects it.
-                self.data["cubic_devices"][device_identity]["configuration"][
-                    "valveState"
-                ] = (
-                    CUBIC_SECURE_VALVE_STATE_CLOSED
-                    if expect_closed
-                    else CUBIC_SECURE_VALVE_STATE_OPEN
-                )
-                _resolve()
-                _LOGGER.debug(
-                    "Giving up on confirming valve %s reached the requested "
-                    "state after %ss - assuming it did, the regular poll "
-                    "will correct this if not",
-                    device_identity,
-                    VALVE_ACTION_MAX_RETRY_SECONDS,
-                )
+                _give_up()
                 return
 
             _track_at(now + timedelta(seconds=VALVE_ACTION_RETRY_INTERVAL_SECONDS))

--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -37,12 +37,15 @@ from homeassistant.helpers import config_validation as cv
 from .const import (
     CONF_UPDATE_INTERVAL,
     CUBIC_SECURE_MODEL,
+    CUBIC_SECURE_VALVE_STATE_CLOSED,
     DEFAULT_UPDATE_INTERVAL,
     DOMAIN,
     LEAK_DETECTION_EXPIRY_MAX_RETRY_SECONDS,
     LEAK_DETECTION_EXPIRY_RETRY_INTERVAL_SECONDS,
     LEAK_DETECTION_LOCAL_WRITE_GRACE_SECONDS,
     MANUFACTURER,
+    VALVE_ACTION_MAX_RETRY_SECONDS,
+    VALVE_ACTION_RETRY_INTERVAL_SECONDS,
 )
 from .pylksystems import (
     LKSystemsManager,
@@ -297,6 +300,11 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         # stale value until the next regular poll (up to a full
         # update_interval later) picked up the change.
         self._leak_detection_refresh_unsub: dict[str, CALLBACK_TYPE] = {}
+
+        # Cancel handle for each device's pending
+        # _schedule_valve_state_confirmation() call, if any - see that
+        # method's own docstring.
+        self._valve_action_unsub: dict[str, CALLBACK_TYPE] = {}
 
         # Initialize coordinator with update interval
         super().__init__(
@@ -643,15 +651,78 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         if unsub := self._leak_detection_refresh_unsub.pop(device_identity, None):
             unsub()
 
+    def _schedule_valve_state_confirmation(
+        self, device_identity: str, expect_closed: bool
+    ) -> None:
+        """After an open/close write, poll the cloud every
+        VALVE_ACTION_RETRY_INTERVAL_SECONDS until it confirms the valve
+        actually reached the requested state, giving up after
+        VALVE_ACTION_MAX_RETRY_SECONDS and leaving it to the regular poll.
+
+        Without this, valve.py's single immediate force-refresh right
+        after the write reads a stale pre-action snapshot - the physical
+        motor takes on the order of 10-30s to finish moving (confirmed
+        against a real device) and the API doesn't report the change
+        until then - and publishes it as if it were final, flipping the
+        entity right back to the old state until the next regular poll,
+        possibly minutes later.
+        """
+        self._cancel_valve_action_confirmation(device_identity)
+        retry_deadline = dt_util.utcnow() + timedelta(
+            seconds=VALVE_ACTION_MAX_RETRY_SECONDS
+        )
+
+        def _track_at(when: datetime) -> None:
+            self._valve_action_unsub[device_identity] = async_track_point_in_time(
+                self.hass, _check_valve_state, when
+            )
+
+        async def _check_valve_state(now: datetime) -> None:
+            self._valve_action_unsub.pop(device_identity, None)
+            if not await self.force_cubic_secure_configuration_update(device_identity):
+                return
+            valve_state = self.data["cubic_devices"][device_identity][
+                "configuration"
+            ].get("valveState")
+            actually_closed = valve_state == CUBIC_SECURE_VALVE_STATE_CLOSED
+
+            if actually_closed == expect_closed:
+                _LOGGER.debug(
+                    "Valve %s confirmed %s",
+                    device_identity,
+                    "closed" if expect_closed else "open",
+                )
+                return
+            if now >= retry_deadline:
+                _LOGGER.debug(
+                    "Giving up on confirming valve %s reached the requested "
+                    "state after %ss - leaving it to the regular poll",
+                    device_identity,
+                    VALVE_ACTION_MAX_RETRY_SECONDS,
+                )
+                return  # give up - the regular poll will pick it up eventually
+
+            _track_at(now + timedelta(seconds=VALVE_ACTION_RETRY_INTERVAL_SECONDS))
+
+        _track_at(dt_util.utcnow() + timedelta(seconds=VALVE_ACTION_RETRY_INTERVAL_SECONDS))
+
+    def _cancel_valve_action_confirmation(self, device_identity: str) -> None:
+        """Cancel a device's pending valve-state check, if one is scheduled."""
+        if unsub := self._valve_action_unsub.pop(device_identity, None):
+            unsub()
+
     async def async_shutdown(self) -> None:
         """Cancel any scheduled call, and ignore new runs.
 
-        Also cancels every pending leak-detection expiry check - they'd
-        otherwise fire against a torn-down coordinator after unload.
+        Also cancels every pending leak-detection expiry check and
+        valve-state confirmation - they'd otherwise fire against a
+        torn-down coordinator after unload.
         """
         await super().async_shutdown()
         for device_identity in list(self._leak_detection_refresh_unsub):
             self._cancel_leak_detection_expiry_refresh(device_identity)
+        for device_identity in list(self._valve_action_unsub):
+            self._cancel_valve_action_confirmation(device_identity)
 
     async def _update_cubic_secure_configuration(
         self, device_identity: str, *, force_update: bool

--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -22,6 +22,7 @@ from homeassistant.exceptions import HomeAssistantError, ConfigEntryAuthFailed
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.event import async_track_point_in_time
 from homeassistant.helpers.typing import ConfigType
@@ -63,7 +64,13 @@ _LOGGER = logging.getLogger(__name__)
 CONSECUTIVE_FAILURE_THRESHOLD = 3
 
 # Define the platforms we support
-PLATFORMS = [Platform.SENSOR, Platform.CLIMATE, Platform.NUMBER, Platform.BUTTON]
+PLATFORMS = [
+    Platform.SENSOR,
+    Platform.CLIMATE,
+    Platform.NUMBER,
+    Platform.BUTTON,
+    Platform.VALVE,
+]
 
 
 class LkStructureResp(TypedDict):
@@ -1182,6 +1189,48 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
 def cubic_secure_device_identities(coordinator: LKSystemCoordinator) -> list[str]:
     """Return the device identities of every Cubic Secure device on the account."""
     return list(coordinator.data.get("cubic_devices", {}))
+
+
+def cubic_secure_configuration(
+    coordinator: LKSystemCoordinator, device_identity: str
+) -> dict[str, Any]:
+    """Return a Cubic Secure device's last-fetched configuration dict.
+
+    Configuration (valveState, firmwareVersion, ...) is fetched
+    separately from measurement data and can fail independently, so this
+    is always defensive about it being missing.
+    """
+    cubic_device = coordinator.data["cubic_devices"][device_identity]
+    return cubic_device.get("configuration") or {}
+
+
+async def async_call_cubic_secure_service(
+    hass: HomeAssistant,
+    device_identity: str,
+    service: str,
+    extra_data: dict[str, Any] | None = None,
+) -> bool:
+    """Resolve a Cubic Secure device identity to its registered device and
+    call one of this integration's own services on it.
+
+    Shared by every platform whose action is "call an existing lksystems
+    service for this device" (button.py, valve.py, ...), so the device
+    lookup and its "not registered" error handling exist in one place.
+    Returns whether the service was actually called.
+    """
+    device_entry = dr.async_get(hass).async_get_device(
+        identifiers={(DOMAIN, device_identity)}
+    )
+    if device_entry is None:
+        _LOGGER.error(
+            "No registered device found for %s, cannot call %s", device_identity, service
+        )
+        return False
+
+    await hass.services.async_call(
+        DOMAIN, service, {"device_id": device_entry.id, **(extra_data or {})}, blocking=True
+    )
+    return True
 
 
 def cubic_secure_device_info(

--- a/custom_components/lksystems/const.py
+++ b/custom_components/lksystems/const.py
@@ -34,6 +34,10 @@ DEFAULT_PAUSE_LEAK_DETECTION_SECONDS: Final = 3600
 PAUSE_LEAK_DETECTION_MIN_SECONDS: Final = 60
 PAUSE_LEAK_DETECTION_MAX_SECONDS: Final = 86400
 
+# The API reports a Cubic Secure's valveState as "closed" for a shut
+# valve; any other value is treated as open.
+CUBIC_SECURE_VALVE_STATE_CLOSED: Final = "closed"
+
 # Once a pause's target end time is reached, poll the cloud at this
 # interval until it confirms the pause is actually over, so "Leak
 # Detection Paused Until" clears promptly instead of waiting on the next

--- a/custom_components/lksystems/const.py
+++ b/custom_components/lksystems/const.py
@@ -35,8 +35,11 @@ PAUSE_LEAK_DETECTION_MIN_SECONDS: Final = 60
 PAUSE_LEAK_DETECTION_MAX_SECONDS: Final = 86400
 
 # The API reports a Cubic Secure's valveState as "closed" for a shut
-# valve; any other value is treated as open.
+# valve; any other value is treated as open - "open" is the value the
+# API itself actually reports for that case (confirmed against a real
+# device), not just this integration's own placeholder.
 CUBIC_SECURE_VALVE_STATE_CLOSED: Final = "closed"
+CUBIC_SECURE_VALVE_STATE_OPEN: Final = "open"
 
 # After an open/close write, poll the cloud at this interval until it
 # confirms the valve actually reached the requested state - the physical
@@ -46,11 +49,14 @@ CUBIC_SECURE_VALVE_STATE_CLOSED: Final = "closed"
 # snapshot.
 VALVE_ACTION_RETRY_INTERVAL_SECONDS: Final = 5
 
-# Stop retrying this long after an open/close write and fall back to the
-# regular poll - generous over the observed 10-30s motor travel time to
-# also allow for the cloud's own lag reporting it, not a value normal
-# operation is expected to reach.
-VALVE_ACTION_MAX_RETRY_SECONDS: Final = 90
+# Stop retrying this long after an open/close write - the longest the
+# entity should ever show a transitional "closing"/"opening" state
+# (confirmed real motor travel time tops out around 25s). Past this, the
+# entity optimistically shows the state the write actually requested
+# rather than lingering on a stale reading - HA already issued the
+# command, so assume it succeeded, and let the next regular poll quietly
+# correct it if it didn't.
+VALVE_ACTION_MAX_RETRY_SECONDS: Final = 30
 
 # Once a pause's target end time is reached, poll the cloud at this
 # interval until it confirms the pause is actually over, so "Leak

--- a/custom_components/lksystems/const.py
+++ b/custom_components/lksystems/const.py
@@ -38,6 +38,20 @@ PAUSE_LEAK_DETECTION_MAX_SECONDS: Final = 86400
 # valve; any other value is treated as open.
 CUBIC_SECURE_VALVE_STATE_CLOSED: Final = "closed"
 
+# After an open/close write, poll the cloud at this interval until it
+# confirms the valve actually reached the requested state - the physical
+# motor takes on the order of 10-30s to finish moving (confirmed against
+# a real device) and the API doesn't report the change until then, so a
+# single immediate check right after the write reads a stale pre-action
+# snapshot.
+VALVE_ACTION_RETRY_INTERVAL_SECONDS: Final = 5
+
+# Stop retrying this long after an open/close write and fall back to the
+# regular poll - generous over the observed 10-30s motor travel time to
+# also allow for the cloud's own lag reporting it, not a value normal
+# operation is expected to reach.
+VALVE_ACTION_MAX_RETRY_SECONDS: Final = 90
+
 # Once a pause's target end time is reached, poll the cloud at this
 # interval until it confirms the pause is actually over, so "Leak
 # Detection Paused Until" clears promptly instead of waiting on the next

--- a/custom_components/lksystems/valve.py
+++ b/custom_components/lksystems/valve.py
@@ -68,13 +68,36 @@ class LKCubicSecureValve(CoordinatorEntity[LKSystemCoordinator], ValveEntity):
 
     @property
     def is_closed(self) -> bool | None:
-        """Return True if the valve is closed, None if not yet known."""
+        """Return True if the valve is closed, None if not yet known.
+
+        Not consulted while is_opening/is_closing is set - ValveEntity's
+        own state property checks those first - so this doesn't need to
+        guard against showing a stale mid-action reading itself.
+        """
         valve_state = cubic_secure_configuration(self.coordinator, self._device_identity).get(
             "valveState"
         )
         if valve_state is None:
             return None
         return valve_state == CUBIC_SECURE_VALVE_STATE_CLOSED
+
+    @property
+    def is_opening(self) -> bool:
+        """Return True while an open write is pending confirmation.
+
+        Takes priority over is_closed in ValveEntity's own state property,
+        so the entity shows a steady "opening" for the real time the
+        motor takes, instead of flashing through whatever intermediate
+        (possibly stale) reads the confirmation retries publish along the
+        way - see LKSystemCoordinator.valve_action_pending.
+        """
+        return self.coordinator.valve_action_pending.get(self._device_identity) is False
+
+    @property
+    def is_closing(self) -> bool:
+        """Return True while a close write is pending confirmation - see
+        is_opening above."""
+        return self.coordinator.valve_action_pending.get(self._device_identity) is True
 
     async def async_open_valve(self) -> None:
         """Open the valve."""

--- a/custom_components/lksystems/valve.py
+++ b/custom_components/lksystems/valve.py
@@ -38,13 +38,14 @@ class LKCubicSecureValve(CoordinatorEntity[LKSystemCoordinator], ValveEntity):
     picks up a state change from any source - a scheduled poll, or the
     valve being toggled from the vendor app - not just its own actions.
     Open/close delegate to the existing open_valve/close_valve services
-    (rather than duplicating their login/error-handling), followed by
-    force_cubic_secure_configuration_update(): valveState is fetched
-    independently of the write itself and the LK API caches it
-    server-side, so a generic coordinator refresh isn't enough to
-    reliably reflect the change (see that method's own docstring).
-    Doesn't report a position: the API only exposes open/closed, not a
-    percentage.
+    (rather than duplicating their login/error-handling), then confirm
+    the valve actually reached that state via
+    _schedule_valve_state_confirmation() - the physical motor takes on
+    the order of 10-30s to finish moving (confirmed against a real
+    device), so a single immediate refresh right after the write would
+    just read a stale pre-action snapshot (see that method's own
+    docstring). Doesn't report a position: the API only exposes
+    open/closed, not a percentage.
     """
 
     _attr_attribution = ATTRIBUTION
@@ -86,6 +87,6 @@ class LKCubicSecureValve(CoordinatorEntity[LKSystemCoordinator], ValveEntity):
     async def _async_call_valve_service(self, service: str) -> None:
         called = await async_call_cubic_secure_service(self.hass, self._device_identity, service)
         if called:
-            await self.coordinator.force_cubic_secure_configuration_update(
-                self._device_identity
+            self.coordinator._schedule_valve_state_confirmation(
+                self._device_identity, service == "close_valve"
             )

--- a/custom_components/lksystems/valve.py
+++ b/custom_components/lksystems/valve.py
@@ -1,0 +1,91 @@
+"""Valve platform for LK Systems integration."""
+
+from __future__ import annotations
+
+from homeassistant.components.valve import ValveDeviceClass, ValveEntity, ValveEntityFeature
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from . import (
+    LKSystemCoordinator,
+    async_call_cubic_secure_service,
+    cubic_secure_configuration,
+    cubic_secure_device_identities,
+    cubic_secure_device_info,
+)
+from .const import ATTRIBUTION, CUBIC_SECURE_VALVE_STATE_CLOSED, DOMAIN
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    """Set up LK Systems valve entities based on a config entry."""
+    coordinator = hass.data[DOMAIN][entry.entry_id]
+
+    async_add_entities(
+        LKCubicSecureValve(coordinator, device_identity)
+        for device_identity in cubic_secure_device_identities(coordinator)
+    )
+
+
+class LKCubicSecureValve(CoordinatorEntity[LKSystemCoordinator], ValveEntity):
+    """The Cubic Secure's main shutoff valve.
+
+    Reflects live coordinator data (like the sibling sensors), so it
+    picks up a state change from any source - a scheduled poll, or the
+    valve being toggled from the vendor app - not just its own actions.
+    Open/close delegate to the existing open_valve/close_valve services
+    (rather than duplicating their login/error-handling), followed by
+    force_cubic_secure_configuration_update(): valveState is fetched
+    independently of the write itself and the LK API caches it
+    server-side, so a generic coordinator refresh isn't enough to
+    reliably reflect the change (see that method's own docstring).
+    Doesn't report a position: the API only exposes open/closed, not a
+    percentage.
+    """
+
+    _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
+    _attr_name = "Valve"
+    _attr_device_class = ValveDeviceClass.WATER
+    _attr_supported_features = ValveEntityFeature.OPEN | ValveEntityFeature.CLOSE
+    _attr_reports_position = False
+
+    def __init__(self, coordinator: LKSystemCoordinator, device_identity: str) -> None:
+        """Initialize the valve entity."""
+        super().__init__(coordinator)
+        self._device_identity = device_identity
+        self._attr_unique_id = f"LkUid_valve_{device_identity}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device_info of the device."""
+        return cubic_secure_device_info(self.coordinator, self._device_identity)
+
+    @property
+    def is_closed(self) -> bool | None:
+        """Return True if the valve is closed, None if not yet known."""
+        valve_state = cubic_secure_configuration(self.coordinator, self._device_identity).get(
+            "valveState"
+        )
+        if valve_state is None:
+            return None
+        return valve_state == CUBIC_SECURE_VALVE_STATE_CLOSED
+
+    async def async_open_valve(self) -> None:
+        """Open the valve."""
+        await self._async_call_valve_service("open_valve")
+
+    async def async_close_valve(self) -> None:
+        """Close the valve."""
+        await self._async_call_valve_service("close_valve")
+
+    async def _async_call_valve_service(self, service: str) -> None:
+        called = await async_call_cubic_secure_service(self.hass, self._device_identity, service)
+        if called:
+            await self.coordinator.force_cubic_secure_configuration_update(
+                self._device_identity
+            )

--- a/custom_components/lksystems/valve.py
+++ b/custom_components/lksystems/valve.py
@@ -108,8 +108,16 @@ class LKCubicSecureValve(CoordinatorEntity[LKSystemCoordinator], ValveEntity):
         await self._async_call_valve_service("close_valve")
 
     async def _async_call_valve_service(self, service: str) -> None:
+        expect_closed = service == "close_valve"
+        # Marked pending before the write below, not just once its
+        # confirmation retries start - the write itself (login, then the
+        # API call) can take a while too (see
+        # coordinator.mark_valve_action_pending's own docstring).
+        self.coordinator.mark_valve_action_pending(self._device_identity, expect_closed)
         called = await async_call_cubic_secure_service(self.hass, self._device_identity, service)
         if called:
             self.coordinator._schedule_valve_state_confirmation(
-                self._device_identity, service == "close_valve"
+                self._device_identity, expect_closed
             )
+        else:
+            self.coordinator.clear_valve_action_pending(self._device_identity)

--- a/tests_ha/conftest.py
+++ b/tests_ha/conftest.py
@@ -118,6 +118,10 @@ class FakeLKSystemsManager:
         self.get_hub_devices_result = True
         self.get_cubic_secure_measurement_result = True
         self.get_cubic_secure_configuration_result = True
+        # Simulates a real fetch taking a while - e.g. pylksystems
+        # honoring a long Retry-After from LK's own rate limiter, which
+        # can take tens of seconds on a real device (confirmed live).
+        self.get_cubic_secure_configuration_delay: float = 0
         self.set_thermostat_temperature_result: dict = {
             "success": True,
             "data": {},
@@ -182,6 +186,8 @@ class FakeLKSystemsManager:
     async def get_cubic_secure_configuration(
         self, device_identity, force_update=False
     ):
+        if self.get_cubic_secure_configuration_delay:
+            await asyncio.sleep(self.get_cubic_secure_configuration_delay)
         self.calls.append(
             ("get_cubic_secure_configuration", device_identity, force_update)
         )
@@ -490,6 +496,22 @@ def patch_all_managers(manager: FakeLKSystemsManager):
     """
     with patch_coordinator_manager(manager), patch_services_manager(manager):
         yield
+
+
+def tiny_valve_retry_timings():
+    """The valve confirmation's give-up decision compares real
+    dt_util.utcnow() reads (a single fetch's own real duration - e.g.
+    honoring a long Retry-After - has to count, see
+    LKSystemCoordinator._schedule_valve_state_confirmation's own comment
+    on why), which HA's simulated-time test helpers
+    (async_fire_time_changed) can't drive. Patches the retry timing
+    constants down to a few milliseconds so give-up tests can use real
+    waiting instead, without actually taking VALVE_ACTION_MAX_RETRY_SECONDS
+    to run."""
+    return (
+        patch("custom_components.lksystems.VALVE_ACTION_MAX_RETRY_SECONDS", 0.05),
+        patch("custom_components.lksystems.VALVE_ACTION_RETRY_INTERVAL_SECONDS", 0.01),
+    )
 
 
 @pytest.fixture

--- a/tests_ha/conftest.py
+++ b/tests_ha/conftest.py
@@ -131,6 +131,11 @@ class FakeLKSystemsManager:
         # Call log, for tests that want to assert *what* was called.
         self.calls: list[tuple] = []
 
+        # Simulates a real open/close write taking a while - the write
+        # goes through the same unbounded Retry-After-honoring network
+        # layer as any other request, so it can itself take a long time.
+        self.valve_write_delay: float = 0
+
     async def __aenter__(self):
         return self
 
@@ -212,9 +217,13 @@ class FakeLKSystemsManager:
         return self.set_thermostat_temperature_result
 
     async def cubic_secure_close_valve(self, cubic_identity):
+        if self.valve_write_delay:
+            await asyncio.sleep(self.valve_write_delay)
         self.calls.append(("cubic_secure_close_valve", cubic_identity))
 
     async def cubic_secure_open_valve(self, cubic_identity):
+        if self.valve_write_delay:
+            await asyncio.sleep(self.valve_write_delay)
         self.calls.append(("cubic_secure_open_valve", cubic_identity))
 
     async def cubic_secure_pause_leak_detection(self, cubic_identity, seconds):

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -755,6 +755,83 @@ class TestValveStateConfirmation:
             == "open"
         )
 
+    async def test_marks_the_device_pending_as_soon_as_scheduled(
+        self, hass, fake_manager
+    ):
+        """valve.py's is_closing/is_opening read this immediately, before
+        the first retry check even runs - otherwise the entity would show
+        the (possibly stale) prior state for the first
+        VALVE_ACTION_RETRY_INTERVAL_SECONDS, not "closing"/"opening"."""
+        coordinator = await _valve_action_coordinator(hass, fake_manager)
+
+        coordinator._schedule_valve_state_confirmation(CUBIC_IDENTITY, True)
+
+        assert coordinator.valve_action_pending[CUBIC_IDENTITY] is True
+        await coordinator.async_shutdown()  # cancel the still-pending check
+
+    async def test_stays_pending_through_a_non_matching_intermediate_check(
+        self, hass, fake_manager
+    ):
+        """A retry that reads a not-yet-updated value still publishes it
+        (force_cubic_secure_configuration_update() always does) - pending
+        must stay set through that, or the entity would flash to the
+        stale value instead of continuing to show "closing"/"opening"."""
+        coordinator = await _valve_action_coordinator(hass, fake_manager)
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(valve_state="open")
+        )
+
+        coordinator._schedule_valve_state_confirmation(CUBIC_IDENTITY, True)
+        with _patch_manager(fake_manager):
+            async_fire_time_changed(
+                hass,
+                dt_util.utcnow()
+                + timedelta(seconds=VALVE_ACTION_RETRY_INTERVAL_SECONDS),
+            )
+            await hass.async_block_till_done()
+
+        assert coordinator.valve_action_pending[CUBIC_IDENTITY] is True
+        await coordinator.async_shutdown()  # cancel the still-pending check
+
+    async def test_clears_pending_once_confirmed(self, hass, fake_manager):
+        coordinator = await _valve_action_coordinator(hass, fake_manager)
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(valve_state="closed")
+        )
+
+        coordinator._schedule_valve_state_confirmation(CUBIC_IDENTITY, True)
+        with _patch_manager(fake_manager):
+            async_fire_time_changed(
+                hass,
+                dt_util.utcnow()
+                + timedelta(seconds=VALVE_ACTION_RETRY_INTERVAL_SECONDS),
+            )
+            await hass.async_block_till_done()
+
+        assert CUBIC_IDENTITY not in coordinator.valve_action_pending
+
+    async def test_clears_pending_after_giving_up(self, hass, fake_manager):
+        coordinator = await _valve_action_coordinator(hass, fake_manager)
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(valve_state="open")
+        )
+
+        coordinator._schedule_valve_state_confirmation(CUBIC_IDENTITY, True)
+        steps = (
+            VALVE_ACTION_MAX_RETRY_SECONDS // VALVE_ACTION_RETRY_INTERVAL_SECONDS + 2
+        )
+        start = dt_util.utcnow()
+        with _patch_manager(fake_manager):
+            for step in range(1, steps + 1):
+                async_fire_time_changed(
+                    hass,
+                    start
+                    + timedelta(seconds=step * VALVE_ACTION_RETRY_INTERVAL_SECONDS),
+                )
+                await hass.async_block_till_done()
+
+        assert CUBIC_IDENTITY not in coordinator.valve_action_pending
+
 
 class TestRefreshCubicSecureConfiguration:
     """See refresh_cubic_secure_configuration()'s own docstring for why

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -649,6 +649,51 @@ async def _valve_action_coordinator(hass, fake_manager):
     return coordinator
 
 
+class TestMarkAndClearValveActionPending:
+    """valve.py calls these directly around the write itself (not just
+    the confirmation retry-loop), so the entity shows "opening"/"closing"
+    the instant the user acts - the write goes through the same
+    unbounded Retry-After-honoring network layer as any other request
+    and can itself take a long time, confirmed missing live: a slow
+    write left the entity showing nothing until the frontend's own
+    optimistic toggle reverted."""
+
+    async def test_mark_sets_pending_and_notifies(self, hass, fake_manager):
+        coordinator = await _valve_action_coordinator(hass, fake_manager)
+        notified = []
+        coordinator.async_add_listener(lambda: notified.append(True))
+
+        coordinator.mark_valve_action_pending(CUBIC_IDENTITY, True)
+
+        assert coordinator.valve_action_pending[CUBIC_IDENTITY] is True
+        assert notified
+        await coordinator.async_shutdown()  # cancel the now-listened-for refresh interval
+
+    async def test_clear_pops_pending_and_notifies(self, hass, fake_manager):
+        """Used when the write itself never got attempted (e.g. the
+        device wasn't found) - nothing to confirm, so don't leave the
+        entity stuck showing a transitional state with no retry loop
+        ever going to resolve it."""
+        coordinator = await _valve_action_coordinator(hass, fake_manager)
+        coordinator.mark_valve_action_pending(CUBIC_IDENTITY, True)
+        notified = []
+        coordinator.async_add_listener(lambda: notified.append(True))
+
+        coordinator.clear_valve_action_pending(CUBIC_IDENTITY)
+
+        assert CUBIC_IDENTITY not in coordinator.valve_action_pending
+        assert notified
+        await coordinator.async_shutdown()  # cancel the now-listened-for refresh interval
+
+    async def test_clear_cancels_a_pending_confirmation_retry(self, hass, fake_manager):
+        coordinator = await _valve_action_coordinator(hass, fake_manager)
+        coordinator._schedule_valve_state_confirmation(CUBIC_IDENTITY, True)
+
+        coordinator.clear_valve_action_pending(CUBIC_IDENTITY)
+
+        assert CUBIC_IDENTITY not in coordinator._valve_action_unsub
+
+
 class TestValveStateConfirmation:
     """Confirms an open/close write actually took effect, retrying past
     the real-world lag between sending the command and the physical

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -8,6 +8,7 @@ whatever the client returns, token caching, and error handling.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import logging
@@ -54,6 +55,7 @@ from .conftest import (
     build_cubic_configuration,
     build_live_config_without_mute_leak,
     get_issue,
+    tiny_valve_retry_timings,
 )
 
 
@@ -732,19 +734,10 @@ class TestValveStateConfirmation:
             build_cubic_configuration(valve_state="open")
         )
 
-        coordinator._schedule_valve_state_confirmation(CUBIC_IDENTITY, True)
-        steps = (
-            VALVE_ACTION_MAX_RETRY_SECONDS // VALVE_ACTION_RETRY_INTERVAL_SECONDS + 2
-        )
-        start = dt_util.utcnow()
-        with _patch_manager(fake_manager):
-            for step in range(1, steps + 1):
-                async_fire_time_changed(
-                    hass,
-                    start
-                    + timedelta(seconds=step * VALVE_ACTION_RETRY_INTERVAL_SECONDS),
-                )
-                await hass.async_block_till_done()
+        max_retry, retry_interval = tiny_valve_retry_timings()
+        with max_retry, retry_interval, _patch_manager(fake_manager):
+            coordinator._schedule_valve_state_confirmation(CUBIC_IDENTITY, True)
+            await asyncio.sleep(0.3)  # comfortably past the (patched) tiny window
 
         # Never confirmed by the cloud - shows the requested state anyway
         # - but no retry left pending (the test's own teardown would fail
@@ -817,21 +810,49 @@ class TestValveStateConfirmation:
             build_cubic_configuration(valve_state="open")
         )
 
-        coordinator._schedule_valve_state_confirmation(CUBIC_IDENTITY, True)
-        steps = (
-            VALVE_ACTION_MAX_RETRY_SECONDS // VALVE_ACTION_RETRY_INTERVAL_SECONDS + 2
-        )
-        start = dt_util.utcnow()
-        with _patch_manager(fake_manager):
-            for step in range(1, steps + 1):
-                async_fire_time_changed(
-                    hass,
-                    start
-                    + timedelta(seconds=step * VALVE_ACTION_RETRY_INTERVAL_SECONDS),
-                )
-                await hass.async_block_till_done()
+        max_retry, retry_interval = tiny_valve_retry_timings()
+        with max_retry, retry_interval, _patch_manager(fake_manager):
+            coordinator._schedule_valve_state_confirmation(CUBIC_IDENTITY, True)
+            await asyncio.sleep(0.3)  # comfortably past the (patched) tiny window
 
         assert CUBIC_IDENTITY not in coordinator.valve_action_pending
+
+    async def test_a_single_slow_check_gives_up_without_retrying_again(
+        self, hass, fake_manager
+    ):
+        """Regression test for a real bug found live: LK's API can
+        rate-limit this specific endpoint with a Retry-After long enough
+        that pylksystems' own (correct) wait for it can alone exceed the
+        whole retry window (a 93s Retry-After was observed on one real
+        attempt). The give-up decision has to catch that on its own -
+        comparing against a timestamp captured before the slow fetch
+        under-counts the elapsed time and would schedule yet another
+        retry into the same rate limit that just delayed this one."""
+        coordinator = await _valve_action_coordinator(hass, fake_manager)
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(valve_state="open")
+        )
+        # Longer than the patched max retry window below - simulates a
+        # single fetch whose own Retry-After wait alone blows the budget.
+        fake_manager.get_cubic_secure_configuration_delay = 0.1
+
+        max_retry, retry_interval = tiny_valve_retry_timings()
+        with max_retry, retry_interval, _patch_manager(fake_manager):
+            coordinator._schedule_valve_state_confirmation(CUBIC_IDENTITY, True)
+            await asyncio.sleep(0.3)
+
+        assert (
+            fake_manager.calls.count(
+                ("get_cubic_secure_configuration", CUBIC_IDENTITY, True)
+            )
+            == 1
+        ), "should give up after the one slow attempt, not retry again"
+        assert (
+            coordinator.data["cubic_devices"][CUBIC_IDENTITY]["configuration"][
+                "valveState"
+            ]
+            == "closed"
+        )
 
 
 class TestRefreshCubicSecureConfiguration:

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -39,6 +39,8 @@ from custom_components.lksystems.const import (
     LEAK_DETECTION_EXPIRY_RETRY_INTERVAL_SECONDS,
     LEAK_DETECTION_LOCAL_WRITE_GRACE_SECONDS,
     PAUSE_LEAK_DETECTION_MIN_SECONDS,
+    VALVE_ACTION_MAX_RETRY_SECONDS,
+    VALVE_ACTION_RETRY_INTERVAL_SECONDS,
 )
 from custom_components.lksystems.repairs import _issue_id
 
@@ -632,6 +634,126 @@ class TestForceCubicSecureConfigurationUpdate:
             )
 
         assert result is False
+
+
+async def _valve_action_coordinator(hass, fake_manager):
+    """Build a coordinator with an already-completed initial refresh, for
+    the valve-state-confirmation retry tests below."""
+    entry = _make_entry(hass)
+    coordinator = LKSystemCoordinator(hass, entry)
+    with _patch_manager(fake_manager):
+        data = await coordinator._async_update_data()
+    coordinator.async_set_updated_data(data)
+    return coordinator
+
+
+class TestValveStateConfirmation:
+    """Confirms an open/close write actually took effect, retrying past
+    the real-world lag between sending the command and the physical
+    valve motor finishing its 10-30s travel (confirmed against a real
+    device) - a single immediate check right after the write reads a
+    stale pre-action snapshot and would otherwise flip the entity right
+    back to the old state until the next regular poll, possibly minutes
+    later."""
+
+    async def test_resolves_on_the_first_check_if_already_matching(
+        self, hass, fake_manager
+    ):
+        coordinator = await _valve_action_coordinator(hass, fake_manager)
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(valve_state="closed")
+        )
+
+        coordinator._schedule_valve_state_confirmation(CUBIC_IDENTITY, True)
+        with _patch_manager(fake_manager):
+            async_fire_time_changed(
+                hass,
+                dt_util.utcnow()
+                + timedelta(seconds=VALVE_ACTION_RETRY_INTERVAL_SECONDS),
+            )
+            await hass.async_block_till_done()
+
+        assert (
+            coordinator.data["cubic_devices"][CUBIC_IDENTITY]["configuration"][
+                "valveState"
+            ]
+            == "closed"
+        )
+
+    async def test_retries_until_the_motor_finishes_moving(self, hass, fake_manager):
+        coordinator = await _valve_action_coordinator(hass, fake_manager)
+        # Still mid-travel - the write hasn't taken effect yet.
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(valve_state="open")
+        )
+
+        coordinator._schedule_valve_state_confirmation(CUBIC_IDENTITY, True)
+        with _patch_manager(fake_manager):
+            async_fire_time_changed(
+                hass,
+                dt_util.utcnow()
+                + timedelta(seconds=VALVE_ACTION_RETRY_INTERVAL_SECONDS),
+            )
+            await hass.async_block_till_done()
+
+        assert (
+            coordinator.data["cubic_devices"][CUBIC_IDENTITY]["configuration"][
+                "valveState"
+            ]
+            == "open"
+        ), "the motor is still moving - shouldn't be confirmed yet"
+
+        # The motor has now finished moving.
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(valve_state="closed")
+        )
+        with _patch_manager(fake_manager):
+            async_fire_time_changed(
+                hass,
+                dt_util.utcnow()
+                + timedelta(seconds=2 * VALVE_ACTION_RETRY_INTERVAL_SECONDS),
+            )
+            await hass.async_block_till_done()
+
+        assert (
+            coordinator.data["cubic_devices"][CUBIC_IDENTITY]["configuration"][
+                "valveState"
+            ]
+            == "closed"
+        )
+
+    async def test_gives_up_after_the_max_retry_window(self, hass, fake_manager):
+        """A safety cap for if the valve never reports the expected state
+        (e.g. it's jammed, or offline) - falls back to the regular poll
+        rather than retrying forever."""
+        coordinator = await _valve_action_coordinator(hass, fake_manager)
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(valve_state="open")
+        )
+
+        coordinator._schedule_valve_state_confirmation(CUBIC_IDENTITY, True)
+        steps = (
+            VALVE_ACTION_MAX_RETRY_SECONDS // VALVE_ACTION_RETRY_INTERVAL_SECONDS + 2
+        )
+        start = dt_util.utcnow()
+        with _patch_manager(fake_manager):
+            for step in range(1, steps + 1):
+                async_fire_time_changed(
+                    hass,
+                    start
+                    + timedelta(seconds=step * VALVE_ACTION_RETRY_INTERVAL_SECONDS),
+                )
+                await hass.async_block_till_done()
+
+        # Never confirmed - still shows the pre-action state - but no
+        # retry left pending (the test's own teardown would fail on a
+        # lingering timer if one were).
+        assert (
+            coordinator.data["cubic_devices"][CUBIC_IDENTITY]["configuration"][
+                "valveState"
+            ]
+            == "open"
+        )
 
 
 class TestRefreshCubicSecureConfiguration:

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -817,36 +817,34 @@ class TestValveStateConfirmation:
 
         assert CUBIC_IDENTITY not in coordinator.valve_action_pending
 
-    async def test_a_single_slow_check_gives_up_without_retrying_again(
+    async def test_abandons_a_fetch_that_would_outlast_the_retry_window(
         self, hass, fake_manager
     ):
         """Regression test for a real bug found live: LK's API can
         rate-limit this specific endpoint with a Retry-After long enough
         that pylksystems' own (correct) wait for it can alone exceed the
         whole retry window (a 93s Retry-After was observed on one real
-        attempt). The give-up decision has to catch that on its own -
-        comparing against a timestamp captured before the slow fetch
-        under-counts the elapsed time and would schedule yet another
-        retry into the same rate limit that just delayed this one."""
+        attempt). Waiting for such a fetch to finish before checking the
+        deadline would leave the entity showing a transitional state for
+        as long as LK's server says to wait, however much longer than
+        VALVE_ACTION_MAX_RETRY_SECONDS that is - the fetch itself has to
+        be abandoned once its own budget runs out, not just ignored
+        afterwards."""
         coordinator = await _valve_action_coordinator(hass, fake_manager)
         fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
             build_cubic_configuration(valve_state="open")
         )
-        # Longer than the patched max retry window below - simulates a
-        # single fetch whose own Retry-After wait alone blows the budget.
-        fake_manager.get_cubic_secure_configuration_delay = 0.1
+        # Far longer than the patched max retry window below and than
+        # this test's own real wait - if the fetch weren't abandoned, the
+        # assertions below would still find it pending/unresolved.
+        fake_manager.get_cubic_secure_configuration_delay = 5
 
         max_retry, retry_interval = tiny_valve_retry_timings()
         with max_retry, retry_interval, _patch_manager(fake_manager):
             coordinator._schedule_valve_state_confirmation(CUBIC_IDENTITY, True)
             await asyncio.sleep(0.3)
 
-        assert (
-            fake_manager.calls.count(
-                ("get_cubic_secure_configuration", CUBIC_IDENTITY, True)
-            )
-            == 1
-        ), "should give up after the one slow attempt, not retry again"
+        assert CUBIC_IDENTITY not in coordinator.valve_action_pending
         assert (
             coordinator.data["cubic_devices"][CUBIC_IDENTITY]["configuration"][
                 "valveState"

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -724,8 +724,9 @@ class TestValveStateConfirmation:
 
     async def test_gives_up_after_the_max_retry_window(self, hass, fake_manager):
         """A safety cap for if the valve never reports the expected state
-        (e.g. it's jammed, or offline) - falls back to the regular poll
-        rather than retrying forever."""
+        (e.g. it's jammed, or offline) - assumes the write succeeded
+        (HA already issued it) rather than retrying forever or leaving
+        the entity showing the stale pre-action reading."""
         coordinator = await _valve_action_coordinator(hass, fake_manager)
         fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
             build_cubic_configuration(valve_state="open")
@@ -745,14 +746,14 @@ class TestValveStateConfirmation:
                 )
                 await hass.async_block_till_done()
 
-        # Never confirmed - still shows the pre-action state - but no
-        # retry left pending (the test's own teardown would fail on a
-        # lingering timer if one were).
+        # Never confirmed by the cloud - shows the requested state anyway
+        # - but no retry left pending (the test's own teardown would fail
+        # on a lingering timer if one were).
         assert (
             coordinator.data["cubic_devices"][CUBIC_IDENTITY]["configuration"][
                 "valveState"
             ]
-            == "open"
+            == "closed"
         )
 
     async def test_marks_the_device_pending_as_soon_as_scheduled(

--- a/tests_ha/test_valve.py
+++ b/tests_ha/test_valve.py
@@ -5,11 +5,15 @@
 
 from __future__ import annotations
 
+from datetime import timedelta
+
 import pytest
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
-from custom_components.lksystems.const import DOMAIN
+from custom_components.lksystems.const import DOMAIN, VALVE_ACTION_RETRY_INTERVAL_SECONDS
 
 from .conftest import (
     CUBIC_IDENTITY,
@@ -85,6 +89,13 @@ async def test_action_calls_the_client_and_refreshes(
         await hass.services.async_call(
             "valve", ha_service, {"entity_id": valve_entity_id}, blocking=True
         )
+        # The confirmation that the valve actually reached the requested
+        # state is scheduled to check a few seconds later, not
+        # immediately - see LKSystemCoordinator._schedule_valve_state_confirmation.
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=VALVE_ACTION_RETRY_INTERVAL_SECONDS)
+        )
+        await hass.async_block_till_done()
 
     assert (client_call, CUBIC_IDENTITY) in fake_manager.calls
     assert hass.states.get(valve_entity_id).state == resulting_state

--- a/tests_ha/test_valve.py
+++ b/tests_ha/test_valve.py
@@ -13,7 +13,11 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
-from custom_components.lksystems.const import DOMAIN, VALVE_ACTION_RETRY_INTERVAL_SECONDS
+from custom_components.lksystems.const import (
+    DOMAIN,
+    VALVE_ACTION_MAX_RETRY_SECONDS,
+    VALVE_ACTION_RETRY_INTERVAL_SECONDS,
+)
 
 from .conftest import (
     CUBIC_IDENTITY,
@@ -165,3 +169,32 @@ async def test_two_cubic_secure_devices_get_independent_valves(
     # open and the second closed - see conftest.py.
     assert hass.states.get(first_id).state == "open"
     assert hass.states.get(second_id).state == "closed"
+
+
+async def test_assumes_success_if_never_confirmed_within_the_max_retry_window(
+    hass, fake_manager
+):
+    """HA already issued the write - if the cloud never confirms it within
+    VALVE_ACTION_MAX_RETRY_SECONDS, the entity shows the requested state
+    rather than getting stuck on "closing"/"opening" or reverting to the
+    stale pre-action reading."""
+    fake_manager.cubic_configuration_data = build_cubic_configuration(valve_state="open")
+    await setup_entry(hass, fake_manager)
+    valve_entity_id = entity_id(hass, "valve", _valve_unique_id(CUBIC_IDENTITY))
+    fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+        build_cubic_configuration(valve_state="open")
+    )
+
+    steps = VALVE_ACTION_MAX_RETRY_SECONDS // VALVE_ACTION_RETRY_INTERVAL_SECONDS + 2
+    start = dt_util.utcnow()
+    with patch_all_managers(fake_manager):
+        await hass.services.async_call(
+            "valve", "close_valve", {"entity_id": valve_entity_id}, blocking=True
+        )
+        for step in range(1, steps + 1):
+            async_fire_time_changed(
+                hass, start + timedelta(seconds=step * VALVE_ACTION_RETRY_INTERVAL_SECONDS)
+            )
+            await hass.async_block_till_done()
+
+    assert hass.states.get(valve_entity_id).state == "closed"

--- a/tests_ha/test_valve.py
+++ b/tests_ha/test_valve.py
@@ -101,6 +101,59 @@ async def test_action_calls_the_client_and_refreshes(
     assert hass.states.get(valve_entity_id).state == resulting_state
 
 
+@pytest.mark.parametrize(
+    ("ha_service", "starting_state", "transitional_state", "resulting_state"),
+    [
+        ("close_valve", "open", "closing", "closed"),
+        ("open_valve", "closed", "opening", "open"),
+    ],
+)
+async def test_shows_a_transitional_state_until_the_motor_finishes_moving(
+    hass, fake_manager, ha_service, starting_state, transitional_state, resulting_state
+):
+    """The physical motor takes real time to move - the entity must show
+    a steady "closing"/"opening" throughout, not flash through whatever
+    stale intermediate reads the confirmation retries publish along the
+    way (see LKSystemCoordinator.valve_action_pending)."""
+    fake_manager.cubic_configuration_data = build_cubic_configuration(
+        valve_state=starting_state
+    )
+    await setup_entry(hass, fake_manager)
+    valve_entity_id = entity_id(hass, "valve", _valve_unique_id(CUBIC_IDENTITY))
+    # Still mid-travel on the first retry check.
+    fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+        build_cubic_configuration(valve_state=starting_state)
+    )
+
+    with patch_all_managers(fake_manager):
+        await hass.services.async_call(
+            "valve", ha_service, {"entity_id": valve_entity_id}, blocking=True
+        )
+
+        assert hass.states.get(valve_entity_id).state == transitional_state
+
+        async_fire_time_changed(
+            hass, dt_util.utcnow() + timedelta(seconds=VALVE_ACTION_RETRY_INTERVAL_SECONDS)
+        )
+        await hass.async_block_till_done()
+
+        assert (
+            hass.states.get(valve_entity_id).state == transitional_state
+        ), "still mid-travel - must not flash to the stale pre-action reading"
+
+        # The motor has now finished moving.
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_cubic_configuration(valve_state=resulting_state)
+        )
+        async_fire_time_changed(
+            hass,
+            dt_util.utcnow() + timedelta(seconds=2 * VALVE_ACTION_RETRY_INTERVAL_SECONDS),
+        )
+        await hass.async_block_till_done()
+
+    assert hass.states.get(valve_entity_id).state == resulting_state
+
+
 async def test_two_cubic_secure_devices_get_independent_valves(
     hass, fake_manager_with_two_cubic_devices
 ):

--- a/tests_ha/test_valve.py
+++ b/tests_ha/test_valve.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import timedelta
 
 import pytest
@@ -13,11 +14,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 from pytest_homeassistant_custom_component.common import async_fire_time_changed
 
-from custom_components.lksystems.const import (
-    DOMAIN,
-    VALVE_ACTION_MAX_RETRY_SECONDS,
-    VALVE_ACTION_RETRY_INTERVAL_SECONDS,
-)
+from custom_components.lksystems.const import DOMAIN, VALVE_ACTION_RETRY_INTERVAL_SECONDS
 
 from .conftest import (
     CUBIC_IDENTITY,
@@ -26,6 +23,7 @@ from .conftest import (
     entity_id,
     patch_all_managers,
     setup_entry,
+    tiny_valve_retry_timings,
 )
 
 
@@ -185,16 +183,11 @@ async def test_assumes_success_if_never_confirmed_within_the_max_retry_window(
         build_cubic_configuration(valve_state="open")
     )
 
-    steps = VALVE_ACTION_MAX_RETRY_SECONDS // VALVE_ACTION_RETRY_INTERVAL_SECONDS + 2
-    start = dt_util.utcnow()
-    with patch_all_managers(fake_manager):
+    max_retry, retry_interval = tiny_valve_retry_timings()
+    with max_retry, retry_interval, patch_all_managers(fake_manager):
         await hass.services.async_call(
             "valve", "close_valve", {"entity_id": valve_entity_id}, blocking=True
         )
-        for step in range(1, steps + 1):
-            async_fire_time_changed(
-                hass, start + timedelta(seconds=step * VALVE_ACTION_RETRY_INTERVAL_SECONDS)
-            )
-            await hass.async_block_till_done()
+        await asyncio.sleep(0.3)  # comfortably past the (patched) tiny window
 
     assert hass.states.get(valve_entity_id).state == "closed"

--- a/tests_ha/test_valve.py
+++ b/tests_ha/test_valve.py
@@ -1,0 +1,103 @@
+"""Tests for valve.py: the Cubic Secure's main shutoff valve as a native
+`valve.*` entity, rather than only the pre-existing read-only
+`sensor.*_valve_state` and the open_valve/close_valve services.
+"""
+
+from __future__ import annotations
+
+import pytest
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
+
+from custom_components.lksystems.const import DOMAIN
+
+from .conftest import (
+    CUBIC_IDENTITY,
+    CUBIC_IDENTITY_2,
+    build_cubic_configuration,
+    entity_id,
+    patch_all_managers,
+    setup_entry,
+)
+
+
+def _valve_unique_id(device_identity: str) -> str:
+    return f"LkUid_valve_{device_identity}"
+
+
+async def test_belongs_to_the_cubic_secure_device(hass, fake_manager):
+    await setup_entry(hass, fake_manager)
+    valve_entity_id = entity_id(hass, "valve", _valve_unique_id(CUBIC_IDENTITY))
+
+    device = dr.async_get(hass).async_get_device(identifiers={(DOMAIN, CUBIC_IDENTITY)})
+    entry = er.async_get(hass).async_get(valve_entity_id)
+
+    assert entry.device_id == device.id
+
+
+@pytest.mark.parametrize("valve_state", ["open", "closed"])
+async def test_reflects_state_from_client_data(hass, fake_manager, valve_state):
+    fake_manager.cubic_configuration_data = build_cubic_configuration(valve_state=valve_state)
+    await setup_entry(hass, fake_manager)
+    valve_entity_id = entity_id(hass, "valve", _valve_unique_id(CUBIC_IDENTITY))
+
+    state = hass.states.get(valve_entity_id)
+
+    assert state.state == valve_state
+
+
+async def test_unknown_when_configuration_data_is_missing(hass, fake_manager):
+    fake_manager.get_cubic_secure_configuration_result = False
+    await setup_entry(hass, fake_manager)
+    valve_entity_id = entity_id(hass, "valve", _valve_unique_id(CUBIC_IDENTITY))
+
+    state = hass.states.get(valve_entity_id)
+
+    assert state.state == "unknown"
+
+
+@pytest.mark.parametrize(
+    ("ha_service", "client_call", "starting_state", "resulting_state"),
+    [
+        ("close_valve", "cubic_secure_close_valve", "open", "closed"),
+        ("open_valve", "cubic_secure_open_valve", "closed", "open"),
+    ],
+)
+async def test_action_calls_the_client_and_refreshes(
+    hass, fake_manager, ha_service, client_call, starting_state, resulting_state
+):
+    fake_manager.cubic_configuration_data = build_cubic_configuration(
+        valve_state=starting_state
+    )
+    await setup_entry(hass, fake_manager)
+    valve_entity_id = entity_id(hass, "valve", _valve_unique_id(CUBIC_IDENTITY))
+    # A fresh cached (force_update=False) response still showing the
+    # pre-action state - proves the entity forces a fresh fetch rather
+    # than relying on a regular refresh, which would keep serving this.
+    fake_manager.cubic_configurations_cached_by_device[CUBIC_IDENTITY] = (
+        build_cubic_configuration(valve_state=starting_state)
+    )
+    fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = build_cubic_configuration(
+        valve_state=resulting_state
+    )
+
+    with patch_all_managers(fake_manager):
+        await hass.services.async_call(
+            "valve", ha_service, {"entity_id": valve_entity_id}, blocking=True
+        )
+
+    assert (client_call, CUBIC_IDENTITY) in fake_manager.calls
+    assert hass.states.get(valve_entity_id).state == resulting_state
+
+
+async def test_two_cubic_secure_devices_get_independent_valves(
+    hass, fake_manager_with_two_cubic_devices
+):
+    await setup_entry(hass, fake_manager_with_two_cubic_devices)
+    first_id = entity_id(hass, "valve", _valve_unique_id(CUBIC_IDENTITY))
+    second_id = entity_id(hass, "valve", _valve_unique_id(CUBIC_IDENTITY_2))
+
+    # configure_fake_manager_with_two_cubic_devices() sets the first device
+    # open and the second closed - see conftest.py.
+    assert hass.states.get(first_id).state == "open"
+    assert hass.states.get(second_id).state == "closed"

--- a/tests_ha/test_valve.py
+++ b/tests_ha/test_valve.py
@@ -191,3 +191,28 @@ async def test_assumes_success_if_never_confirmed_within_the_max_retry_window(
         await asyncio.sleep(0.3)  # comfortably past the (patched) tiny window
 
     assert hass.states.get(valve_entity_id).state == "closed"
+
+
+async def test_shows_opening_immediately_even_if_the_write_itself_is_slow(
+    hass, fake_manager
+):
+    """The write (login, then the API call) goes through the same
+    unbounded Retry-After-honoring network layer as any other request -
+    it can itself take a long time, confirmed missing live: a slow write
+    left the entity showing nothing until the frontend's own optimistic
+    toggle reverted. The entity must show "opening" the instant the user
+    acts, not only once that write finishes."""
+    fake_manager.cubic_configuration_data = build_cubic_configuration(valve_state="closed")
+    await setup_entry(hass, fake_manager)
+    valve_entity_id = entity_id(hass, "valve", _valve_unique_id(CUBIC_IDENTITY))
+    fake_manager.valve_write_delay = 0.2  # far longer than this test waits below
+
+    with patch_all_managers(fake_manager):
+        call_task = hass.async_create_task(
+            hass.services.async_call(
+                "valve", "open_valve", {"entity_id": valve_entity_id}, blocking=True
+            )
+        )
+        await asyncio.sleep(0.02)  # well before the write itself would finish
+        assert hass.states.get(valve_entity_id).state == "opening"
+        await call_task


### PR DESCRIPTION
Adds a native `valve.*` entity for the Cubic Secure's shutoff valve - a controllable open/close entity with proper `is_opening`/`is_closing` transitional state, rather than only the pre-existing read-only `sensor.*_valve_state` and the `open_valve`/`close_valve` services.

Closes #32: restores the controllable `valve.*` entity that disappeared after v0.3.0-alpha, this time as its own dedicated entity rather than reintroducing the old one.

## What's here

- `LKCubicSecureValve` entity, reflecting live coordinator data like the sibling sensors.
- Confirms an open/close write actually took effect (retrying past the real 10-30s the physical motor takes to move) instead of a single immediate check.
- Shows a steady `opening`/`closing` transitional state throughout - both while confirming the write landed, and from the instant the button is pressed, before the write itself even completes.
- Bounded retry window (30s, tuned against repeated real-device timing) with a bounded max-wait on the confirming fetch itself, so a single slow/rate-limited attempt can't block the UI past the promised cap.

Live-tested and iterated through several real bugs found only by testing against the actual device and account - see the individual commit messages for the specifics. The rate-limiting behavior LK's API exhibited during that testing prompted separate follow-up work (a shared cross-caller cooldown + per-call max-wait budget in `pylksystems`'s network layer) - now its own merged PR (#86).

Rebased onto current `main` (post #80/#81). 219 passed, 1 error in the combined `tests/`+`tests_ha/` run - the error is a pre-existing, unrelated lingering-thread teardown flake in `tests/test_pylksystems.py`, already fixed on its own branch (#87).

