### PR TITLE
Route set_thermostat_temperature through the shared authenticated_client

### DIFF
--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -369,7 +369,7 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
             temperature: The temperature value in tenths of a degree (e.g. 215 = 21.5°C)
 
         Returns:
-            Result of the API call
+            True if the temperature was set successfully, False otherwise.
         """
         _LOGGER.debug("Setting temperature for device %s to %s", device_id, temperature)
 

--- a/custom_components/lksystems/__init__.py
+++ b/custom_components/lksystems/__init__.py
@@ -374,32 +374,7 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
         _LOGGER.debug("Setting temperature for device %s to %s", device_id, temperature)
 
         try:
-            # Create a new instance of LKSystemsManager for this operation
-            username = self._entry.data.get(CONF_USERNAME)
-            password = self._entry.data.get(CONF_PASSWORD)
-
-            async with LKSystemsManager(username, password) as lk_inst:
-                # Use existing token if available
-                stored_tokens = TOKEN_STORAGE.get(self._entry_id, {})
-                stored_jwt = stored_tokens.get("jwt")
-
-                if stored_jwt and is_token_valid(stored_jwt):
-                    lk_inst.jwt_token = stored_jwt
-                    lk_inst.refresh_token = stored_tokens.get("refresh")
-                else:
-                    # Login if no valid token
-                    if not await lk_inst.login():
-                        _LOGGER.error("Login failed when setting temperature")
-                        return False
-
-                    # Store the new tokens
-                    TOKEN_STORAGE[self._entry_id] = {
-                        "jwt": lk_inst.jwt_token,
-                        "refresh": lk_inst.refresh_token,
-                        "expiry": dt_util.utcnow().timestamp() + 3600,
-                    }
-
-                # Call the LKSystemsManager method to set the temperature
+            async with self._authenticated_client() as lk_inst:
                 result = await lk_inst.set_thermostat_temperature(
                     device_id, temperature
                 )
@@ -415,6 +390,9 @@ class LKSystemCoordinator(DataUpdateCoordinator[LkStructureResp]):
 
                 return True
 
+        except _LoginFailed:
+            _LOGGER.error("Login failed when setting temperature")
+            return False
         except Exception as ex:
             _LOGGER.error("Failed to set temperature: %s", ex)
             return False


### PR DESCRIPTION
Part of #98 (issue) - the `set_thermostat_temperature` half only. `_fetch_data()`'s own third copy of this shape is left as-is: it raises `ConfigEntryAuthFailed` (HA's reauth trigger) rather than `_LoginFailed`, stores an extra `userid` field, has its own missing-credentials guard, and the login block is threaded through the largest, already `noqa: C901`-flagged method in the file - genuinely different, not just copy-pasted, and deserves its own careful pass rather than a tag-along fix here.

## What

`set_thermostat_temperature` hand-rolled the exact token-check/login/store sequence `LKSystemCoordinator._authenticated_client()` already provides, a few lines below it in the same file. Routed it through that instead - same interface, same return values, same log messages on failure.

## Testing

No new behavior, so no new tests - relied on the existing `TestSetThermostatTemperature` suite as the safety net (it already covers success, API failure, unexpected exception, login-before-call ordering, login failure, and cached-token reuse). All 6 pass unchanged. Full suite: 237 passed, 0 failures.

