### PR TITLE
Dedupe device_info plumbing across sensor/number/button entities

### DIFF
--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -34,6 +34,7 @@ import voluptuous as vol
 from homeassistant.helpers import config_validation as cv
 
 from .const import (
+    ATTRIBUTION,
     CONF_UPDATE_INTERVAL,
     CUBIC_SECURE_MODEL,
     DEFAULT_UPDATE_INTERVAL,
@@ -1201,6 +1202,25 @@ def cubic_secure_device_info(
         name=f"Cubic Secure {machine_info['zone']['zoneName']}",
         serial_number=device_identity,
     )
+
+
+class CubicSecureEntityMixin:
+    """Shared identity plumbing for every entity on a Cubic Secure device.
+
+    Mixed in by sensor.py, number.py, and button.py's per-platform base
+    classes, whose self.coordinator and self._device_identity this relies
+    on, so a future change to a Cubic Secure device's attribution/naming/
+    device_info only needs editing here instead of at each platform
+    separately.
+    """
+
+    _attr_attribution = ATTRIBUTION
+    _attr_has_entity_name = True
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Return the device_info of the device."""
+        return cubic_secure_device_info(self.coordinator, self._device_identity)
 
 
 async def async_setup(hass: HomeAssistant, config: ConfigType) -> bool:

--- a/custom_components/lksystems/button.py
+++ b/custom_components/lksystems/button.py
@@ -5,12 +5,11 @@ from __future__ import annotations
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from . import LKSystemCoordinator, cubic_secure_device_identities, cubic_secure_device_info
-from .const import ATTRIBUTION, DEFAULT_PAUSE_LEAK_DETECTION_SECONDS, DOMAIN
+from . import CubicSecureEntityMixin, LKSystemCoordinator, cubic_secure_device_identities
+from .const import DEFAULT_PAUSE_LEAK_DETECTION_SECONDS, DOMAIN
 from .services import pause_leak_detection_for_serial
 
 
@@ -27,11 +26,9 @@ async def async_setup_entry(
     )
 
 
-class _LKCubicSecureButton(ButtonEntity):
+class _LKCubicSecureButton(CubicSecureEntityMixin, ButtonEntity):
     """Shared plumbing for the per-Cubic-Secure-device buttons below."""
 
-    _attr_attribution = ATTRIBUTION
-    _attr_has_entity_name = True
     _unique_id_suffix: str
 
     def __init__(self, coordinator: LKSystemCoordinator, device_identity: str) -> None:
@@ -39,11 +36,6 @@ class _LKCubicSecureButton(ButtonEntity):
         self.coordinator = coordinator
         self._device_identity = device_identity
         self._attr_unique_id = f"LkUid_{self._unique_id_suffix}_{device_identity}"
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device_info of the device."""
-        return cubic_secure_device_info(self.coordinator, self._device_identity)
 
 
 class LKPauseLeakDetectionButton(_LKCubicSecureButton):

--- a/custom_components/lksystems/number.py
+++ b/custom_components/lksystems/number.py
@@ -8,13 +8,11 @@ from homeassistant.components.number import NumberDeviceClass, NumberMode, Resto
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import UnitOfTime
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.util.unit_conversion import DurationConverter
 
-from . import LKSystemCoordinator, cubic_secure_device_identities, cubic_secure_device_info
+from . import CubicSecureEntityMixin, LKSystemCoordinator, cubic_secure_device_identities
 from .const import (
-    ATTRIBUTION,
     DEFAULT_PAUSE_LEAK_DETECTION_SECONDS,
     DOMAIN,
     PAUSE_LEAK_DETECTION_MAX_SECONDS,
@@ -41,7 +39,7 @@ async def async_setup_entry(
     )
 
 
-class LKPauseLeakDetectionDurationNumber(RestoreNumber):
+class LKPauseLeakDetectionDurationNumber(CubicSecureEntityMixin, RestoreNumber):
     """How long the device's "Pause Leak Detection" button should pause for.
 
     A local preference, not fetched from the API - the API only takes a
@@ -63,8 +61,6 @@ class LKPauseLeakDetectionDurationNumber(RestoreNumber):
     own boundary instead, via DurationConverter.
     """
 
-    _attr_attribution = ATTRIBUTION
-    _attr_has_entity_name = True
     _attr_name = "Pause Duration"
     _attr_icon = "mdi:timer-outline"
     _attr_device_class = NumberDeviceClass.DURATION
@@ -80,11 +76,6 @@ class LKPauseLeakDetectionDurationNumber(RestoreNumber):
         self._device_identity = device_identity
         self._attr_unique_id = f"LkUid_pause_leak_detection_duration_{device_identity}"
         self._attr_native_value = _minutes(DEFAULT_PAUSE_LEAK_DETECTION_SECONDS)
-
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device_info of the device."""
-        return cubic_secure_device_info(self.coordinator, self._device_identity)
 
     def _store_duration_minutes(self, minutes: float) -> None:
         """Set the displayed value and push the equivalent seconds

--- a/custom_components/lksystems/sensor.py
+++ b/custom_components/lksystems/sensor.py
@@ -29,9 +29,8 @@ from homeassistant.helpers.update_coordinator import (
 )
 import homeassistant.util.dt as dt_util
 
-from . import LKSystemCoordinator, cubic_secure_device_info
+from . import CubicSecureEntityMixin, LKSystemCoordinator
 from .const import (
-    ATTRIBUTION,
     C_NEXT_UPDATE_TIME,
     C_UPDATE_TIME,
     DOMAIN,
@@ -922,12 +921,12 @@ class LKArcHubEntity(RestoredNativeValueMixin, CoordinatorEntity, RestoreSensor)
 
 
 class AbstractLkCubicSensor(
-    RestoredNativeValueMixin, CoordinatorEntity[LKSystemCoordinator], RestoreSensor
+    CubicSecureEntityMixin,
+    RestoredNativeValueMixin,
+    CoordinatorEntity[LKSystemCoordinator],
+    RestoreSensor,
 ):
     """Abstract class for an LK Cubic secure sensor."""
-
-    _attr_attribution = ATTRIBUTION
-    _attr_has_entity_name = True
 
     def __init__(
         self,
@@ -939,21 +938,16 @@ class AbstractLkCubicSensor(
         _LOGGER.debug("Creating %s sensor", description.name)
         super().__init__(coordinator)
         self._coordinator = coordinator
-        self._id = device_identity
+        self._device_identity = device_identity
         self.entity_description = description
         self.native_unit_of_measurement = description.native_unit_of_measurement
         self._attr_unique_id = f"LkUid_{description.key}_{device_identity}"
         self._attr_extra_state_attributes = {}
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return the device_info of the device."""
-        return cubic_secure_device_info(self.coordinator, self._id)
-
     def _cubic_configuration(self) -> dict:
         """Return this device's last-fetched configuration dict."""
         device_data = self._coordinator.data.get("cubic_devices", {}).get(
-            self._id, {}
+            self._device_identity, {}
         )
         return device_data.get("configuration") or {}
 
@@ -1018,7 +1012,7 @@ class LKCubicSensor(AbstractLkCubicSensor):
         """Get the latest state value from the coordinator's live data."""
         value = None
         device_data = self._coordinator.data.get("cubic_devices", {}).get(
-            self._id, {}
+            self._device_identity, {}
         )
 
         if self._data_source == "configuration":
@@ -1081,7 +1075,7 @@ class LKLeakDetectionPausedUntilSensor(AbstractLkCubicSensor):
 
     def _live_native_value(self) -> datetime | None:
         """Get the latest state value from the coordinator's live data."""
-        return self.coordinator.leak_detection_paused_until.get(self._id)
+        return self.coordinator.leak_detection_paused_until.get(self._device_identity)
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:


### PR DESCRIPTION
Part of #75 (item 6: "Deduplicate device_info plumbing across sensor.py, number.py, and button.py").

`AbstractLkCubicSensor` (`sensor.py`), `LKPauseLeakDetectionDurationNumber` (`number.py`), and `_LKCubicSecureButton` (`button.py`) each independently redefined the same `device_info` property plus `_attr_attribution`/`_attr_has_entity_name`. Extracted a shared `CubicSecureEntityMixin` in `__init__.py`, alongside the existing `cubic_secure_device_info` helper, and had all three inherit it instead. Pure refactor, no behavior change - verified by keeping the existing per-platform `device_info` tests green throughout rather than adding new ones.

As part of consolidating onto one shared attribute name, standardized `sensor.py`'s device-identity attribute from `self._id` to `self._device_identity` to match the other two platforms.

**Not included:** `valve.py`'s `LKCubicSecureValve` has the identical pattern too, but that file only exists on the still-open #90 - couldn't touch it without pulling in the whole unrelated valve-entity feature. Same mechanical change should be applied there once #90 merges.

Tests: `tests/` 33 passed, 1 error (pre-existing, unrelated - see #71/#87). `tests_ha/` 164/164.
