### PR TITLE
Share one session between the valve's write and its confirmation read

### DIFF
--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -22,7 +22,6 @@ from homeassistant.exceptions import HomeAssistantError, ConfigEntryAuthFailed
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_PASSWORD, CONF_USERNAME, Platform
 from homeassistant.core import CALLBACK_TYPE, HomeAssistant
-from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.event import async_track_point_in_time
 from homeassistant.helpers.typing import ConfigType
@@ -683,14 +682,56 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         self.valve_action_pending.pop(device_identity, None)
         self.async_update_listeners()
 
+    def _valve_reached_expected_state(
+        self, device_identity: str, expect_closed: bool
+    ) -> bool:
+        """Whether the coordinator's current data already shows the valve
+        in the state an open/close write was asked to reach."""
+        valve_state = self.data["cubic_devices"][device_identity]["configuration"].get(
+            "valveState"
+        )
+        return (valve_state == CUBIC_SECURE_VALVE_STATE_CLOSED) == expect_closed
+
+    def _resolve_valve_action(self, device_identity: str) -> None:
+        """Mark a device's pending open/close write as confirmed.
+
+        A confirming fetch already notified listeners once with its raw
+        data; entities reading valve_action_pending (is_closing/
+        is_opening) need a second notification to pick up that it just
+        cleared, or they're stuck showing the transitional state until
+        the next regular poll.
+        """
+        self.valve_action_pending.pop(device_identity, None)
+        self.async_update_listeners()
+
+    def handle_valve_write_result(
+        self, device_identity: str, expect_closed: bool, write_succeeded: bool
+    ) -> None:
+        """Decide what a just-finished open/close write means for the
+        pending confirmation mark_valve_action_pending() set before it.
+
+        The write is expected to have already reused its own session for
+        one confirmation read, so coordinator data may already reflect
+        the new state - resolve immediately rather than waiting out a
+        retry interval for news that already arrived. If it doesn't yet
+        (the physical motor is still moving), fall back to the regular
+        confirmation retry loop. If the write was never actually issued
+        (e.g. login failed), there's nothing to confirm.
+        """
+        if not write_succeeded:
+            self.clear_valve_action_pending(device_identity)
+        elif self._valve_reached_expected_state(device_identity, expect_closed):
+            self._resolve_valve_action(device_identity)
+        else:
+            self._schedule_valve_state_confirmation(device_identity, expect_closed)
+
     def _schedule_valve_state_confirmation(
         self, device_identity: str, expect_closed: bool
     ) -> None:
-        """After an open/close write, poll the cloud every
-        VALVE_ACTION_RETRY_INTERVAL_SECONDS until it confirms the valve
-        actually reached the requested state, giving up after
-        VALVE_ACTION_MAX_RETRY_SECONDS - see that constant's own comment
-        for what happens then.
+        """Poll the cloud every VALVE_ACTION_RETRY_INTERVAL_SECONDS until
+        it confirms the valve actually reached the requested state, giving
+        up after VALVE_ACTION_MAX_RETRY_SECONDS - see that constant's own
+        comment for what happens then.
         """
         self.mark_valve_action_pending(device_identity, expect_closed)
         retry_deadline = dt_util.utcnow() + timedelta(
@@ -701,16 +742,6 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
             self._valve_action_unsub[device_identity] = async_track_point_in_time(
                 self.hass, _check_valve_state, when
             )
-
-        def _resolve() -> None:
-            self.valve_action_pending.pop(device_identity, None)
-            # force_cubic_secure_configuration_update() below already
-            # notified listeners once with this check's raw fetch -
-            # entities reading valve_action_pending (is_closing/
-            # is_opening) need a second notification to pick up that it
-            # just cleared, or they're stuck showing the transitional
-            # state until the next regular poll.
-            self.async_update_listeners()
 
         def _give_up() -> None:
             # HA already issued the write - assume it succeeded rather
@@ -725,7 +756,7 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                 if expect_closed
                 else CUBIC_SECURE_VALVE_STATE_OPEN
             )
-            _resolve()
+            self._resolve_valve_action(device_identity)
             _LOGGER.debug(
                 "Giving up on confirming valve %s reached the requested "
                 "state after %ss - assuming it did, the regular poll "
@@ -764,13 +795,8 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
                 return
 
             now = dt_util.utcnow()
-            valve_state = self.data["cubic_devices"][device_identity][
-                "configuration"
-            ].get("valveState")
-            actually_closed = valve_state == CUBIC_SECURE_VALVE_STATE_CLOSED
-
-            if actually_closed == expect_closed:
-                _resolve()
+            if self._valve_reached_expected_state(device_identity, expect_closed):
+                self._resolve_valve_action(device_identity)
                 _LOGGER.debug(
                     "Valve %s confirmed %s",
                     device_identity,
@@ -907,6 +933,21 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         )
         return await self._apply_cubic_secure_configuration(
             lk_inst, device_identity, force_update=False
+        )
+
+    async def force_cubic_secure_configuration_update_with_client(
+        self, lk_inst: LKSystemsManager, device_identity: str
+    ) -> bool:
+        """Like force_cubic_secure_configuration_update(), but reusing an
+        already-authenticated `lk_inst` instead of opening a new session -
+        see refresh_cubic_secure_configuration_with_client()'s own
+        docstring for why.
+        """
+        _LOGGER.debug(
+            "Forcing configuration update for Cubic Secure device %s", device_identity
+        )
+        return await self._apply_cubic_secure_configuration(
+            lk_inst, device_identity, force_update=True
         )
 
     async def _async_update_data(self) -> LkStructureResp:
@@ -1391,35 +1432,6 @@ def cubic_secure_configuration(
     """
     cubic_device = coordinator.data["cubic_devices"][device_identity]
     return cubic_device.get("configuration") or {}
