### PR TITLE
Generalize coordinator cache-bypass, field preservation, and session reuse

### DIFF
--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -318,6 +318,19 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         # the way.
         self.valve_action_pending: dict[str, bool] = {}
 
+        # Device identities queued for a cache-bypassing fetch on the
+        # coordinator's next update, via async_request_forced_refresh()
+        # below. A set rather than a single overwritable value, so two
+        # callers requesting a bypass for two different devices before that
+        # update actually runs both get honored by it, instead of the
+        # second overwriting the first. _fetch_data() snapshots and clears
+        # this in one statement with no `await` in between, so a request
+        # already queued by the time it does that is never lost, and one
+        # that arrives after simply waits for the next update - the same
+        # way a plain async_request_refresh() call arriving mid-update
+        # already behaves.
+        self._force_bypass_device_ids: set[str] = set()
+
         # Initialize coordinator with update interval
         super().__init__(
             hass,
@@ -395,98 +408,50 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
             _LOGGER.error("Failed to set temperature: %s", ex)
             return False
 
+    def _apply_device_measurement(self, device_id: str, measurement_data: dict) -> None:
+        """Write a fresh measurement for one Arc device into every place
+        self.data stores it: device_details, the flat devices list, and
+        any hub_data the device belongs to."""
+        device_details = self.data.setdefault("device_details", {})
+        device_details.setdefault(device_id, {})["measurement"] = measurement_data
+
+        for device in self.data.get("devices", []):
+            device_title = device.get("deviceTitle", {})
+            if device.get("mac") == device_id or device_title.get("identity") == device_id:
+                device["measurement"] = measurement_data.copy()
+                break
+
+        for hub_data in self.data.get("hub_data", {}).values():
+            if not isinstance(hub_data, dict):
+                continue
+            for device in hub_data.get("devices", []):
+                if device.get("mac") == device_id:
+                    device["measurement"] = measurement_data.copy()
+
     async def force_device_update(self, device_id: str) -> bool:
-        """Force update for a specific device from API."""
-        _LOGGER.warning("FORCE UPDATE REQUESTED for device %s", device_id)
+        """Force a fresh, cache-bypassing measurement fetch for one Arc
+        device, publishing it immediately rather than waiting for the next
+        regular poll.
+        """
+        _LOGGER.debug("Forcing measurement update for device %s", device_id)
 
         try:
-            # Get credentials
-            username = self._entry.data.get(CONF_USERNAME)
-            password = self._entry.data.get(CONF_PASSWORD)
-
-            async with LKSystemsManager(username, password) as lk_inst:
-                # Use existing token if available
-                stored_tokens = TOKEN_STORAGE.get(self._entry_id, {})
-                stored_jwt = stored_tokens.get("jwt")
-
-                if stored_jwt and is_token_valid(stored_jwt):
-                    lk_inst.jwt_token = stored_jwt
-                    lk_inst.refresh_token = stored_tokens.get("refresh")
-                else:
-                    # Login if no valid token
-                    if not await lk_inst.login():
-                        _LOGGER.error("Login failed when forcing device update")
-                        return False
-
-                    # Store the new tokens
-                    TOKEN_STORAGE[self._entry_id] = {
-                        "jwt": lk_inst.jwt_token,
-                        "refresh": lk_inst.refresh_token,
-                        "expiry": dt_util.utcnow().timestamp() + 3600,
-                    }
-
-                # Always force update for this device
+            async with self._authenticated_client() as lk_inst:
                 success = await lk_inst.get_device_measurement(
                     device_id, force_update=True
                 )
 
-                if success and device_id in lk_inst.device_measurements:
-                    measurement_data = lk_inst.device_measurements[device_id]
-
-                    # Log the raw measurement data
-                    _LOGGER.warning(
-                        "Got fresh data for %s: Temperature=%s, Humidity=%s, Battery=%s",
-                        device_id,
-                        measurement_data.get("currentTemperature"),
-                        measurement_data.get("currentHumidity"),
-                        measurement_data.get("currentBattery"),
+                if success and device_id in lk_inst.device_measurements and self.data:
+                    self._apply_device_measurement(
+                        device_id, lk_inst.device_measurements[device_id]
                     )
-
-                    # Update our local data
-                    if self.data:
-                        # Create device_details dict if not exists
-                        if "device_details" not in self.data:
-                            self.data["device_details"] = {}
-
-                        if device_id not in self.data["device_details"]:
-                            self.data["device_details"][device_id] = {}
-
-                        # Ensure measurement dict exists
-                        if "measurement" not in self.data["device_details"][device_id]:
-                            self.data["device_details"][device_id]["measurement"] = {}
-
-                        # Update with latest data - full replacement to ensure all fields are updated
-                        self.data["device_details"][device_id]["measurement"] = (
-                            measurement_data
-                        )
-
-                        # Also update in devices list
-                        for device in self.data.get("devices", []):
-                            device_title = device.get("deviceTitle", {})
-                            if (
-                                device.get("mac") == device_id
-                                or device_title.get("identity") == device_id
-                            ):
-                                device["measurement"] = measurement_data.copy()
-                                break
-
-                        # Also update any devices in hub_data
-                        if "hub_data" in self.data:
-                            for hub_id, hub_data in self.data["hub_data"].items():
-                                if isinstance(hub_data, dict) and "devices" in hub_data:
-                                    for device in hub_data["devices"]:
-                                        if device.get("mac") == device_id:
-                                            device["measurement"] = (
-                                                measurement_data.copy()
-                                            )
-
-                        # Trigger all listeners to update with new data
-                        self.async_set_updated_data(self.data)
-
-                        return True
+                    self.async_set_updated_data(self.data)
 
                 return success
 
+        except _LoginFailed:
+            _LOGGER.error("Login failed when forcing device update")
+            return False
         except Exception as ex:
             _LOGGER.error("Error during forced device update: %s", ex)
             return False
@@ -519,6 +484,20 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                 }
 
             yield lk_inst
+
+    async def async_request_forced_refresh(self, device_id: str) -> None:
+        """Request a cache-bypassing fetch for one device on the
+        coordinator's next update, then trigger that update.
+
+        Covers data types that have no other bypass entry point - a Cubic
+        Secure device's own measurement (which carries its leak state) and
+        an Arc-sense device's configuration (used for thermostat-role
+        devices). Cubic Secure configuration already has its own dedicated
+        force_cubic_secure_configuration_update(); this is the general
+        primitive behind that gap that one doesn't cover.
+        """
+        self._force_bypass_device_ids.add(device_id)
+        await self.async_request_refresh()
 
     def _pause_end_time(self, seconds: int) -> datetime:
         """Return the (rounded) wall-clock time `seconds` from now."""
@@ -922,6 +901,16 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
             repairs.async_clear_all_issues(self.hass, self._entry_id)
             return resp
 
+    def _should_bypass_cache(
+        self, device_identity: str, forced_device_ids: set[str], cache_updated: int
+    ) -> bool:
+        """Whether a cached response for device_identity is stale enough to
+        warrant a fresh, cache-bypassing fetch instead - or a bypass was
+        explicitly requested for it via async_request_forced_refresh()."""
+        if device_identity in forced_device_ids:
+            return True
+        return int(time.time()) - cache_updated > self.update_interval.total_seconds()
+
     async def _fetch_data(self) -> LkStructureResp:  # noqa: C901
         """Fetch the latest data from the source."""
         # Record update time at the beginning of update
@@ -930,6 +919,13 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
             "Starting LK Systems data update at %s",
             self._last_cloud_fetch_attempt.isoformat(),
         )
