### PR TITLE
Add a Release workflow so the version bump can't be forgotten

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release, without a leading v (e.g. 0.4.3-alpha)"
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Require a release to be cut from main
+        if: github.ref != 'refs/heads/main'
+        run: |
+          echo "Releases must be cut from main, not ${{ github.ref }}." >&2
+          exit 1
+
+      - name: Reject a version string that isn't a plain word
+        run: |
+          version="${{ inputs.version }}"
+          if [[ ! "$version" =~ ^[A-Za-z0-9.-]+$ ]]; then
+            echo "Version '$version' contains characters other than letters, digits, dots, and hyphens." >&2
+            exit 1
+          fi
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Reject a version that's already been released
+        run: |
+          if git rev-parse "v${{ inputs.version }}" >/dev/null 2>&1; then
+            echo "Tag v${{ inputs.version }} already exists." >&2
+            exit 1
+          fi
+
+      - name: Bump manifest.json's version
+        run: |
+          manifest=custom_components/lksystems/manifest.json
+          before=$(grep -o '"version": "[^"]*"' "$manifest")
+          sed -i -E 's/"version": "[^"]*"/"version": "${{ inputs.version }}"/' "$manifest"
+          after=$(grep -o '"version": "[^"]*"' "$manifest")
+          if [ "$before" = "$after" ]; then
+            echo "manifest.json's version line wasn't found or didn't change." >&2
+            exit 1
+          fi
+          echo "$before -> $after"
+
+      - name: Commit the version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add custom_components/lksystems/manifest.json
+          git commit -m "Bump version to ${{ inputs.version }}"
+          git push origin HEAD:main
+
+      - name: Tag the release
+        run: |
+          git tag "v${{ inputs.version }}"
+          git push origin "v${{ inputs.version }}"
+
+      - name: Create the GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          prerelease_flag=()
+          case "${{ inputs.version }}" in
+            *alpha*|*beta*|*rc*) prerelease_flag=(--prerelease) ;;
+          esac
+          gh release create "v${{ inputs.version }}" "${prerelease_flag[@]}" \
+            --title "v${{ inputs.version }}" \
+            --generate-notes

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,10 +13,10 @@ jobs:
         # pytest-homeassistant-custom-component / homeassistant require >=3.12
         python-version: ["3.12", "3.13"]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Relates to #94: `manifest.json`'s `version` field has been frozen at `0.0.3` since `v0.3.0-alpha` - the last five releases (`v0.3.1` through `v0.4.2-alpha`) all shipped it unchanged, making Home Assistant's own Integration page unable to show which release is actually installed.

This PR doesn't close #94 by itself, though - merging it only adds the mechanism; the currently-stale `0.0.3` stays stale until someone actually dispatches a real release through it. Worth cutting one (even a trivial patch bump) right after merging, both to fix #94 for real and to confirm the workflow behaves the same against this repo's actual settings as it did against my fork.

## What this adds

A `workflow_dispatch` "Release" action (Actions tab -> Release -> Run workflow, one `version` input, e.g. `0.4.3-alpha`) that does the whole release in one run:

1. Refuses to run from anything but `main`.
2. Rejects a version string with anything but letters/digits/dots/hyphens (it ends up in a tag name and a sed pattern).
3. Rejects a version that's already tagged.
4. Bumps `manifest.json`'s `version` field, verifying the line was actually found and changed rather than silently no-op'ing if the file's shape ever changes.
5. Commits that bump to `main`, tags it `v<version>`, and creates the GitHub release from that tag - marked pre-release automatically if the version string contains `alpha`/`beta`/`rc`, matching the existing tag naming convention.

## Testing

No `pytest` coverage applies to a workflow file, so I tested it for real instead: pushed this workflow to my own fork, dispatched it with a throwaway version, and confirmed all of manifest.json's bump, the commit, the tag, and the release (correctly flagged pre-release) were created correctly. Also confirmed dispatching the same version a second time fails cleanly at the "already released" check rather than double-tagging. Cleaned up all test artifacts (release, tag, branch) afterward - nothing from testing was left on the fork.

One thing I couldn't test from a fork: whether this repo's branch protection (if any) on `main` blocks a push from `GITHUB_TOKEN` even with `permissions: contents: write` declared. Worth a real (even if trivial, e.g. a patch release) dry run here after merging before relying on it for a real release.