-
-
-async def async_call_cubic_secure_service(
-    hass: HomeAssistant,
-    device_identity: str,
-    service: str,
-    extra_data: dict[str, Any] | None = None,
-) -> bool:
-    """Resolve a Cubic Secure device identity to its registered device and
-    call one of this integration's own services on it.
-
-    Shared by every platform whose action is "call an existing lksystems
-    service for this device" (button.py, valve.py, ...), so the device
-    lookup and its "not registered" error handling exist in one place.
-    Returns whether the service was actually called.
-    """
-    device_entry = dr.async_get(hass).async_get_device(
-        identifiers={(DOMAIN, device_identity)}
-    )
-    if device_entry is None:
-        _LOGGER.error(
-            "No registered device found for %s, cannot call %s", device_identity, service
-        )
-        return False
-
-    await hass.services.async_call(
-        DOMAIN, service, {"device_id": device_entry.id, **(extra_data or {})}, blocking=True
-    )
-    return True
 
 
 def cubic_secure_device_info(

--- a/custom_components/lksystems/services.py
+++ b/custom_components/lksystems/services.py
@@ -1,4 +1,5 @@
 from .pylksystems import LKSystemsManager, LKThresholds, LKPressureThresholds
+from contextlib import asynccontextmanager
 import logging
 
 from homeassistant.config_entries import ConfigEntry
@@ -14,6 +15,30 @@ from .const import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+
+
+class _ServiceLoginFailed(Exception):
+    """Raised by _authenticated_session() when login fails."""
+
+
+@asynccontextmanager
+async def _authenticated_session(hass: HomeAssistant, entry: ConfigEntry):
+    """Open one logged-in LKSystemsManager session for a service-layer
+    write - the shared shape every write below needs (extract
+    credentials, open a session, log in), instead of each
+    re-implementing its own copy.
+
+    Raises _ServiceLoginFailed if login fails - the caller decides what
+    that means for its own return value/error message.
+    """
+    username = entry.data.get(CONF_USERNAME)
+    password = entry.data.get(CONF_PASSWORD)
+
+    async with LKSystemsManager(username, password) as lk_inst:
+        if not await lk_inst.login():
+            _LOGGER.error("Failed to login, abort update")
+            raise _ServiceLoginFailed("Failed to login")
+        yield lk_inst
 
 
 def _get_serial_number(hass: HomeAssistant, device_id: str) -> str | None:
@@ -52,14 +77,9 @@ async def pause_leak_detection_for_serial(
     """
     _LOGGER.info("Pausing leak detection for %s for %s seconds", serial_number, seconds)
     try:
-        username = entry.data.get(CONF_USERNAME)
-        password = entry.data.get(CONF_PASSWORD)
         coordinator = hass.data[DOMAIN][entry.entry_id]
 
-        async with LKSystemsManager(username, password) as lk_inst:
-            if not await lk_inst.login():
-                _LOGGER.error("Failed to login, abort update")
-                raise Exception("Failed to login")
+        async with _authenticated_session(hass, entry) as lk_inst:
             await lk_inst.cubic_secure_pause_leak_detection(serial_number, seconds)
 
             coordinator.set_leak_detection_paused_until(serial_number, seconds)
@@ -85,14 +105,9 @@ async def _set_valve_state_for_serial(
     action = "Closing" if close else "Opening"
     _LOGGER.info("%s valve %s", action, serial_number)
     try:
-        username = entry.data.get(CONF_USERNAME)
-        password = entry.data.get(CONF_PASSWORD)
         coordinator = hass.data[DOMAIN][entry.entry_id]
 
-        async with LKSystemsManager(username, password) as lk_inst:
-            if not await lk_inst.login():
-                _LOGGER.error("Failed to login, abort update")
-                return False
+        async with _authenticated_session(hass, entry) as lk_inst:
             if close:
                 await lk_inst.cubic_secure_close_valve(serial_number)
             else:
@@ -101,6 +116,8 @@ async def _set_valve_state_for_serial(
                 lk_inst, serial_number
             )
         return True
+    except _ServiceLoginFailed:
+        return False
     except Exception as e:
         _LOGGER.error("Error %s valve: %s", action.lower(), e)
         return False
@@ -169,13 +186,7 @@ async def async_setup_services(hass: HomeAssistant, entry: ConfigEntry) -> None:
             return
         _LOGGER.info(f"Setting pressure test schedule {sn} to {hour}:{minute}")
         try:
-            username = entry.data.get(CONF_USERNAME)
-            password = entry.data.get(CONF_PASSWORD)
-
-            async with LKSystemsManager(username, password) as lk_inst:
-                if not await lk_inst.login():
-                    _LOGGER.error("Failed to login, abort update")
-                    raise Exception("Failed to login")
+            async with _authenticated_session(hass, entry) as lk_inst:
                 await lk_inst.cubic_secure_set_pressure_test_schedule(sn, hour, minute)
         except Exception as e:
             _LOGGER.error("Error setting pressure test schedule: %s", e)
@@ -223,13 +234,7 @@ async def async_setup_services(hass: HomeAssistant, entry: ConfigEntry) -> None:
         )
         _LOGGER.info(f"Setting thresholds {sn} to {thresholds}")
         try:
-            username = entry.data.get(CONF_USERNAME)
-            password = entry.data.get(CONF_PASSWORD)
-
-            async with LKSystemsManager(username, password) as lk_inst:
-                if not await lk_inst.login():
-                    _LOGGER.error("Failed to login, abort update")
-                    raise Exception("Failed to login")
+            async with _authenticated_session(hass, entry) as lk_inst:
                 await lk_inst.cubic_secure_set_thresholds(sn, thresholds)
         except Exception as e:
             _LOGGER.error("Error setting thresholds: %s", e)

--- a/custom_components/lksystems/services.py
+++ b/custom_components/lksystems/services.py
@@ -70,6 +70,65 @@ async def pause_leak_detection_for_serial(
         _LOGGER.error("Error pausing leak detection: %s", e)
 
 
+async def _set_valve_state_for_serial(
+    hass: HomeAssistant, entry: ConfigEntry, serial_number: str, *, close: bool
+) -> bool:
+    """Log in, write the valve's requested state, and confirm it by
+    reusing the same session for one immediate read - shared body for
+    close_valve_for_serial/open_valve_for_serial below.
+
+    Returns whether the write itself was issued (a real login and API
+    call happened), not whether the valve has already reached the
+    requested state - that's for the caller to check against the
+    coordinator data this also just refreshed.
+    """
+    action = "Closing" if close else "Opening"
+    _LOGGER.info("%s valve %s", action, serial_number)
+    try:
+        username = entry.data.get(CONF_USERNAME)
+        password = entry.data.get(CONF_PASSWORD)
+        coordinator = hass.data[DOMAIN][entry.entry_id]
+
+        async with LKSystemsManager(username, password) as lk_inst:
+            if not await lk_inst.login():
+                _LOGGER.error("Failed to login, abort update")
+                return False
+            if close:
+                await lk_inst.cubic_secure_close_valve(serial_number)
+            else:
+                await lk_inst.cubic_secure_open_valve(serial_number)
+            await coordinator.force_cubic_secure_configuration_update_with_client(
+                lk_inst, serial_number
+            )
+        return True
+    except Exception as e:
+        _LOGGER.error("Error %s valve: %s", action.lower(), e)
+        return False
+
+
+async def close_valve_for_serial(
+    hass: HomeAssistant, entry: ConfigEntry, serial_number: str
+) -> bool:
+    """Close one device's valve.
+
+    Shared by the close_valve service handler below and valve.py's valve
+    entity, which already has the serial number and would otherwise have
+    to round-trip it through the device registry into a device_id just to
+    go through the service call layer. Confirms the write by reusing the
+    same session for the follow-up read
+    (coordinator.force_cubic_secure_configuration_update_with_client())
+    rather than opening a second one just for that.
+    """
+    return await _set_valve_state_for_serial(hass, entry, serial_number, close=True)
+
+
+async def open_valve_for_serial(
+    hass: HomeAssistant, entry: ConfigEntry, serial_number: str
+) -> bool:
+    """Open one device's valve - see close_valve_for_serial's own docstring."""
+    return await _set_valve_state_for_serial(hass, entry, serial_number, close=False)
+
+
 async def async_setup_services(hass: HomeAssistant, entry: ConfigEntry) -> None:
     @callback
     async def pause_leak_detection(call: ServiceCall) -> None:
@@ -88,18 +147,7 @@ async def async_setup_services(hass: HomeAssistant, entry: ConfigEntry) -> None:
         sn = _get_serial_number(hass, device_id)
         if not sn:
             return
-        _LOGGER.info(f"Closing valve {sn}")
-        try:
-            username = entry.data.get(CONF_USERNAME)
-            password = entry.data.get(CONF_PASSWORD)
-
-            async with LKSystemsManager(username, password) as lk_inst:
-                if not await lk_inst.login():
-                    _LOGGER.error("Failed to login, abort update")
-                    raise Exception("Failed to login")
-                await lk_inst.cubic_secure_close_valve(sn)
-        except Exception as e:
-            _LOGGER.error("Error closing valve: %s", e)
+        await close_valve_for_serial(hass, entry, sn)
 
     @callback
     async def open_valve(call: ServiceCall) -> None:
@@ -108,18 +156,7 @@ async def async_setup_services(hass: HomeAssistant, entry: ConfigEntry) -> None:
         sn = _get_serial_number(hass, device_id)
         if not sn:
             return
-        _LOGGER.info(f"Open valve {sn}")
-        try:
-            username = entry.data.get(CONF_USERNAME)
-            password = entry.data.get(CONF_PASSWORD)
-
-            async with LKSystemsManager(username, password) as lk_inst:
-                if not await lk_inst.login():
-                    _LOGGER.error("Failed to login, abort update")
-                    raise Exception("Failed to login")
-                await lk_inst.cubic_secure_open_valve(sn)
-        except Exception as e:
-            _LOGGER.error("Error open valve: %s", e)
+        await open_valve_for_serial(hass, entry, sn)
 
     @callback
     async def set_pressure_test_schedule(call: ServiceCall) -> None:

--- a/custom_components/lksystems/services.py
+++ b/custom_components/lksystems/services.py
@@ -18,15 +18,23 @@ _LOGGER = logging.getLogger(__name__)
 
 
 class _ServiceLoginFailed(Exception):
-    """Raised by _authenticated_session() when login fails."""
+    """Raised by _service_write_session() when login fails."""
 
 
 @asynccontextmanager
-async def _authenticated_session(hass: HomeAssistant, entry: ConfigEntry):
+async def _service_write_session(entry: ConfigEntry):
     """Open one logged-in LKSystemsManager session for a service-layer
     write - the shared shape every write below needs (extract
     credentials, open a session, log in), instead of each
     re-implementing its own copy.
+
+    Deliberately always logs in fresh rather than reusing a cached token
+    the way LKSystemCoordinator._authenticated_client() does for the
+    regular poll - these are one-off, user-initiated writes (open/close
+    the valve, change a threshold, ...), where a token that's stale by
+    even a few seconds (e.g. right after a password change) is worth the
+    cost of a fresh login to avoid, unlike a poll that just runs again in
+    a few minutes regardless.
 
     Raises _ServiceLoginFailed if login fails - the caller decides what
     that means for its own return value/error message.
@@ -79,7 +87,7 @@ async def pause_leak_detection_for_serial(
     try:
         coordinator = hass.data[DOMAIN][entry.entry_id]
 
-        async with _authenticated_session(hass, entry) as lk_inst:
+        async with _service_write_session(entry) as lk_inst:
             await lk_inst.cubic_secure_pause_leak_detection(serial_number, seconds)
 
             coordinator.set_leak_detection_paused_until(serial_number, seconds)
@@ -91,27 +99,34 @@ async def pause_leak_detection_for_serial(
 
 
 async def _set_valve_state_for_serial(
-    hass: HomeAssistant, entry: ConfigEntry, serial_number: str, *, close: bool
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    serial_number: str,
+    action: str,
+    write_method_name: str,
 ) -> bool:
-    """Log in, write the valve's requested state, and confirm it by
+    """Log in, write the valve's requested state (by calling
+    `write_method_name` on the session's client), and confirm it by
     reusing the same session for one immediate read - shared body for
     close_valve_for_serial/open_valve_for_serial below.
+
+    Takes the write's method name rather than a bound/unbound method
+    reference: the LKSystemsManager class itself gets replaced with a
+    mock in tests, so resolving the method against the real *instance*
+    each call (via getattr) is what keeps this working under test rather
+    than silently calling through to the wrong object.
 
     Returns whether the write itself was issued (a real login and API
     call happened), not whether the valve has already reached the
     requested state - that's for the caller to check against the
     coordinator data this also just refreshed.
     """
-    action = "Closing" if close else "Opening"
     _LOGGER.info("%s valve %s", action, serial_number)
     try:
         coordinator = hass.data[DOMAIN][entry.entry_id]
 
-        async with _authenticated_session(hass, entry) as lk_inst:
-            if close:
-                await lk_inst.cubic_secure_close_valve(serial_number)
-            else:
-                await lk_inst.cubic_secure_open_valve(serial_number)
+        async with _service_write_session(entry) as lk_inst:
+            await getattr(lk_inst, write_method_name)(serial_number)
             await coordinator.force_cubic_secure_configuration_update_with_client(
                 lk_inst, serial_number
             )
@@ -128,22 +143,23 @@ async def close_valve_for_serial(
 ) -> bool:
     """Close one device's valve.
 
-    Shared by the close_valve service handler below and valve.py's valve
-    entity, which already has the serial number and would otherwise have
-    to round-trip it through the device registry into a device_id just to
-    go through the service call layer. Confirms the write by reusing the
-    same session for the follow-up read
-    (coordinator.force_cubic_secure_configuration_update_with_client())
-    rather than opening a second one just for that.
+    Shared by the close_valve service handler below and callers that
+    already have a serial number and would otherwise have to round-trip
+    it through the device registry into a device_id just to go through
+    the service call layer.
     """
-    return await _set_valve_state_for_serial(hass, entry, serial_number, close=True)
+    return await _set_valve_state_for_serial(
+        hass, entry, serial_number, "Closing", "cubic_secure_close_valve"
+    )
 
 
 async def open_valve_for_serial(
     hass: HomeAssistant, entry: ConfigEntry, serial_number: str
 ) -> bool:
     """Open one device's valve - see close_valve_for_serial's own docstring."""
-    return await _set_valve_state_for_serial(hass, entry, serial_number, close=False)
+    return await _set_valve_state_for_serial(
+        hass, entry, serial_number, "Opening", "cubic_secure_open_valve"
+    )
 
 
 async def async_setup_services(hass: HomeAssistant, entry: ConfigEntry) -> None:
@@ -186,7 +202,7 @@ async def async_setup_services(hass: HomeAssistant, entry: ConfigEntry) -> None:
             return
         _LOGGER.info(f"Setting pressure test schedule {sn} to {hour}:{minute}")
         try:
-            async with _authenticated_session(hass, entry) as lk_inst:
+            async with _service_write_session(entry) as lk_inst:
                 await lk_inst.cubic_secure_set_pressure_test_schedule(sn, hour, minute)
         except Exception as e:
             _LOGGER.error("Error setting pressure test schedule: %s", e)
@@ -234,7 +250,7 @@ async def async_setup_services(hass: HomeAssistant, entry: ConfigEntry) -> None:
         )
         _LOGGER.info(f"Setting thresholds {sn} to {thresholds}")
         try:
-            async with _authenticated_session(hass, entry) as lk_inst:
+            async with _service_write_session(entry) as lk_inst:
                 await lk_inst.cubic_secure_set_thresholds(sn, thresholds)
         except Exception as e:
             _LOGGER.error("Error setting thresholds: %s", e)

--- a/custom_components/lksystems/valve.py
+++ b/custom_components/lksystems/valve.py
@@ -11,12 +11,12 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import (
     LKSystemCoordinator,
-    async_call_cubic_secure_service,
     cubic_secure_configuration,
     cubic_secure_device_identities,
     cubic_secure_device_info,
 )
 from .const import ATTRIBUTION, CUBIC_SECURE_VALVE_STATE_CLOSED, DOMAIN
+from .services import close_valve_for_serial, open_valve_for_serial
 
 
 async def async_setup_entry(
@@ -37,15 +37,14 @@ class LKCubicSecureValve(CoordinatorEntity[LKSystemCoordinator], ValveEntity):
     Reflects live coordinator data (like the sibling sensors), so it
     picks up a state change from any source - a scheduled poll, or the
     valve being toggled from the vendor app - not just its own actions.
-    Open/close delegate to the existing open_valve/close_valve services
-    (rather than duplicating their login/error-handling), then confirm
-    the valve actually reached that state via
-    _schedule_valve_state_confirmation() - the physical motor takes on
+    Open/close call close_valve_for_serial/open_valve_for_serial directly
+    (sharing one session between the write and its immediate confirmation
+    read, rather than going through the service-call layer), then let
+    the coordinator decide whether that confirmed it already or a
+    confirmation retry loop is still needed - the physical motor takes on
     the order of 10-30s to finish moving (confirmed against a real
-    device), so a single immediate refresh right after the write would
-    just read a stale pre-action snapshot (see that method's own
-    docstring). Doesn't report a position: the API only exposes
-    open/closed, not a percentage.
+    device), so it usually is. Doesn't report a position: the API only
+    exposes open/closed, not a percentage.
     """
 
     _attr_attribution = ATTRIBUTION
@@ -101,23 +100,22 @@ class LKCubicSecureValve(CoordinatorEntity[LKSystemCoordinator], ValveEntity):
 
     async def async_open_valve(self) -> None:
         """Open the valve."""
-        await self._async_call_valve_service("open_valve")
+        await self._write_valve_state(expect_closed=False)
 
     async def async_close_valve(self) -> None:
         """Close the valve."""
-        await self._async_call_valve_service("close_valve")
+        await self._write_valve_state(expect_closed=True)
 
-    async def _async_call_valve_service(self, service: str) -> None:
-        expect_closed = service == "close_valve"
-        # Marked pending before the write below, not just once its
-        # confirmation retries start - the write itself (login, then the
-        # API call) can take a while too (see
+    async def _write_valve_state(self, *, expect_closed: bool) -> None:
+        # Marked pending before the write below, not just once a
+        # confirmation retry loop might start - the write itself (login,
+        # then the API call) can take a while too (see
         # coordinator.mark_valve_action_pending's own docstring).
         self.coordinator.mark_valve_action_pending(self._device_identity, expect_closed)
-        called = await async_call_cubic_secure_service(self.hass, self._device_identity, service)
-        if called:
-            self.coordinator._schedule_valve_state_confirmation(
-                self._device_identity, expect_closed
-            )
-        else:
-            self.coordinator.clear_valve_action_pending(self._device_identity)
+        write_for_serial = close_valve_for_serial if expect_closed else open_valve_for_serial
+        write_succeeded = await write_for_serial(
+            self.hass, self.coordinator.entry, self._device_identity
+        )
+        self.coordinator.handle_valve_write_result(
+            self._device_identity, expect_closed, write_succeeded
+        )

--- a/tests_ha/test_services.py
+++ b/tests_ha/test_services.py
@@ -231,8 +231,8 @@ class TestValveActionForSerial:
         self, hass, fake_manager
     ):
         """The write (cubic_secure_close_valve) and its immediate
-        confirmation read (get_cubic_secure_configuration) used to each
-        open their own session - two logins for one logical action."""
+        confirmation read (get_cubic_secure_configuration) share one
+        session - a single login should cover both."""
         entry, _ = await _setup_entry_and_get_cubic_device(hass, fake_manager)
         fake_manager.calls.clear()
 

--- a/tests_ha/test_services.py
+++ b/tests_ha/test_services.py
@@ -266,6 +266,26 @@ async def test_set_pressure_test_schedule_calls_client(hass, fake_manager):
     ) in fake_manager.calls
 
 
+async def test_set_pressure_test_schedule_login_failure_does_not_raise(
+    hass, fake_manager
+):
+    """Handler catches the login failure inside its try/except and just logs."""
+    _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
+    fake_manager.login_result = False
+
+    with patch_services_manager(fake_manager):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_pressure_test_schedule",
+            {"device_id": device_entry.id, "hour": 3, "minute": 30},
+            blocking=True,
+        )
+
+    assert not any(
+        c[0] == "cubic_secure_set_pressure_test_schedule" for c in fake_manager.calls
+    )
+
+
 async def test_set_thresholds_calls_client_with_defaults(hass, fake_manager):
     _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
 
@@ -285,6 +305,22 @@ async def test_set_thresholds_calls_client_with_defaults(hass, fake_manager):
     thresholds = threshold_calls[0][2]
     assert thresholds["pressure"]["sensitivity"] == 0.3
     assert thresholds["leakLarge"]["threshold"] == 1500.0
+
+
+async def test_set_thresholds_login_failure_does_not_raise(hass, fake_manager):
+    """Handler catches the login failure inside its try/except and just logs."""
+    _, device_entry = await _setup_entry_and_get_cubic_device(hass, fake_manager)
+    fake_manager.login_result = False
+
+    with patch_services_manager(fake_manager):
+        await hass.services.async_call(
+            DOMAIN,
+            "set_thresholds",
+            {"device_id": device_entry.id},
+            blocking=True,
+        )
+
+    assert not any(c[0] == "cubic_secure_set_thresholds" for c in fake_manager.calls)
 
 
 async def test_close_valve_login_failure_does_not_raise(hass, fake_manager):

--- a/tests_ha/test_services.py
+++ b/tests_ha/test_services.py
@@ -18,7 +18,11 @@ from homeassistant.helpers import device_registry as dr
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.lksystems.const import DOMAIN
-from custom_components.lksystems.services import pause_leak_detection_for_serial
+from custom_components.lksystems.services import (
+    close_valve_for_serial,
+    open_valve_for_serial,
+    pause_leak_detection_for_serial,
+)
 
 from .conftest import (
     CUBIC_IDENTITY,
@@ -186,6 +190,61 @@ class TestPauseLeakDetectionForSerial:
             await pause_leak_detection_for_serial(hass, entry, CUBIC_IDENTITY, 1800)
 
         assert fake_manager.calls.count(("login",)) == 1
+
+
+class TestValveActionForSerial:
+    """Direct tests for close_valve_for_serial/open_valve_for_serial (see
+    their own docstring for why they're called directly rather than only
+    through the close_valve/open_valve services)."""
+
+    async def test_close_calls_the_client(self, hass, fake_manager):
+        entry, _ = await _setup_entry_and_get_cubic_device(hass, fake_manager)
+
+        with patch_all_managers(fake_manager):
+            result = await close_valve_for_serial(hass, entry, CUBIC_IDENTITY)
+
+        assert result is True
+        assert ("cubic_secure_close_valve", CUBIC_IDENTITY) in fake_manager.calls
+
+    async def test_open_calls_the_client(self, hass, fake_manager):
+        entry, _ = await _setup_entry_and_get_cubic_device(hass, fake_manager)
+
+        with patch_all_managers(fake_manager):
+            result = await open_valve_for_serial(hass, entry, CUBIC_IDENTITY)
+
+        assert result is True
+        assert ("cubic_secure_open_valve", CUBIC_IDENTITY) in fake_manager.calls
+
+    async def test_login_failure_returns_false_and_does_not_call_the_client(
+        self, hass, fake_manager
+    ):
+        entry, _ = await _setup_entry_and_get_cubic_device(hass, fake_manager)
+        fake_manager.login_result = False
+
+        with patch_all_managers(fake_manager):
+            result = await close_valve_for_serial(hass, entry, CUBIC_IDENTITY)
+
+        assert result is False
+        assert not any(c[0] == "cubic_secure_close_valve" for c in fake_manager.calls)
+
+    async def test_reuses_one_session_for_the_write_and_its_confirmation_read(
+        self, hass, fake_manager
+    ):
+        """The write (cubic_secure_close_valve) and its immediate
+        confirmation read (get_cubic_secure_configuration) used to each
+        open their own session - two logins for one logical action."""
+        entry, _ = await _setup_entry_and_get_cubic_device(hass, fake_manager)
+        fake_manager.calls.clear()
+
+        with patch_all_managers(fake_manager):
+            await close_valve_for_serial(hass, entry, CUBIC_IDENTITY)
+
+        assert fake_manager.calls.count(("login",)) == 1
+        assert (
+            "get_cubic_secure_configuration",
+            CUBIC_IDENTITY,
+            True,
+        ) in fake_manager.calls
 
 
 async def test_set_pressure_test_schedule_calls_client(hass, fake_manager):

--- a/tests_ha/test_valve.py
+++ b/tests_ha/test_valve.py
@@ -110,7 +110,7 @@ async def test_action_calls_the_client_and_refreshes(
         ("open_valve", "closed", "open"),
     ],
 )
-async def test_resolves_immediately_when_the_write_s_own_confirmation_read_already_shows_it(
+async def test_resolves_immediately_when_confirmation_read_already_matches(
     hass, fake_manager, ha_service, starting_state, resulting_state
 ):
     """The write and its confirmation read share one session (see

--- a/tests_ha/test_valve.py
+++ b/tests_ha/test_valve.py
@@ -91,9 +91,9 @@ async def test_action_calls_the_client_and_refreshes(
         await hass.services.async_call(
             "valve", ha_service, {"entity_id": valve_entity_id}, blocking=True
         )
-        # The confirmation that the valve actually reached the requested
-        # state is scheduled to check a few seconds later, not
-        # immediately - see LKSystemCoordinator._schedule_valve_state_confirmation.
+        # Already resolved by the write's own shared-session confirmation
+        # read below, but a stray extra tick must still be a no-op rather
+        # than reopen the retry loop against a resolved action.
         async_fire_time_changed(
             hass, dt_util.utcnow() + timedelta(seconds=VALVE_ACTION_RETRY_INTERVAL_SECONDS)
         )
@@ -101,6 +101,39 @@ async def test_action_calls_the_client_and_refreshes(
 
     assert (client_call, CUBIC_IDENTITY) in fake_manager.calls
     assert hass.states.get(valve_entity_id).state == resulting_state
+
+
+@pytest.mark.parametrize(
+    ("ha_service", "starting_state", "resulting_state"),
+    [
+        ("close_valve", "open", "closed"),
+        ("open_valve", "closed", "open"),
+    ],
+)
+async def test_resolves_immediately_when_the_write_s_own_confirmation_read_already_shows_it(
+    hass, fake_manager, ha_service, starting_state, resulting_state
+):
+    """The write and its confirmation read share one session (see
+    close_valve_for_serial/open_valve_for_serial) - if that read already
+    shows the requested state, there's no reason to wait out a full
+    VALVE_ACTION_RETRY_INTERVAL_SECONDS for news that already arrived."""
+    fake_manager.cubic_configuration_data = build_cubic_configuration(
+        valve_state=starting_state
+    )
+    await setup_entry(hass, fake_manager)
+    valve_entity_id = entity_id(hass, "valve", _valve_unique_id(CUBIC_IDENTITY))
+    fake_manager.cubic_configurations_by_device[CUBIC_IDENTITY] = build_cubic_configuration(
+        valve_state=resulting_state
+    )
+    fake_manager.calls.clear()
+
+    with patch_all_managers(fake_manager):
+        await hass.services.async_call(
+            "valve", ha_service, {"entity_id": valve_entity_id}, blocking=True
+        )
+
+        assert hass.states.get(valve_entity_id).state == resulting_state
+        assert fake_manager.calls.count(("login",)) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #96 (issue). Also completes #75 (issue) - items 1-4, 6, 7 already merged via #80 (PR), #91 (PR), and #92 (PR), and this is the remaining half of item 5 (the pause_leak_detection half was fixed in #92; this is the valve's own open/close, which #92 (PR) explicitly left as a follow-up since `valve.py` didn't exist on `main` yet when it was written).

## What

`close_valve`/`open_valve` each opened a session for the write, then `force_cubic_secure_configuration_update()` opened a second one just to read the result back - two logins for one logical action. Extracted `close_valve_for_serial`/`open_valve_for_serial` (mirroring `pause_leak_detection_for_serial`'s existing shape): one session for the login, the write, and one confirmation read via a new `force_cubic_secure_configuration_update_with_client()` on the coordinator.

The valve entity now calls these directly instead of going through the service-call layer (same pattern as the Pause/Resume buttons), and a new `LKSystemCoordinator.handle_valve_write_result()` decides what to do with the result: resolve immediately if that shared-session read already confirms the expected state (skipping the wait entirely in the lucky/fast case), fall back to the existing scheduled retry loop if the motor's still moving, or just clear the pending mark if the write itself never got issued.

`async_call_cubic_secure_service` is removed - this was its last caller.

## Testing

TDD throughout: new tests for `close_valve_for_serial`/`open_valve_for_serial` (including a login-count assertion, confirmed RED with 2 logins before the fix, GREEN with 1 after) and for the immediate-resolve path at the entity level (confirmed RED by temporarily reverting just that branch and rerunning - it genuinely exercises new behavior, not already covered by the existing suite). Full suite: 243 passed, 0 failures.

No live hardware needed - fully covered by the existing `FakeLKSystemsManager` harness.

## Follow-up commit: the same duplication, one call site over

The first commit fixed the double-login by writing a second copy of the exact login/session-opening shape #75 (issue) was framed around eliminating - `_set_valve_state_for_serial` duplicated `pause_leak_detection_for_serial`'s boilerplate instead of sharing it, and `set_pressure_test_schedule`/`set_thresholds` already had their own two independent copies of the same shape. Four places total, all doing "extract credentials, open a session, log in, handle failure" independently.

Extracted `_authenticated_session()`, an async context manager covering that shared shape; all four write functions now use it, keeping only what's actually specific to each. Also added login-failure tests for `set_pressure_test_schedule`/`set_thresholds`, which had none before this. Full suite: 245 passed, 0 failures.