+
+        # Snapshot and clear in one statement (no `await` in between) so a
+        # request queued by async_request_forced_refresh() is either fully
+        # reflected in this fetch or left untouched for the next one - see
+        # _force_bypass_device_ids' own comment for why.
+        forced_device_ids = self._force_bypass_device_ids
+        self._force_bypass_device_ids = set()
 
         try:
             # Get credentials from config entry
@@ -1044,9 +1040,11 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                                         lk_inst.device_measurements.get(device_identity)
                                     )
 
-                                # Fetch configuration data
+                                # Fetch configuration data (used for
+                                # thermostat-role devices by climate.py)
                                 if await lk_inst.get_device_configuration(
-                                    device_identity
+                                    device_identity,
+                                    force_update=device_identity in forced_device_ids,
                                 ):
                                     if device_identity not in resp["device_details"]:
                                         resp["device_details"][device_identity] = {}
@@ -1124,17 +1122,15 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                                 )
 
                                 if lk_inst.cubic_secure_measurement is not None:
-                                    # Get time as unix timestamp
-                                    timestamp = int(time.time())
-                                    if (
-                                        timestamp
-                                        - lk_inst.cubic_secure_measurement[
+                                    if self._should_bypass_cache(
+                                        device_identity,
+                                        forced_device_ids,
+                                        lk_inst.cubic_secure_measurement[
                                             "cacheUpdated"
-                                        ]
-                                        > self.update_interval.total_seconds()
+                                        ],
                                     ):
                                         _LOGGER.debug(
-                                            "Cubic secure measurement is older than update interval, force update"
+                                            "Cubic secure measurement is stale or a fresh fetch was requested, force update"
                                         )
                                         if not await lk_inst.get_cubic_secure_measurement(
                                             device_identity, force_update=True
@@ -1159,17 +1155,15 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                                         "Unknown error get_cubic_secure_measurement"
                                     )
                                 if lk_inst.cubic_secure_configuration is not None:
-                                    # Get time as unix timestamp
-                                    timestamp = int(time.time())
-                                    if (
-                                        timestamp
-                                        - lk_inst.cubic_secure_configuration[
+                                    if self._should_bypass_cache(
+                                        device_identity,
+                                        forced_device_ids,
+                                        lk_inst.cubic_secure_configuration[
                                             "cacheUpdated"
-                                        ]
-                                        > self.update_interval.total_seconds()
+                                        ],
                                     ):
                                         _LOGGER.debug(
-                                            "Cubic secure configuration is older than update interval, force update"
+                                            "Cubic secure configuration is stale or a fresh fetch was requested, force update"
                                         )
                                         # The forced/bypass fetch below polls
                                         # the physical device live rather

--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -803,45 +803,52 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         for device_identity in list(self._valve_action_unsub):
             self._cancel_valve_action_confirmation(device_identity)
 
+    async def _apply_cubic_secure_configuration(
+        self, lk_inst: LKSystemsManager, device_identity: str, *, force_update: bool
+    ) -> bool:
+        """Fetch one Cubic Secure device's configuration via `lk_inst` (an
+        already-authenticated client) and publish it.
+
+        Shared by every variant below - see their own docstrings for which
+        to use when.
+        """
+        success = await lk_inst.get_cubic_secure_configuration(
+            device_identity, force_update=force_update
+        )
+
+        if success and self.data:
+            self.data["cubic_devices"][device_identity]["configuration"] = (
+                lk_inst.cubic_secure_configuration
+            )
+            # Deliberately doesn't call
+            # _reconcile_leak_detection_paused_until() here: some callers
+            # of this method (a pause/resume, an open/close) reach it
+            # right after HA itself just wrote something, and the cached
+            # response can still be serving a pre-write snapshot for tens
+            # of seconds - confirmed empirically against the real API -
+            # reconciling off it there would race the explicit
+            # set_leak_detection_paused_until() call the caller already
+            # made and undo it. Reconciliation instead happens at each
+            # call site once it's independently established that enough
+            # time has passed for the cached read to be trustworthy: the
+            # regular poll (_fetch_data) isn't tied to a just-made write,
+            # and the leak-detection expiry check
+            # (_schedule_leak_detection_expiry_refresh) only ever calls
+            # this at or after a pause's own target end time.
+            self.async_set_updated_data(self.data)
+
+        return success
+
     async def _update_cubic_secure_configuration(
         self, device_identity: str, *, force_update: bool
     ) -> bool:
-        """Fetch one Cubic Secure device's configuration and publish it.
-
-        Shared implementation for the two variants below - see their own
-        docstrings for which to use when.
-        """
+        """Fetch one Cubic Secure device's configuration, opening its own
+        authenticated session first."""
         try:
             async with self._authenticated_client() as lk_inst:
-                success = await lk_inst.get_cubic_secure_configuration(
-                    device_identity, force_update=force_update
+                return await self._apply_cubic_secure_configuration(
+                    lk_inst, device_identity, force_update=force_update
                 )
-
-                if success and self.data:
-                    self.data["cubic_devices"][device_identity]["configuration"] = (
-                        lk_inst.cubic_secure_configuration
-                    )
-                    # Deliberately doesn't call
-                    # _reconcile_leak_detection_paused_until() here: some
-                    # callers of this method (a pause/resume, an
-                    # open/close) reach it right after HA itself just
-                    # wrote something, and the cached response can still
-                    # be serving a pre-write snapshot for tens of seconds
-                    # - confirmed empirically against the real API -
-                    # reconciling off it there would race the explicit
-                    # set_leak_detection_paused_until() call the caller
-                    # already made and undo it. Reconciliation instead
-                    # happens at each call site once it's independently
-                    # established that enough time has passed for the
-                    # cached read to be trustworthy: the regular poll
-                    # (_fetch_data) isn't tied to a just-made write, and
-                    # the leak-detection expiry check
-                    # (_schedule_leak_detection_expiry_refresh) only ever
-                    # calls this at or after a pause's own target end time.
-                    self.async_set_updated_data(self.data)
-
-                return success
-
         except _LoginFailed:
             _LOGGER.error("Login failed when updating Cubic Secure configuration")
             return False
@@ -885,6 +892,21 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         )
         return await self._update_cubic_secure_configuration(
             device_identity, force_update=False
+        )
+
+    async def refresh_cubic_secure_configuration_with_client(
+        self, lk_inst: LKSystemsManager, device_identity: str
+    ) -> bool:
+        """Like refresh_cubic_secure_configuration(), but reusing an
+        already-authenticated `lk_inst` instead of opening a new session -
+        for a caller that just used it for a write and wants to confirm
+        that write with a read, at the cost of one login rather than two.
+        """
+        _LOGGER.debug(
+            "Refreshing configuration for Cubic Secure device %s", device_identity
+        )
+        return await self._apply_cubic_secure_configuration(
+            lk_inst, device_identity, force_update=False
         )
 
     async def _async_update_data(self) -> LkStructureResp:

--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -240,6 +240,17 @@ def _round_to_nearest_minute(moment: datetime) -> datetime:
     return (moment + timedelta(seconds=30)).replace(second=0, microsecond=0)
 
 
+def _fill_missing_keys(target: dict, fallback: dict) -> None:
+    """Copy every key `fallback` has that `target` doesn't, into `target`.
+
+    For a live/bypass API response whose schema is narrower than the
+    cached one it's replacing - so a cache-only field doesn't just vanish
+    because a caller bypassed the cache.
+    """
+    for key, value in fallback.items():
+        target.setdefault(key, value)
+
+
 class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
     """Data update coordinator for LK Systems."""
 
@@ -1165,18 +1176,8 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                                         _LOGGER.debug(
                                             "Cubic secure configuration is stale or a fresh fetch was requested, force update"
                                         )
-                                        # The forced/bypass fetch below polls
-                                        # the physical device live rather
-                                        # than LK's backend cache, and the
-                                        # device doesn't report muteLeak at
-                                        # all - carry the cached value over
-                                        # so this staleness-triggered force
-                                        # doesn't wipe out a pause that's
-                                        # still running.
-                                        cached_mute_leak = (
-                                            lk_inst.cubic_secure_configuration.get(
-                                                "muteLeak"
-                                            )
+                                        cached_configuration = (
+                                            lk_inst.cubic_secure_configuration
                                         )
                                         if not await lk_inst.get_cubic_secure_configuration(
                                             device_identity, force_update=True
@@ -1187,8 +1188,20 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                                             raise UpdateFailed(
                                                 "Unknown error get_cubic_secure_configuration"
                                             )
-                                        lk_inst.cubic_secure_configuration.setdefault(
-                                            "muteLeak", cached_mute_leak
+                                        # The bypass fetch above polls the
+                                        # physical device live rather than
+                                        # LK's backend cache, and that
+                                        # response has a narrower schema
+                                        # (confirmed empirically: it never
+                                        # carries muteLeak) - carry over
+                                        # whatever the cached response has
+                                        # that the live one doesn't, so a
+                                        # cache-only field doesn't just
+                                        # vanish because this device was
+                                        # bypassed.
+                                        _fill_missing_keys(
+                                            lk_inst.cubic_secure_configuration,
+                                            cached_configuration,
                                         )
 
                                 resp["cubic_devices"][device_identity][

--- a/custom_components/lksystems/services.py
+++ b/custom_components/lksystems/services.py
@@ -45,11 +45,16 @@ async def pause_leak_detection_for_serial(
     success, rather than leaving either to the next scheduled poll -
     living here means every caller gets that, not just whichever one
     remembers to ask for it.
+
+    Confirms the write by reusing the same session for the follow-up read
+    (coordinator.refresh_cubic_secure_configuration_with_client()) rather
+    than opening a second one just for that.
     """
     _LOGGER.info("Pausing leak detection for %s for %s seconds", serial_number, seconds)
     try:
         username = entry.data.get(CONF_USERNAME)
         password = entry.data.get(CONF_PASSWORD)
+        coordinator = hass.data[DOMAIN][entry.entry_id]
 
         async with LKSystemsManager(username, password) as lk_inst:
             if not await lk_inst.login():
@@ -57,9 +62,10 @@ async def pause_leak_detection_for_serial(
                 raise Exception("Failed to login")
             await lk_inst.cubic_secure_pause_leak_detection(serial_number, seconds)
 
-        coordinator = hass.data[DOMAIN][entry.entry_id]
-        coordinator.set_leak_detection_paused_until(serial_number, seconds)
-        await coordinator.refresh_cubic_secure_configuration(serial_number)
+            coordinator.set_leak_detection_paused_until(serial_number, seconds)
+            await coordinator.refresh_cubic_secure_configuration_with_client(
+                lk_inst, serial_number
+            )
     except Exception as e:
         _LOGGER.error("Error pausing leak detection: %s", e)
 

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -909,6 +909,138 @@ class TestValveStateConfirmation:
         )
 
 
+class TestAsyncRequestForcedRefresh:
+    """async_request_forced_refresh() is the general cache-bypass primitive:
+    unlike force_device_update() (Arc-sense measurement) and
+    force_cubic_secure_configuration_update() (Cubic Secure configuration),
+    it's the only entry point for bypassing the cache for a Cubic Secure
+    device's own measurement (which carries leak state) or an Arc-sense
+    device's configuration (used for thermostat-role devices) - neither had
+    any bypass at all before this.
+    """
+
+    async def test_bypasses_cubic_secure_measurement_cache_for_the_requested_device(
+        self, hass, fake_manager
+    ):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            data = await coordinator._async_update_data()
+        coordinator.async_set_updated_data(data)
+        fake_manager.calls.clear()
+
+        with _patch_manager(fake_manager):
+            await coordinator.async_request_forced_refresh(CUBIC_IDENTITY)
+
+        assert (
+            "get_cubic_secure_measurement",
+            CUBIC_IDENTITY,
+            True,
+        ) in fake_manager.calls
+        await coordinator.async_shutdown()  # cancel the debouncer's cooldown timer
+
+    async def test_bypasses_device_configuration_cache_for_the_requested_device(
+        self, hass, fake_manager
+    ):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            data = await coordinator._async_update_data()
+        coordinator.async_set_updated_data(data)
+        fake_manager.calls.clear()
+
+        with _patch_manager(fake_manager):
+            await coordinator.async_request_forced_refresh(THERMOSTAT_MAC)
+
+        assert (
+            "get_device_configuration",
+            THERMOSTAT_MAC,
+            True,
+        ) in fake_manager.calls
+        await coordinator.async_shutdown()  # cancel the debouncer's cooldown timer
+
+    async def test_does_not_bypass_for_a_device_that_was_not_requested(
+        self, hass, fake_manager
+    ):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            data = await coordinator._async_update_data()
+        coordinator.async_set_updated_data(data)
+        fake_manager.calls.clear()
+
+        with _patch_manager(fake_manager):
+            await coordinator.async_request_forced_refresh(CUBIC_IDENTITY)
+
+        assert (
+            "get_device_configuration",
+            THERMOSTAT_MAC,
+            True,
+        ) not in fake_manager.calls
+        await coordinator.async_shutdown()  # cancel the debouncer's cooldown timer
+
+    async def test_forced_bypass_is_only_honored_once(self, hass, fake_manager):
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            data = await coordinator._async_update_data()
+        coordinator.async_set_updated_data(data)
+
+        with _patch_manager(fake_manager):
+            await coordinator.async_request_forced_refresh(CUBIC_IDENTITY)
+        fake_manager.calls.clear()
+
+        with _patch_manager(fake_manager):
+            await coordinator.async_request_refresh()
+
+        assert (
+            "get_cubic_secure_measurement",
+            CUBIC_IDENTITY,
+            True,
+        ) not in fake_manager.calls
+        await coordinator.async_shutdown()  # cancel the debouncer's cooldown timer
+
+    async def test_two_devices_queued_before_the_snapshot_are_both_honored(
+        self, hass, fake_manager
+    ):
+        """Regression test for using a set of device ids rather than a
+        single overwritable value: two callers queuing a bypass for two
+        different devices before _fetch_data() takes its snapshot must not
+        have one request clobber the other. Queues both directly rather
+        than through two overlapping async_request_forced_refresh() calls,
+        since FakeLKSystemsManager never actually suspends, so two such
+        calls would just run back-to-back rather than genuinely overlap."""
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        with _patch_manager(fake_manager):
+            data = await coordinator._async_update_data()
+        coordinator.async_set_updated_data(data)
+        fake_manager.calls.clear()
+
+        coordinator._force_bypass_device_ids.add(CUBIC_IDENTITY)
+        coordinator._force_bypass_device_ids.add(THERMOSTAT_MAC)
+
+        with _patch_manager(fake_manager):
+            await coordinator.async_request_refresh()
+
+        assert (
+            "get_cubic_secure_measurement",
+            CUBIC_IDENTITY,
+            True,
+        ) in fake_manager.calls
+        assert (
+            "get_device_configuration",
+            THERMOSTAT_MAC,
+            True,
+        ) in fake_manager.calls
+        await coordinator.async_shutdown()  # cancel the debouncer's cooldown timer
+
+
 class TestRefreshCubicSecureConfiguration:
     """See refresh_cubic_secure_configuration()'s own docstring for why
     this reads the cached response rather than bypassing it."""

--- a/tests_ha/test_coordinator.py
+++ b/tests_ha/test_coordinator.py
@@ -446,6 +446,37 @@ class TestCubicConfigurationStalenessForceFetch:
         )
         await coordinator.async_shutdown()  # cancel the expiry check this adopted
 
+    async def test_preserves_any_field_missing_from_the_live_response(
+        self, hass, fake_manager
+    ):
+        """Not just muteLeak - any key the cached response carries that the
+        live/bypass one omits should survive the merge."""
+        entry = _make_entry(hass)
+        coordinator = LKSystemCoordinator(hass, entry)
+
+        stale_cache_updated = (
+            int(time.time()) - int(coordinator.update_interval.total_seconds()) - 60
+        )
+        cached_config = build_cubic_configuration(mute_leak=1200)
+        cached_config["cacheUpdated"] = stale_cache_updated
+        cached_config["pairingCode"] = "abc123"
+        fake_manager.cubic_configurations_cached_by_device[CUBIC_IDENTITY] = (
+            cached_config
+        )
+
+        fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = (
+            build_live_config_without_mute_leak()
+        )
+
+        with _patch_manager(fake_manager):
+            data = await coordinator._async_update_data()
+
+        assert (
+            data["cubic_devices"][CUBIC_IDENTITY]["configuration"]["pairingCode"]
+            == "abc123"
+        )
+        await coordinator.async_shutdown()  # cancel the expiry check this adopted
+
 
 class TestMultipleCubicSecureDevices:
     """Two Cubic Secure devices registered under the same property used to

--- a/tests_ha/test_services.py
+++ b/tests_ha/test_services.py
@@ -173,6 +173,20 @@ class TestPauseLeakDetectionForSerial:
 
         assert CUBIC_IDENTITY not in coordinator.leak_detection_paused_until
 
+    async def test_reuses_one_session_for_the_write_and_its_confirmation_read(
+        self, hass, fake_manager
+    ):
+        """The write (cubic_secure_pause_leak_detection) and its immediate
+        confirmation read (refresh_cubic_secure_configuration) used to each
+        open their own session - two logins for one logical action."""
+        entry, _ = await _setup_entry_and_get_cubic_device(hass, fake_manager)
+        fake_manager.calls.clear()
+
+        with patch_all_managers(fake_manager):
+            await pause_leak_detection_for_serial(hass, entry, CUBIC_IDENTITY, 1800)
+
+        assert fake_manager.calls.count(("login",)) == 1
+
 
 async def test_set_pressure_test_schedule_calls_client(hass, fake_manager):
     _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)


### PR DESCRIPTION
Part of #75 (items 4, 5, and 7 - the remaining ones after 1-3 landed via #80).

Three separate commits, each its own TDD cycle:

**Item 4 - generalize the force-bypass mechanism.** Added `LKSystemCoordinator.async_request_forced_refresh(device_id)`, backed by a `set` of pending device ids (not a single value) so two callers requesting a bypass for two different devices before the next fetch runs are both honored, not just the last one. `_fetch_data()` snapshots-and-clears that set and folds it into the existing staleness check, extending cache-bypass to leak state and thermostat data, which had none before. `force_device_update()` was reworked to reuse `_authenticated_client()` instead of hand-rolling its own login/token logic.

Deliberately did **not** fold `force_cubic_secure_configuration_update`/`refresh_cubic_secure_configuration` into this same mechanism - they serve a targeted single-field read that several existing call sites depend on, and routing them through a full coordinator refresh would be a real behavior change (heavier, full-account re-fetch) with no live account available to verify it against. Left them as-is; the new primitive only closes the two genuinely-missing bypass gaps.

**Item 7 - generalize the muteLeak field-preservation.** Replaced the hardcoded save-`muteLeak`/bypass/restore dance with a small `_fill_missing_keys(target, fallback)` merge, so any cache-only field surviving the live response's narrower schema is handled generically. Tested against a synthetic field, not just `muteLeak`, to prove it's not just a renamed special case.

**Item 5 - share one session for a write + its confirmation read.** `pause_leak_detection_for_serial()` was opening two full sessions (one for the write, a second inside `refresh_cubic_secure_configuration()` for the read-back). Split the coordinator's update method into an already-authenticated variant (`refresh_cubic_secure_configuration_with_client`) and a self-authenticating wrapper, and had the write reuse its own open client for the confirmation read. Test asserts exactly one login for the whole call - confirmed RED (2 logins) before, GREEN (1) after.

**Not included:** the issue also flags the valve's open/close doing the same double-login - `valve.py` doesn't exist on `main` yet (#90, still open). Once that merges, its service calls should reuse `refresh_cubic_secure_configuration_with_client` the same way, from inside their own already-open session.

Tests: `tests/` 33/33, `tests_ha/` 171/171.

Known to conflict with #88 and #90 (both touch coordinator code in `__init__.py`) - ordinary conflicts from working the same area in parallel, not a correctness issue between them.
